### PR TITLE
Card href goes to blog page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,5 @@
 from fasthtml.common import fast_app, serve, Title, Main, database
-from src.pages import HERO_PAGE, MASONRY_PAGE
-
+from src.pages import HERO_PAGE, MASONRY_PAGE, create_blog_page
 # This is a simple FastHTML app that serves a page with a title and a main content area.
 app, rt = fast_app()
 
@@ -14,5 +13,8 @@ def get():
 def projects():
     return Title("Gabriel - Projects"), MASONRY_PAGE
 
+@rt("/projects/{blog_id}")
+def get(blog_id: str):
+    return Title("Gabriel - Projects"), create_blog_page(blog_id)
 
 serve(port=8080, reload=False)

--- a/src/lib/css/base.py
+++ b/src/lib/css/base.py
@@ -32,6 +32,7 @@ body {
     background-color: var(--black); /* rgba(154, 83, 48, 1); */
     overflow-x: hidden;
     scroll-behavior: smooth;
+    padding-bottom: 2rem;
 }
 
 .container {
@@ -41,6 +42,7 @@ body {
     position: relative;
     z-index: 2;
     padding: 0 1rem;
+    padding-bottom: 2rem;
 }
 
 

--- a/src/pages/__init__.py
+++ b/src/pages/__init__.py
@@ -1,2 +1,3 @@
 from src.pages.hero import HERO_PAGE
 from src.pages.projects.forge import MASONRY_PAGE
+from src.pages.projects.blog import create_blog_page

--- a/src/pages/projects/blog.py
+++ b/src/pages/projects/blog.py
@@ -1,0 +1,55 @@
+from fasthtml.common import Style, Div
+from typing import List, Dict
+from src.components import NAVIGATION
+from src.lib.css import ROOT_CSS, BODY_CSS
+from src.lib.javascript import MarkedJS
+from src.lib.google.bigquery import BigQueryClient
+
+
+css = """
+/* marked test section */
+.marked {
+    max-width: var(--container-max-width);
+    margin: auto auto;
+    position: relative;
+    z-index: 2;
+    padding: 0 1rem;
+}
+
+.centered-not-found {
+    max-width: var(--container-max-width);
+    margin: auto auto;
+    position: relative;
+    z-index: 2;
+    padding: 0 1rem;
+    text-align: center;
+    font-size: 1.5rem;
+    color: var(--dark-newspaper-bg);
+}
+
+"""
+
+
+def blog_div_from_blog(blog: List[Dict]):
+    """ Example of a section with Marked.js for Markdown parsing."""
+    return Div(
+        "No blog found",
+        cls="centered-not-found"
+    ) if not blog else Div(
+        blog[0]["body"],
+        cls="marked"
+    )
+
+def create_blog_page(uuid: str):
+    """ Create a blog page with a specific UUID. """
+    client = BigQueryClient()
+    blog = client.query(sql="SELECT * FROM `noble-office-299208.portfolio.gn-blog` WHERE id = @uuid", params={"uuid": uuid})
+    blog_div = blog_div_from_blog(blog)
+    return Div(
+        Style(ROOT_CSS + BODY_CSS + css),
+        MarkedJS(),
+        NAVIGATION,
+        Div(style="height: 10vh;"),
+        blog_div,
+        cls="container"
+    )

--- a/src/pages/projects/forge.py
+++ b/src/pages/projects/forge.py
@@ -1,13 +1,10 @@
-from fasthtml.common import Style, Div, Script, Img, H1, H3, P
+from fasthtml.common import Style, Div, Img, H3, P, A
 from src.components import NAVIGATION
 from src.lib.css import ROOT_CSS, BODY_CSS
 from src.lib.javascript import MasonryJS, MarkedJS
 from typing import Optional
 from src.lib.google.bigquery import BigQueryClient
-import random
 
-
-MAX_CARD_WIDTH = 250
 
 css = """
 .masonry-container {
@@ -60,17 +57,11 @@ css = """
     border-radius: 5px;
 }
 
-/* marked test section */
-.marked {
-    max-width: var(--container-max-width);
-    margin: auto auto;
-    position: relative;
-    z-index: 2;
-    padding: 0 1rem;
+.a-card {
+    text-decoration: none;
 }
 
 """
-rando = random.Random()
 
 def generate_cards(tag:Optional[str] = None):
     """ Create a card with an image, title, and description."""
@@ -79,7 +70,7 @@ def generate_cards(tag:Optional[str] = None):
     
     return Div(
         *[
-            Div(
+            A(
                 Img(
                     src=entry["image"], 
                     alt=f"",
@@ -87,57 +78,14 @@ def generate_cards(tag:Optional[str] = None):
                 ),
                 H3(entry["title"], cls="white"),
                 P(entry["description"], cls="white"),
-                cls="masonry-card masonry-sizer"
+                href=f"/projects/{entry['id']}",
+                cls="masonry-card masonry-sizer a-card",
             ) for entry in blogs],
         cls="masonry-container",
     )
 
 
-# TODO: Move this to bigquery for blog posts and for cards
-# def marked_section():
-#     """ Example of a section with Marked.js for Markdown parsing."""
-#     return Div(
-#         """
-# # Mastering Quality Control in Omics with FastQC
-
-# Quality control (QC) of sequencing data is a foundational step in bioinformatics workflows, crucial for ensuring reliable and accurate results in omics analyses. Among the many available tools, **FastQC** has emerged as an industry-standard software for performing quality assessments of FASTQ files.
-
-# ### Basic Usage Example
-
-# Running FastQC on single-end reads:
-
-# ```bash
-# fastqc sample.fastq -o output_directory
-# ```
-
-# - `sample.fastq`: The FASTQ file to be assessed.
-# - `-o`: Specifies the directory for output reports.
-
-# For paired-end data:
-
-# ```bash
-# fastqc sample_R1.fastq sample_R2.fastq -o output_directory
-# ```
-
-# ## Interpreting FastQC Reports
-
-# FastQC reports use traffic-light indicators:
-
-# - 🟢 **Pass**: The metric falls within an acceptable range.
-# - 🟡 **Warn**: Potential issues; requires careful interpretation.
-# - 🔴 **Fail**: Significant quality issues that require intervention.
-
-# ## Conclusion
-
-# FastQC remains indispensable in modern bioinformatics, providing clear, actionable insights into sequencing data quality. Integrating FastQC into your omics workflows helps ensure robust and reliable data analysis outcomes.
-
-# Happy sequencing and quality checking!
-#         """,
-#         cls="marked"
-#     )
-
-
-def create_blog_page():
+def create_masonry_page():
     return Div(
         Style(ROOT_CSS + BODY_CSS + css),
         MasonryJS(
@@ -161,4 +109,4 @@ def create_blog_page():
 
 
 
-MASONRY_PAGE = create_blog_page()
+MASONRY_PAGE = create_masonry_page()


### PR DESCRIPTION
## Pull Request: Enable Blog Cards to Link to Individual Blog Pages

### Summary
This PR upgrades the **masonry blog page** to allow clicking on any blog card to open the corresponding full blog post.

### Changes
- **`app.py`**
  - Updated `/projects/{blog_id}` route to serve a specific blog page dynamically using `create_blog_page(blog_id)`.
  - Minor import restructuring for better organization.

- **`src/pages/__init__.py`**
  - Imported `create_blog_page` to expose it for routing.

- **`src/pages/projects/blog.py`**
  - New file!  
  - Added `create_blog_page()` to load a specific blog post from BigQuery by `id`.
  - Gracefully handles case when blog is not found ("No blog found" message).
  - Includes CSS to style blog pages.

- **`src/pages/projects/forge.py`**
  - Refactored `generate_cards()`:
    - Replaced blog cards with `<a>` elements linking to `/projects/{id}`.
    - Improved layout and accessibility with `a-card` CSS class.
  - Renamed `create_blog_page()` → `create_masonry_page()` for clarity.
  - Updated `MASONRY_PAGE` to use the new `create_masonry_page()` function.

- **`src/lib/css/base.py`**
  - Added `padding-bottom` to `body` and `container` for better page spacing.

### Motivation
- Enable users to explore full blog posts by clicking on any blog preview card.
- Improve user experience by connecting the masonry display to full content.
- Prepare the app for scalable blog navigation with minimal backend complexity.

### Screenshots
*(Optional if you want to show how card click -> blog page looks.)*

### Testing
- Verified that blog cards on `/projects` now navigate to the correct blog page.
- Verified that blog pages dynamically pull content from BigQuery and render properly.
- Tested that non-existent blog IDs show a friendly "No blog found" message.