### PR TITLE
temporary hero button behaviour

### DIFF
--- a/src/components/navigation.py
+++ b/src/components/navigation.py
@@ -85,7 +85,7 @@ NAVIGATION =Div(
         Div(
             A("Home", href="/", cls="nav-link"),
             A("Projects", href="/projects", cls="nav-link"),
-            A("Contact", href="/contact", cls="nav-link"),
+            A("Contact", href="#contact", cls="nav-link"),
             cls="nav-links"
         ),
         cls="nav-container container"

--- a/src/pages/hero/about_section.py
+++ b/src/pages/hero/about_section.py
@@ -103,7 +103,7 @@ ABOUT_ME = Div(
                 )
             ),
             Div(
-                button_outline("My Machine Learning Projects", href="#contact"),
+                button_outline("My Machine Learning Projects", href="/projects"),
                 cls="scroll-right-hidden about-block-right-aligned"
             ),
             cls="about-block"
@@ -128,7 +128,7 @@ ABOUT_ME = Div(
                 )
             ),
             Div(
-                button_outline("My AI Projects", href="#contact"),
+                button_outline("My AI Projects", href="/projects"),
                 cls="scroll-right-hidden about-block-right-aligned"
             ),
             cls="about-block"
@@ -170,7 +170,7 @@ ABOUT_ME = Div(
                 )
             ),
             Div(
-                button_outline("My Omics Projects", href="#contact"),
+                button_outline("My Omics Projects", href="/projects"),
                 cls="scroll-right-hidden about-block-right-aligned"
             ),
             cls="about-block"
@@ -189,7 +189,7 @@ ABOUT_ME = Div(
                 )
             ),
             Div(
-                button_outline("My Visualization Projects", href="#contact"),
+                button_outline("My Visualization Projects", href="/projects"),
                 cls="scroll-right-hidden about-block-right-aligned"
             ),
             cls="about-block"
@@ -208,7 +208,7 @@ ABOUT_ME = Div(
                 )
             ),
             Div(
-                button_outline("My Infrustcture Projects", href="#contact"),
+                button_outline("My Infrustcture Projects", href="/projects"),
                 cls="scroll-right-hidden about-block-right-aligned"
             ),
             cls="about-block"


### PR DESCRIPTION
## 🚀 Pull Request: Temporary Hero Button Behavior

### **Summary**
This PR temporarily updates the behavior of **Hero Page buttons** to **navigate directly to `/projects`** instead of scrolling or targeting `#contact`.  
This simplifies the current navigation experience while setting the foundation for future dynamic filtering improvements.

---

### **Changes Made**

**In `src/components/navigation.py`:**
- Changed "Contact" button link from `/contact` to `#contact` for consistency while future modal improvements are pending.

**In `src/pages/hero/about_section.py`:**
- Updated all Hero "About Section" buttons to navigate to `/projects`:
  - "My Machine Learning Projects" ➔ `/projects`
  - "My AI Projects" ➔ `/projects`
  - "My Omics Projects" ➔ `/projects`
  - "My Visualization Projects" ➔ `/projects`
  - "My Infrastructure Projects" ➔ `/projects`

Previously, these buttons incorrectly pointed to `#contact`.

---

### **Why This Change?**
✅ Provides a consistent user experience during early development.  
✅ Simplifies routing while working on more advanced scroll/filter behaviors.  
✅ Prepares for future feature: **Tag-based filtering on click** (tracked in follow-up ticket).

---

### **Next Steps (Planned)**
- Implement dynamic filtering based on which Hero button was clicked.
- Add smooth scroll to highlight filtered content automatically.

---

### 📎 Related Tickets
- [[Ticket: Temporary Hero Page Button Behavior](https://chatgpt.com/c/67fefecd-0080-8003-8457-3c88b20b21c8#)](#)
- [[Ticket: Hero Page Button Click Should Apply Filter](https://chatgpt.com/c/67fefecd-0080-8003-8457-3c88b20b21c8#)](#)

---

**Status:** Ready for review ✅  
**Type:** Hotfix / Temporary UX Improvement
