### PR TITLE
Hide scollbar

### DIFF
--- a/src/pages/projects/forge.py
+++ b/src/pages/projects/forge.py
@@ -29,6 +29,7 @@ css = """
     z-index: 2;
     padding: 0 1rem;
     min-height: 100vh;
+    overflow-y: hidden;
 }
 
 .masonry-card {


### PR DESCRIPTION
# Pull Request: Fix Masonry Height Scrolling Issue (#64)

## Description
This PR addresses issue #64 - Masonry height scrolling fix. The vertical scrollbar was occasionally appearing when selecting or deselecting filter chips, causing unwanted layout shifts.

## Changes
- Added `overflow-y: hidden;` to the masonry container to prevent the scrollbar from appearing during filter transitions

## How This Fixes The Issue
The unwanted scrollbar was appearing temporarily during height recalculation when filters were applied. By setting `overflow-y: hidden`, we prevent the scrollbar from appearing altogether, which eliminates the layout shift that was occurring during filtering operations.

## Testing Performed
- Tested various filtering combinations to ensure no scrollbar appears
- Verified the fix works across Chrome, Firefox, and Safari
- Confirmed there are no negative side effects on mobile devices
- Ensured content remains accessible despite hiding overflow

## Before & After
**Before:** Scrollbar would temporarily appear when applying filters, causing layout to shift horizontally by the width of the scrollbar.

**After:** No scrollbar appears during filtering operations, resulting in a smooth transition between filtered states with no layout shifts.

## Related Issues
Closes #64

## Screenshots
N/A - Fix addresses behavior shown in the ticket

## Note
While this solution prevents the scrollbar from appearing, we should monitor to ensure that no content becomes inaccessible due to hiding overflow. For very tall content, we may need to implement a more sophisticated solution in the future.