### PR TITLE
feat(epic-b): true masonry blog grid

### DIFF
--- a/src/features/projects/projects_page.py
+++ b/src/features/projects/projects_page.py
@@ -21,13 +21,9 @@ def create_masonry_page(tag: str | None = None):
         H1("BLOGS", cls="factory-title factory-title-tight-bottom"),
         H1("& MORE", cls="factory-title factory-title-tight-top"),
         Div(cls="projects-grid-spacer"),
-        Grid(
+        Div(
             *[render_project_card(num_projects - i - 1, p) for i, p in enumerate(projects)],
-            cols_min=1,
-            cols_sm=1,
-            cols_md=2,
-            cols_lg=3,
-            cls="gap-8",
+            cls="masonry-columns",
         ),
     ]
 

--- a/src/features/projects/projects_page.py
+++ b/src/features/projects/projects_page.py
@@ -14,7 +14,6 @@ def create_masonry_page(tag: str | None = None):
     else:
         projects = service.get_all_projects()
 
-    projects = projects[::-1]
     num_projects = len(projects)
 
     content = [

--- a/src/services/projects.py
+++ b/src/services/projects.py
@@ -16,11 +16,13 @@ class ProjectService:
         need to see hidden posts as well.
         """
         if include_disabled:
-            query = f"SELECT * FROM `{settings.BIGQUERY_TABLE}` LIMIT {int(limit)}"
+            query = (
+                f"SELECT * FROM `{settings.BIGQUERY_TABLE}` ORDER BY date DESC LIMIT {int(limit)}"
+            )
         else:
             query = (
                 f"SELECT * FROM `{settings.BIGQUERY_TABLE}` "
-                f"WHERE disabled = false LIMIT {int(limit)}"
+                f"WHERE disabled = false ORDER BY date DESC LIMIT {int(limit)}"
             )
         results = self.client.query(sql=query)
 
@@ -52,7 +54,8 @@ class ProjectService:
         # BigQuery array filtering
         where_disabled = "" if include_disabled else " AND disabled = false"
         query = (
-            f"SELECT * FROM `{settings.BIGQUERY_TABLE}` WHERE @tag IN UNNEST(tags){where_disabled}"
+            f"SELECT * FROM `{settings.BIGQUERY_TABLE}` "
+            f"WHERE @tag IN UNNEST(tags){where_disabled} ORDER BY date DESC"
         )
         params = {"tag": tag}
         results = self.client.query(sql=query, params=params)

--- a/src/styles/_components.py
+++ b/src/styles/_components.py
@@ -173,7 +173,7 @@ COMPONENTS_CSS = """
 /* Project / blog card image + typography (used inside Card) */
 .factory-card-image {
     width: 100%;
-    height: 200px;
+    aspect-ratio: 16 / 10;
     object-fit: cover;
     border: 1px solid var(--color-base-900);
     border-radius: var(--radius-md);

--- a/src/styles/_components.py
+++ b/src/styles/_components.py
@@ -191,6 +191,7 @@ COMPONENTS_CSS = """
     margin-bottom: 0.5rem;
 }
 
+/* Full-text description; intentionally NO line-clamp/truncation so masonry can vary card heights. */
 .factory-card-description {
     font-size: 0.875rem;
     color: var(--color-base-400);

--- a/src/styles/_pages.py
+++ b/src/styles/_pages.py
@@ -186,4 +186,22 @@ PAGES_CSS = """
     font-weight: 700;
     font-size: 0.75rem;
 }
+
+/* Blog masonry layout (CSS column-count for true variable-height tiling) */
+.masonry-columns {
+    column-count: 3;
+    column-gap: 1.5rem;
+}
+.masonry-columns > * {
+    break-inside: avoid;
+    margin-bottom: 1.5rem;
+    display: inline-block;
+    width: 100%;
+}
+@media (max-width: 992px) {
+    .masonry-columns { column-count: 2; }
+}
+@media (max-width: 640px) {
+    .masonry-columns { column-count: 1; }
+}
 """

--- a/tests/test_masonry.py
+++ b/tests/test_masonry.py
@@ -37,3 +37,36 @@ def test_masonry_page_renders_masonry_columns_wrapper(mock_service_cls):
     assert html.count("Post 0") == 1
     assert html.count("Post 1") == 1
     assert html.count("Post 2") == 1
+
+
+def test_project_card_renders_full_description_without_truncation():
+    """A long description must render verbatim in the card body for masonry to vary card heights."""
+    long_desc = (
+        "FastP is an ultra-fast, all-in-one tool for trimming, filtering, and "
+        "quality-checking FASTQ files, helping you quickly generate clean, "
+        "high-quality datasets for genomics and transcriptomics projects. This "
+        "guide walks you through installation, usage, and key features of FastP, "
+        "making it an essential part of your NGS workflow."
+    )
+    project = Project.from_dict(
+        {
+            "id": "p1",
+            "title": "Long",
+            "description": long_desc,
+            "image": "https://example.com/i.png",
+            "tags": ["genomics"],
+            "disabled": False,
+            "views": 0,
+            "likes": 0,
+            "date": "2025-01-01T00:00:00Z",
+            "body": "",
+        }
+    )
+    from src.features.projects.components import render_project_card
+
+    html = to_xml(render_project_card(0, project))
+    # Full description present, end-to-end (the last clause must appear)
+    assert "essential part of your NGS workflow" in html
+    # And no CSS truncation utility silently slipped in via cls
+    assert "line-clamp" not in html
+    assert "truncate" not in html

--- a/tests/test_masonry.py
+++ b/tests/test_masonry.py
@@ -1,0 +1,39 @@
+"""Smoke tests for the masonry blog grid (Epic B)."""
+
+from unittest.mock import patch
+
+from fasthtml.common import to_xml
+from src.features.projects.projects_page import create_masonry_page
+from src.models.project import Project
+
+
+@patch("src.features.projects.projects_page.ProjectService")
+def test_masonry_page_renders_masonry_columns_wrapper(mock_service_cls):
+    """create_masonry_page wraps cards in a div with class='masonry-columns'."""
+    mock_service = mock_service_cls.return_value
+    mock_service.get_all_projects.return_value = [
+        Project.from_dict(
+            {
+                "id": f"id-{i}",
+                "title": f"Post {i}",
+                "description": "desc",
+                "image": "https://example.com/img.png",
+                "tags": ["genomics"],
+                "disabled": False,
+                "views": 0,
+                "likes": 0,
+                "date": "2025-01-01T00:00:00Z",
+                "body": "",
+            }
+        )
+        for i in range(3)
+    ]
+
+    page = create_masonry_page()
+    html = to_xml(page)
+
+    assert 'class="masonry-columns"' in html or "masonry-columns" in html
+    # All 3 cards should be inside the same masonry-columns div
+    assert html.count("Post 0") == 1
+    assert html.count("Post 1") == 1
+    assert html.count("Post 2") == 1

--- a/tests/test_project_service.py
+++ b/tests/test_project_service.py
@@ -92,3 +92,22 @@ def test_get_project_by_id_returns_none_for_unknown_id(mock_bq):
     result = service.get_project_by_id("does-not-exist")
 
     assert result is None
+
+
+def test_get_all_projects_orders_by_date_desc_in_sql(mock_bq):
+    """SQL emitted by get_all_projects includes ORDER BY date DESC."""
+    mock_bq.query.return_value = []
+    ProjectService().get_all_projects()
+    # Inspect what was passed to mock_bq.query
+    call = mock_bq.query.call_args
+    sql = call.kwargs.get("sql") or call.args[0]
+    assert "order by date desc" in sql.lower()
+
+
+def test_get_projects_by_tag_orders_by_date_desc_in_sql(mock_bq):
+    """get_projects_by_tag also emits ORDER BY date DESC."""
+    mock_bq.query.return_value = []
+    ProjectService().get_projects_by_tag("genomics")
+    call = mock_bq.query.call_args
+    sql = call.kwargs.get("sql") or call.args[0]
+    assert "order by date desc" in sql.lower()


### PR DESCRIPTION
Closes #111

Third PR of the 4-PR plan. Builds on Epic A (#110) which added the `Card` primitive and split the styles. Replaces today's uniform-height CSS Grid on `/blogs` with true masonry via pure CSS `column-count` — no JS, no library.

## What landed (4 tickets, 4 commits)

- [x] **B4** — `ORDER BY date DESC` in SQL for both `get_all_projects` and `get_projects_by_tag` (4 SQL variants total). Removed the now-redundant Python `projects[::-1]` reverse in `create_masonry_page`. 2 new tests assert SQL contains the ordering.
- [x] **B1** — `Grid(...)` in `projects_page.py` replaced with `Div(*cards, cls="masonry-columns")`. New CSS in `_pages.py`: `column-count: 3` (default), `column-count: 2` at ≤992px, `column-count: 1` at ≤640px, with `break-inside: avoid` + `display: inline-block` on each card. Smoke test asserts `masonry-columns` class is rendered.
- [x] **B2** — `.factory-card-image` no longer forces `height: 200px`; uses `aspect-ratio: 16 / 10` so cards image-area shapes consistently while text varies. (The remaining `height: 200` in the codebase is on `.sun-reflection` — hero scene element, intentional.)
- [x] **B3** — Regression guard: a test that asserts a long blog description renders verbatim in the card and contains no `line-clamp` or `truncate`. Plus a CSS comment above `.factory-card-description` so future refactors don't silently re-introduce truncation. (A5 already removed the truncation; this just defends it.)

## Test results

```
$ pytest -q
................................                                         [100%]
============================== 32 passed in 0.55s ==============================

$ ruff check . && ruff format --check .
All checks passed!
66 files already formatted
```

## Manual smoke

| Route | Status | Has `masonry-columns` class |
|---|---|---|
| `/` | 200 | n/a |
| `/blogs` | 200 | yes (5 hits in body) |
| `/cv` | 200 | n/a |

`FACTORY_CSS` bundle includes `.masonry-columns` and `aspect-ratio: 16 / 10`; `height: 200px` is no longer in the bundle.

## Manual visual verification (do once after merge)

Open `/blogs` in a browser:
- Cards have visibly different heights (driven by description length now that the image area is fixed-ratio)
- Resize to ≤ 992px → 2 columns
- Resize to ≤ 640px → 1 column
- No JS console errors
- Lighthouse Layout Shift score ≤ 0.05

## Diff stats

- 6 files touched
- +119 / -11 lines

## Out of scope (deferred)

- Lighthouse audit (manual after merge)
- Epic C: blog pipeline polish + CV experience diagrams (next PR, autopilot routine will pick it up)