### PR TITLE
feat(epic-c): blog pipeline polish + CV experience diagrams

### DIFF
--- a/src/components/layout/footer.py
+++ b/src/components/layout/footer.py
@@ -49,6 +49,7 @@ def Footer():
                     for link in settings.NAV_LINKS
                 ],
                 cls="factory-footer-row",
+                aria_label="Footer navigation",
             ),
             cls="factory-footer-row",
         ),

--- a/src/components/layout/navigation.py
+++ b/src/components/layout/navigation.py
@@ -26,4 +26,5 @@ def navigation(logo: str = "GABRIEL"):
         ),
         sticky=True,
         cls="factory-nav",
+        aria_label="Primary navigation",
     )

--- a/src/components/layout/page.py
+++ b/src/components/layout/page.py
@@ -5,17 +5,50 @@ from .navigation import navigation
 from src.styles import FACTORY_CSS, THEME_CSS
 
 
-def StandardPage(title: str, *content, extra_styles: str = "", extra_scripts=None, cls=""):
+def StandardPage(
+    title: str,
+    *content,
+    extra_styles: str = "",
+    extra_scripts=None,
+    cls: str = "",
+    meta: dict | None = None,
+):
     """
     Standard page wrapper with navigation and Factory theme.
+
+    When ``meta`` is provided, emits Open Graph + Twitter Card + canonical URL
+    meta tags so blog posts unfurl nicely in Slack, LinkedIn, etc.
     """
     scripts = extra_scripts if extra_scripts else []
     if not isinstance(scripts, list):
         scripts = [scripts]
 
+    meta_tags = []
+    if meta:
+        og_title = meta.get("title", title)
+        og_desc = meta.get("description", "")
+        og_image = meta.get("image", "")
+        og_url = meta.get("url", "")
+        og_type = meta.get("type", "article")
+        meta_tags = [
+            Meta(property="og:title", content=og_title),
+            Meta(property="og:description", content=og_desc),
+            Meta(property="og:image", content=og_image),
+            Meta(property="og:url", content=og_url),
+            Meta(property="og:type", content=og_type),
+            Meta(property="og:site_name", content="Gabriel Navarro"),
+            Link(rel="canonical", href=og_url) if og_url else None,
+            Meta(name="twitter:card", content="summary_large_image"),
+            Meta(name="twitter:title", content=og_title),
+            Meta(name="twitter:description", content=og_desc),
+            Meta(name="twitter:image", content=og_image),
+        ]
+        meta_tags = [t for t in meta_tags if t is not None]
+
     return (
         Head(
             Title(title),
+            *meta_tags,
             # Geist Font Import
             Link(
                 rel="stylesheet",

--- a/src/core/routes.py
+++ b/src/core/routes.py
@@ -1,4 +1,6 @@
 from fasthtml.common import *
+from starlette.responses import Response
+
 from src.features.hero import HERO_PAGE
 from src.features.projects import (
     PROJECTS_PAGE,
@@ -7,6 +9,8 @@ from src.features.projects import (
     create_masonry_page,
 )
 from src.features.cv import CV_PAGE
+from src.features.feed.rss import build_rss_feed
+from src.services.projects import ProjectService
 
 
 def register_routes(app, rt):
@@ -37,3 +41,19 @@ def register_routes(app, rt):
     @rt("/cv")
     def cv():
         return CV_PAGE
+
+    @rt("/feed.xml")
+    def feed_xml():
+        service = ProjectService()
+        projects = service.get_all_projects(limit=50, include_disabled=False)
+        body = build_rss_feed(projects)
+        return Response(body, media_type="application/rss+xml")
+
+    # FastHTML's `fast_app` registers a static-asset catch-all
+    # `/{fname:path}.{ext:static}` *before* user routes, and `xml` is one of
+    # its recognized static extensions. Without reordering, /feed.xml is
+    # claimed by the static handler and 404s (no file on disk). Move our
+    # explicit /feed.xml route to the front so Starlette matches it first.
+    feed_routes = [r for r in app.router.routes if getattr(r, "path", None) == "/feed.xml"]
+    other_routes = [r for r in app.router.routes if getattr(r, "path", None) != "/feed.xml"]
+    app.router.routes[:] = feed_routes + other_routes

--- a/src/core/routes.py
+++ b/src/core/routes.py
@@ -1,6 +1,11 @@
 from fasthtml.common import *
 from src.features.hero import HERO_PAGE
-from src.features.projects import PROJECTS_PAGE, create_masonry_page, create_blog_page
+from src.features.projects import (
+    PROJECTS_PAGE,
+    create_blog_page,
+    create_blog_page_by_slug,
+    create_masonry_page,
+)
 from src.features.cv import CV_PAGE
 
 
@@ -20,6 +25,10 @@ def register_routes(app, rt):
     @rt("/blogs")
     def blogs(tag: str = None):
         return create_masonry_page(tag)
+
+    @rt("/blogs/slug/{slug}")
+    def get_blog_by_slug(slug: str):
+        return create_blog_page_by_slug(slug)
 
     @rt("/blogs/{blog_id}")
     def get_blog(blog_id: str):

--- a/src/features/cv/components.py
+++ b/src/features/cv/components.py
@@ -1,6 +1,7 @@
 from fasthtml.common import *
 from monsterui.all import *
 from src.components.base import Card
+from .diagrams import diagram_for
 
 
 def cv_section_header(title):
@@ -70,8 +71,12 @@ def cv_experience():
             Card(
                 Grid(cols=12)(
                     Div(
-                        P(exp["period"], cls="cv-period"),
-                        cls="col-span-12 md:col-span-3",
+                        Div(diagram_for(exp["company"]), cls="cv-date-bg"),
+                        Div(
+                            P(exp["period"], cls="cv-date-pill"),
+                            cls="cv-date-pill-wrap",
+                        ),
+                        cls="col-span-12 md:col-span-3 cv-date-col",
                     ),
                     Div(
                         H3(exp["title"].upper(), cls="cv-role-title"),

--- a/src/features/cv/diagrams.py
+++ b/src/features/cv/diagrams.py
@@ -1,0 +1,227 @@
+"""Per-experience SVG diagrams used as the background of the CV date column.
+
+Each function returns a ``Safe`` raw-SVG string (a ``str`` subclass) so it
+can be passed directly to FastHTML containers and is preserved verbatim by
+``to_xml`` — this preserves the camelCase ``viewBox`` attribute that the
+SVG spec requires (FastHTML's element tree lowercases attribute names).
+
+Conventions followed by every diagram:
+
+- ``viewBox="0 0 200 200"`` and no fixed ``width``/``height`` (CSS sizes them).
+- Strokes/fills use ``currentColor`` so a single CSS ``color`` rule themes
+  every diagram uniformly (see ``.cv-date-bg`` in ``_components.py``).
+- ``stroke-width="1.5"`` reads well at both small and scaled sizes.
+- A non-empty ``<title>`` and ``<desc>`` are included for screen readers.
+- Markup is intentionally stylized — these are decorative diagrams, not
+  technical schematics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fasthtml.common import Safe
+
+
+def genome_lm_bg() -> Safe:
+    """Genome LM training: stacked transformer blocks feeding 4 GPU nodes."""
+    return Safe(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" '
+        'stroke="currentColor" fill="none" stroke-width="1.5">'
+        "<title>Genome language model training</title>"
+        "<desc>Four stacked transformer blocks on the left feed four GPU "
+        "nodes on the right via gradient-sync arrows, with a 2B parameter "
+        "callout.</desc>"
+        # Four stacked transformer blocks (left column)
+        '<rect x="20" y="40" width="60" height="18" rx="2" />'
+        '<rect x="20" y="64" width="60" height="18" rx="2" />'
+        '<rect x="20" y="88" width="60" height="18" rx="2" />'
+        '<rect x="20" y="112" width="60" height="18" rx="2" />'
+        # Inner attention dots
+        '<circle cx="35" cy="49" r="1.5" fill="currentColor" />'
+        '<circle cx="50" cy="49" r="1.5" fill="currentColor" />'
+        '<circle cx="65" cy="49" r="1.5" fill="currentColor" />'
+        '<circle cx="35" cy="121" r="1.5" fill="currentColor" />'
+        '<circle cx="50" cy="121" r="1.5" fill="currentColor" />'
+        '<circle cx="65" cy="121" r="1.5" fill="currentColor" />'
+        # GPU nodes (right column)
+        '<circle cx="160" cy="55" r="9" />'
+        '<circle cx="160" cy="85" r="9" />'
+        '<circle cx="160" cy="115" r="9" />'
+        '<circle cx="160" cy="145" r="9" />'
+        # DDP gradient-sync arrows: blocks -> GPU 1, GPU 4 -> blocks
+        '<line x1="80" y1="50" x2="148" y2="55" />'
+        '<line x1="80" y1="120" x2="148" y2="145" />'
+        # Sync ring between GPUs
+        '<line x1="160" y1="64" x2="160" y2="76" />'
+        '<line x1="160" y1="94" x2="160" y2="106" />'
+        '<line x1="160" y1="124" x2="160" y2="136" />'
+        # 2B parameter callout
+        '<text x="100" y="175" text-anchor="middle" '
+        'font-family="monospace" font-size="14" font-weight="700" '
+        'fill="currentColor" stroke="none">2B</text>'
+        "</svg>"
+    )
+
+
+def multiomics_bg() -> Safe:
+    """Three omics lanes converging into a single candidate gene node."""
+    return Safe(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" '
+        'stroke="currentColor" fill="none" stroke-width="1.5">'
+        "<title>Multi-omics integration</title>"
+        "<desc>Three horizontal lanes representing genomics, proteomics, "
+        "and metabolomics converge into a single candidate gene node on "
+        "the right.</desc>"
+        # Three horizontal swimlanes (left)
+        '<rect x="15" y="55" width="80" height="14" rx="2" />'
+        '<rect x="15" y="93" width="80" height="14" rx="2" />'
+        '<rect x="15" y="131" width="80" height="14" rx="2" />'
+        # Lane sample dots
+        '<circle cx="30" cy="62" r="1.8" fill="currentColor" />'
+        '<circle cx="55" cy="62" r="1.8" fill="currentColor" />'
+        '<circle cx="80" cy="62" r="1.8" fill="currentColor" />'
+        '<circle cx="30" cy="100" r="1.8" fill="currentColor" />'
+        '<circle cx="55" cy="100" r="1.8" fill="currentColor" />'
+        '<circle cx="80" cy="100" r="1.8" fill="currentColor" />'
+        '<circle cx="30" cy="138" r="1.8" fill="currentColor" />'
+        '<circle cx="55" cy="138" r="1.8" fill="currentColor" />'
+        '<circle cx="80" cy="138" r="1.8" fill="currentColor" />'
+        # Convergence lines into the candidate hexagon
+        '<line x1="95" y1="62" x2="150" y2="100" />'
+        '<line x1="95" y1="100" x2="150" y2="100" />'
+        '<line x1="95" y1="138" x2="150" y2="100" />'
+        # Candidate gene hexagon (right)
+        '<polygon points="170,100 162,86 146,86 138,100 146,114 162,114" />'
+        '<circle cx="154" cy="100" r="3" fill="currentColor" />'
+        # Lane labels (single letters for genomics/proteomics/metabolomics)
+        '<text x="8" y="65" font-family="monospace" font-size="8" '
+        'fill="currentColor" stroke="none">G</text>'
+        '<text x="8" y="103" font-family="monospace" font-size="8" '
+        'fill="currentColor" stroke="none">P</text>'
+        '<text x="8" y="141" font-family="monospace" font-size="8" '
+        'fill="currentColor" stroke="none">M</text>'
+        "</svg>"
+    )
+
+
+def lcms_bg() -> Safe:
+    """LC-MS chromatogram peaks feeding a CNN box with a spectral score."""
+    return Safe(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" '
+        'stroke="currentColor" fill="none" stroke-width="1.5">'
+        "<title>LC-MS spectral matching</title>"
+        "<desc>Chromatogram peaks at the top feed a small convolutional "
+        "neural network box, producing a spectral match score shown as "
+        "peaks at the bottom.</desc>"
+        # Top chromatogram baseline + peaks
+        '<line x1="15" y1="55" x2="185" y2="55" stroke-dasharray="2 2" />'
+        '<path d="M15 55 L35 55 L42 30 L48 55 L70 55 L80 18 L88 55 '
+        "L120 55 L128 38 L135 55 L160 55 L168 25 L175 55 L185 55"
+        '" />'
+        # CNN box (middle)
+        '<rect x="60" y="85" width="80" height="32" rx="3" />'
+        # Convolutional kernel hint inside the box
+        '<rect x="72" y="93" width="14" height="16" />'
+        '<rect x="93" y="93" width="14" height="16" />'
+        '<rect x="114" y="93" width="14" height="16" />'
+        '<text x="100" y="135" text-anchor="middle" '
+        'font-family="monospace" font-size="7" fill="currentColor" '
+        'stroke="none">CNN</text>'
+        # Bottom spectral match peaks
+        '<line x1="15" y1="170" x2="185" y2="170" />'
+        '<line x1="40" y1="170" x2="40" y2="148" />'
+        '<line x1="65" y1="170" x2="65" y2="155" />'
+        '<line x1="90" y1="170" x2="90" y2="142" />'
+        '<line x1="115" y1="170" x2="115" y2="158" />'
+        '<line x1="140" y1="170" x2="140" y2="150" />'
+        '<line x1="165" y1="170" x2="165" y2="160" />'
+        "</svg>"
+    )
+
+
+def forager_bg() -> Safe:
+    """Funnel from 20,000 compounds to 50 bioactives with a 100x callout."""
+    return Safe(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" '
+        'stroke="currentColor" fill="none" stroke-width="1.5">'
+        "<title>Forager bioactive discovery funnel</title>"
+        "<desc>A funnel narrows from twenty thousand candidate compounds "
+        "down to fifty bioactives, with a one hundred times throughput "
+        "callout.</desc>"
+        # Funnel outline (trapezoid narrowing downward)
+        '<polygon points="25,40 175,40 130,120 70,120" />'
+        # Compound dots at the wide top
+        '<circle cx="50" cy="55" r="1.5" fill="currentColor" />'
+        '<circle cx="70" cy="58" r="1.5" fill="currentColor" />'
+        '<circle cx="90" cy="52" r="1.5" fill="currentColor" />'
+        '<circle cx="110" cy="60" r="1.5" fill="currentColor" />'
+        '<circle cx="130" cy="55" r="1.5" fill="currentColor" />'
+        '<circle cx="150" cy="58" r="1.5" fill="currentColor" />'
+        '<circle cx="60" cy="70" r="1.5" fill="currentColor" />'
+        '<circle cx="100" cy="72" r="1.5" fill="currentColor" />'
+        '<circle cx="140" cy="70" r="1.5" fill="currentColor" />'
+        # Funnel stem
+        '<line x1="100" y1="120" x2="100" y2="150" />'
+        # Output bioactives (small cluster at the bottom)
+        '<circle cx="92" cy="160" r="3" />'
+        '<circle cx="100" cy="165" r="3" />'
+        '<circle cx="108" cy="160" r="3" />'
+        # 100x callout to the right of the funnel
+        '<text x="170" y="80" text-anchor="middle" '
+        'font-family="monospace" font-size="14" font-weight="700" '
+        'fill="currentColor" stroke="none">100x</text>'
+        '<line x1="155" y1="85" x2="135" y2="100" />'
+        "</svg>"
+    )
+
+
+def qc_bg() -> Safe:
+    """Three factory nodes feeding an ML gate with a 90% callout."""
+    return Safe(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" '
+        'stroke="currentColor" fill="none" stroke-width="1.5">'
+        "<title>Real-time QC gate</title>"
+        "<desc>Three factory floor nodes on the left feed a machine "
+        "learning decision gate on the right, with a ninety percent QC "
+        "throughput callout.</desc>"
+        # Three factory nodes (squares with chimneys)
+        '<rect x="20" y="50" width="28" height="22" />'
+        '<line x1="32" y1="50" x2="32" y2="42" />'
+        '<rect x="20" y="92" width="28" height="22" />'
+        '<line x1="32" y1="92" x2="32" y2="84" />'
+        '<rect x="20" y="134" width="28" height="22" />'
+        '<line x1="32" y1="134" x2="32" y2="126" />'
+        # Lines feeding the diamond gate
+        '<line x1="48" y1="61" x2="120" y2="100" />'
+        '<line x1="48" y1="103" x2="120" y2="100" />'
+        '<line x1="48" y1="145" x2="120" y2="100" />'
+        # Diamond ML gate
+        '<polygon points="140,100 120,80 100,100 120,120" />'
+        # Pass / fail outputs
+        '<line x1="140" y1="100" x2="170" y2="85" />'
+        '<line x1="140" y1="100" x2="170" y2="115" />'
+        '<circle cx="175" cy="83" r="3" fill="currentColor" />'
+        '<circle cx="175" cy="117" r="3" />'
+        # 90% callout
+        '<text x="100" y="175" text-anchor="middle" '
+        'font-family="monospace" font-size="14" font-weight="700" '
+        'fill="currentColor" stroke="none">90%</text>'
+        "</svg>"
+    )
+
+
+# Mapping from CV company name (as used in components.py) to its diagram fn.
+COMPANY_DIAGRAMS: dict[str, Callable[[], Safe]] = {
+    "Triplebar": genome_lm_bg,
+    "Amyris": multiomics_bg,
+    "Hexagon Bio": lcms_bg,
+    "Brightseed": forager_bg,
+    "Mondelez International": qc_bg,
+}
+
+
+def diagram_for(company: str) -> Safe | None:
+    """Return the SVG diagram for a company, or ``None`` if unknown."""
+    fn = COMPANY_DIAGRAMS.get(company)
+    return fn() if fn is not None else None

--- a/src/features/feed/rss.py
+++ b/src/features/feed/rss.py
@@ -1,0 +1,68 @@
+"""Build RSS 2.0 feed XML from a list of Project objects.
+
+Pure stdlib XML construction (no feedgen, no lxml). Caps at 50 items per
+the RSS spec convention; CDATA-wraps title/description to avoid escaping.
+"""
+
+from datetime import datetime, timezone
+from email.utils import format_datetime
+from typing import List
+
+from src.models.project import Project
+
+SITE_URL = "https://gabriel.navarro.bio"
+SITE_TITLE = "Gabriel Navarro"
+SITE_DESCRIPTION = "Posts on computational biology, foundation models, and infrastructure."
+
+
+def _project_link(project: Project, base: str = SITE_URL) -> str:
+    """Prefer slug-based URL; fall back to UUID for legacy/empty-slug rows."""
+    if project.slug:
+        return f"{base}/blogs/slug/{project.slug}"
+    return f"{base}/blogs/{project.id}"
+
+
+def _format_pub_date(date_str: str) -> str:
+    """Convert an ISO 8601 string (BigQuery format) to RFC 822 for RSS."""
+    if not date_str:
+        return ""
+    # BigQuery serializes timestamps with trailing Z; normalize for fromisoformat
+    try:
+        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except ValueError:
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return format_datetime(dt)
+
+
+def _item_xml(project: Project) -> str:
+    pub_date = _format_pub_date(project.date)
+    categories = "\n      ".join(f"<category>{tag}</category>" for tag in project.tags)
+    return f"""    <item>
+      <title><![CDATA[{project.title}]]></title>
+      <link>{_project_link(project)}</link>
+      <guid isPermaLink="false">{project.id}</guid>
+      <pubDate>{pub_date}</pubDate>
+      <description><![CDATA[{project.description}]]></description>
+      {categories}
+    </item>"""
+
+
+def build_rss_feed(projects: List[Project], site_url: str = SITE_URL) -> str:
+    """Render an RSS 2.0 feed for the given projects (cap 50 items)."""
+    last_build = format_datetime(datetime.now(timezone.utc))
+    items = "\n".join(_item_xml(p) for p in projects[:50])
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{SITE_TITLE}</title>
+    <link>{site_url}/blogs</link>
+    <description>{SITE_DESCRIPTION}</description>
+    <language>en-us</language>
+    <lastBuildDate>{last_build}</lastBuildDate>
+    <atom:link href="{site_url}/feed.xml" rel="self" type="application/rss+xml" />
+{items}
+  </channel>
+</rss>
+"""

--- a/src/features/projects/__init__.py
+++ b/src/features/projects/__init__.py
@@ -1,3 +1,13 @@
-from .projects_page import PROJECTS_PAGE, create_masonry_page, create_blog_page
+from .projects_page import (
+    PROJECTS_PAGE,
+    create_blog_page,
+    create_blog_page_by_slug,
+    create_masonry_page,
+)
 
-__all__ = ["PROJECTS_PAGE", "create_masonry_page", "create_blog_page"]
+__all__ = [
+    "PROJECTS_PAGE",
+    "create_blog_page",
+    "create_blog_page_by_slug",
+    "create_masonry_page",
+]

--- a/src/features/projects/components.py
+++ b/src/features/projects/components.py
@@ -22,9 +22,11 @@ def render_project_card(idx, project):
     body.append(H3(project.title.upper(), cls="factory-card-title"))
     body.append(P(project.description, cls="factory-card-description"))
 
+    href = f"/blogs/slug/{project.slug}" if project.slug else f"/blogs/{project.id}"
+
     return Card(
         *body,
-        href=f"/blogs/{project.id}",
+        href=href,
         interactive=True,
         padding="md",
     )

--- a/src/features/projects/projects_page.py
+++ b/src/features/projects/projects_page.py
@@ -30,14 +30,8 @@ def create_masonry_page(tag: str | None = None):
     return StandardPage("Projects", *content)
 
 
-def create_blog_page(uuid: str):
-    """Creates a detail page for a specific blog post."""
-    service = ProjectService()
-    project = service.get_project_by_id(uuid)
-
-    if not project:
-        return StandardPage("Not Found", H1("PROJECT NOT FOUND", cls="factory-title"))
-
+def _render_blog_detail(project):
+    """Render the shared blog detail body for a Project (UUID or slug lookup)."""
     content = [
         Div("TECHNICAL OVERVIEW", cls="factory-label"),
         H1(project.title.upper(), cls="factory-title"),
@@ -56,6 +50,28 @@ def create_blog_page(uuid: str):
     ]
 
     return StandardPage(project.title, *content)
+
+
+def create_blog_page(uuid: str):
+    """Creates a detail page for a specific blog post (looked up by UUID)."""
+    service = ProjectService()
+    project = service.get_project_by_id(uuid)
+
+    if not project:
+        return StandardPage("Not Found", H1("PROJECT NOT FOUND", cls="factory-title"))
+
+    return _render_blog_detail(project)
+
+
+def create_blog_page_by_slug(slug: str):
+    """Render a blog detail page looked up by slug."""
+    service = ProjectService()
+    project = service.get_project_by_slug(slug)
+
+    if not project:
+        return StandardPage("Not Found", H1("PROJECT NOT FOUND", cls="factory-title"))
+
+    return _render_blog_detail(project)
 
 
 def projects_landing_page():

--- a/src/features/projects/projects_page.py
+++ b/src/features/projects/projects_page.py
@@ -32,6 +32,17 @@ def create_masonry_page(tag: str | None = None):
 
 def _render_blog_detail(project):
     """Render the shared blog detail body for a Project (UUID or slug lookup)."""
+    canonical_url = (
+        f"https://gabriel.navarro.bio/blogs/slug/{project.slug}"
+        if project.slug
+        else f"https://gabriel.navarro.bio/blogs/{project.id}"
+    )
+    meta = {
+        "description": project.description,
+        "image": project.image,
+        "url": canonical_url,
+        "type": "article",
+    }
     content = [
         Div("TECHNICAL OVERVIEW", cls="factory-label"),
         H1(project.title.upper(), cls="factory-title"),
@@ -49,7 +60,7 @@ def _render_blog_detail(project):
         ),
     ]
 
-    return StandardPage(project.title, *content)
+    return StandardPage(project.title, *content, meta=meta)
 
 
 def create_blog_page(uuid: str):

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import List
 
+from slugify import slugify
+
 
 @dataclass
 class ProjectTag:
@@ -20,6 +22,7 @@ class Project:
     likes: int = 0
     date: str = ""
     body: str = ""
+    slug: str = ""
 
     @classmethod
     def from_dict(cls, data: dict) -> "Project":
@@ -33,10 +36,19 @@ class Project:
                 elif isinstance(tag, str):
                     tags.append(tag)
 
+        title = data.get("title", "")
+
+        # Slug always exists Python-side. BigQuery's gn-blog table doesn't have a
+        # slug column yet — until the one-time ALTER TABLE + backfill runs, this
+        # fallback derives a slug from the title so URL routing works either way.
+        slug = data.get("slug") or ""
+        if not slug and title:
+            slug = slugify(title)
+
         return cls(
             id=data.get("id", ""),
             blog_id=data.get("blog_id", ""),
-            title=data.get("title", ""),
+            title=title,
             description=data.get("description", ""),
             image=data.get("image", ""),
             tags=tags,
@@ -45,4 +57,5 @@ class Project:
             likes=data.get("likes", 0),
             date=data.get("date", ""),
             body=data.get("body", ""),
+            slug=slug,
         )

--- a/src/services/projects.py
+++ b/src/services/projects.py
@@ -45,6 +45,19 @@ class ProjectService:
 
         return None
 
+    def get_project_by_slug(self, slug: str) -> Optional[Project]:
+        """Look up a project by its slug. Client-side scan over all projects.
+
+        BigQuery's gn-blog table does not yet have a slug column. Until the one-time
+        ALTER TABLE + backfill runs, slugs only exist Python-side via from_dict's
+        fallback to slugify(title). For ~20 posts a client-side scan is trivially
+        fast; for >100 we'd want a SQL WHERE slug = @slug instead.
+        """
+        for project in self.get_all_projects(limit=1000, include_disabled=False):
+            if project.slug == slug:
+                return project
+        return None
+
     def get_projects_by_tag(self, tag: str, include_disabled: bool = False) -> List[Project]:
         """Fetches projects filtered by tag.
 

--- a/src/styles/_base.py
+++ b/src/styles/_base.py
@@ -133,4 +133,12 @@ html, body {
     --font-geist-sans: "Geist","Geist Fallback";
     --font-geist-mono: "Geist Mono","Geist Mono Fallback";
 }
+
+/* Keyboard focus rings (visible only on keyboard nav, not on click) */
+*:focus { outline: none; }
+*:focus-visible {
+    outline: 2px solid var(--color-accent-100);
+    outline-offset: 3px;
+    border-radius: var(--radius-sm);
+}
 """

--- a/src/styles/_components.py
+++ b/src/styles/_components.py
@@ -304,4 +304,52 @@ pre.shiki::after, .uk-codeblock::after {
 .bg-base-200 {
     background-color: var(--background-color) !important;
 }
+
+/* CV experience date column with SVG background + circular date pill */
+.cv-date-col {
+    position: relative;
+    min-height: 12rem;
+    overflow: hidden;
+}
+.cv-date-bg {
+    position: absolute;
+    inset: 0;
+    opacity: 0.35;
+    pointer-events: none;
+    color: var(--color-accent-100);
+}
+.cv-date-bg svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+.cv-date-pill-wrap {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    min-height: 12rem;
+}
+.cv-date-pill {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    background: var(--dark-base-primary);
+    border: 1px solid var(--color-base-700);
+    color: var(--color-white);
+    font-weight: 700;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    backdrop-filter: blur(4px);
+}
+/* Mobile: SVG becomes a fixed-height top banner; pill stays centered. */
+@media (max-width: 768px) {
+    .cv-date-col {
+        min-height: 8rem;
+        max-height: 8rem;
+    }
+    .cv-date-pill-wrap { min-height: 8rem; }
+}
 """

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,0 +1,60 @@
+"""Accessibility regression tests."""
+
+import re
+from unittest.mock import patch
+
+from fasthtml.common import to_xml
+from src.features.hero import HERO_PAGE
+from src.features.cv import CV_PAGE
+
+
+def _img_tags_without_alt(html: str) -> list[str]:
+    """Return all <img ...> tags in html that lack an alt= attribute."""
+    imgs = re.findall(r"<img[^>]*>", html)
+    return [tag for tag in imgs if "alt=" not in tag]
+
+
+def test_hero_page_has_no_img_without_alt():
+    html = to_xml(HERO_PAGE)
+    missing = _img_tags_without_alt(html)
+    assert not missing, f"<img> tags missing alt in HERO_PAGE: {missing}"
+
+
+def test_cv_page_has_no_img_without_alt():
+    html = to_xml(CV_PAGE)
+    missing = _img_tags_without_alt(html)
+    assert not missing, f"<img> tags missing alt in CV_PAGE: {missing}"
+
+
+@patch("src.features.projects.projects_page.ProjectService")
+def test_blogs_index_has_no_img_without_alt(mock_service_cls):
+    from src.features.projects.projects_page import create_masonry_page
+    from src.models.project import Project
+
+    mock_service = mock_service_cls.return_value
+    mock_service.get_all_projects.return_value = [
+        Project.from_dict(
+            {
+                "id": "p1",
+                "title": "Test post",
+                "description": "desc",
+                "image": "https://example.com/img.png",
+                "tags": ["genomics"],
+                "disabled": False,
+                "views": 0,
+                "likes": 0,
+                "date": "2025-01-01T00:00:00Z",
+                "body": "",
+            }
+        )
+    ]
+    html = to_xml(create_masonry_page())
+    missing = _img_tags_without_alt(html)
+    assert not missing, f"<img> tags missing alt in /blogs: {missing}"
+
+
+def test_navigation_has_aria_label():
+    from src.components.layout.navigation import navigation
+
+    html = to_xml(navigation())
+    assert 'aria-label="Primary navigation"' in html or "aria-label='Primary navigation'" in html

--- a/tests/test_cv_diagrams.py
+++ b/tests/test_cv_diagrams.py
@@ -1,0 +1,50 @@
+"""Tests for CV experience SVG diagrams."""
+
+import re
+
+import pytest
+from fasthtml.common import to_xml
+
+from src.features.cv.diagrams import (
+    COMPANY_DIAGRAMS,
+    diagram_for,
+    forager_bg,
+    genome_lm_bg,
+    lcms_bg,
+    multiomics_bg,
+    qc_bg,
+)
+
+
+@pytest.mark.parametrize("fn", [genome_lm_bg, multiomics_bg, lcms_bg, forager_bg, qc_bg])
+def test_diagram_fn_returns_svg_with_title_and_desc(fn):
+    """Each diagram returns an SVG with non-empty <title> and <desc> for a11y."""
+    html = to_xml(fn())
+    assert "<svg" in html
+    assert "viewBox" in html
+    assert "<title>" in html
+    assert "</title>" in html
+    # Title must be non-empty.
+    title_match = re.search(r"<title>(.*?)</title>", html)
+    assert title_match and title_match.group(1).strip()
+    assert "<desc>" in html
+
+
+def test_diagram_for_known_company_returns_svg():
+    html = to_xml(diagram_for("Triplebar"))
+    assert "<svg" in html
+
+
+def test_diagram_for_unknown_company_returns_none():
+    assert diagram_for("Some Company That Doesnt Exist") is None
+
+
+def test_company_diagrams_covers_all_five_roles():
+    expected = {
+        "Triplebar",
+        "Amyris",
+        "Hexagon Bio",
+        "Brightseed",
+        "Mondelez International",
+    }
+    assert set(COMPANY_DIAGRAMS.keys()) == expected

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -1,0 +1,52 @@
+"""Tests for the RSS feed at /feed.xml."""
+
+from src.features.feed.rss import build_rss_feed
+from src.models.project import Project
+
+
+def _make_project(idx: int, **overrides) -> Project:
+    base = {
+        "id": f"id-{idx}",
+        "title": f"Post {idx}",
+        "description": f"Description {idx}",
+        "image": "",
+        "tags": ["genomics", "bioinformatics"],
+        "disabled": False,
+        "views": 0,
+        "likes": 0,
+        "date": f"2025-04-{20 + idx:02d}T00:00:00Z",
+        "body": "",
+    }
+    base.update(overrides)
+    return Project.from_dict(base)
+
+
+def test_build_rss_feed_emits_rss20_with_items_for_each_project():
+    """build_rss_feed produces valid RSS 2.0 with one <item> per project."""
+    projects = [_make_project(i) for i in range(3)]
+    xml = build_rss_feed(projects)
+
+    # RSS 2.0 envelope
+    assert '<?xml version="1.0" encoding="UTF-8"?>' in xml
+    assert '<rss version="2.0"' in xml
+    assert "<channel>" in xml
+    # 3 items
+    assert xml.count("<item>") == 3
+    # Categories rendered per tag
+    assert "<category>genomics</category>" in xml
+    assert "<category>bioinformatics</category>" in xml
+    # Slug-based links (since slug auto-computed from title in from_dict)
+    for i in range(3):
+        assert f"/blogs/slug/post-{i}" in xml
+    # Each item has its title CDATA-wrapped
+    for i in range(3):
+        assert f"<![CDATA[Post {i}]]>" in xml
+    # GUID is the UUID, not perma
+    assert '<guid isPermaLink="false">id-0</guid>' in xml
+
+
+def test_build_rss_feed_caps_at_50_items():
+    """Even when given more, only 50 items appear."""
+    projects = [_make_project(i) for i in range(75)]
+    xml = build_rss_feed(projects)
+    assert xml.count("<item>") == 50

--- a/tests/test_meta_tags.py
+++ b/tests/test_meta_tags.py
@@ -1,0 +1,40 @@
+"""Tests for OG/Twitter meta tags on blog detail pages."""
+
+from unittest.mock import patch
+
+from fasthtml.common import to_xml
+from src.features.projects.projects_page import create_blog_page
+from src.models.project import Project
+
+
+@patch("src.features.projects.projects_page.ProjectService")
+def test_blog_detail_emits_og_image_matching_project(mock_service_cls):
+    """create_blog_page renders <meta property=og:image> matching the project's image URL."""
+    mock_service = mock_service_cls.return_value
+    img_url = "https://storage.googleapis.com/gn-portfolio/images/fastp-thumb.svg"
+    mock_service.get_project_by_id.return_value = Project.from_dict(
+        {
+            "id": "abc",
+            "title": "FastP",
+            "description": "An ultra-fast tool",
+            "image": img_url,
+            "tags": ["genomics"],
+            "disabled": False,
+            "views": 0,
+            "likes": 0,
+            "date": "2025-04-26T00:00:00Z",
+            "body": "Body text",
+        }
+    )
+
+    html = to_xml(create_blog_page("abc"))
+
+    assert 'property="og:image"' in html
+    assert img_url in html
+    assert 'property="og:title"' in html
+    assert "FastP" in html
+    assert 'property="og:description"' in html
+    assert 'name="twitter:card"' in html
+    assert 'rel="canonical"' in html
+    # Slug-based canonical URL since the project has a slug (computed from title)
+    assert "/blogs/slug/" in html

--- a/tests/test_project_service.py
+++ b/tests/test_project_service.py
@@ -111,3 +111,59 @@ def test_get_projects_by_tag_orders_by_date_desc_in_sql(mock_bq):
     call = mock_bq.query.call_args
     sql = call.kwargs.get("sql") or call.args[0]
     assert "order by date desc" in sql.lower()
+
+
+def test_from_dict_computes_slug_from_title_when_missing(mock_bq):
+    """Project.from_dict computes slug from title if BQ row lacks slug."""
+    p = Project.from_dict(
+        {
+            "id": "x",
+            "title": "Speeding Up FASTQ Preprocessing with FastP",
+            "description": "",
+            "image": "",
+            "tags": [],
+            "disabled": False,
+            "views": 0,
+            "likes": 0,
+            "date": "2025-01-01T00:00:00Z",
+            "body": "",
+        }
+    )
+    assert p.slug == "speeding-up-fastq-preprocessing-with-fastp"
+
+
+def test_get_project_by_slug_returns_matching_project(mock_bq):
+    """get_project_by_slug scans all projects and returns the match (or None)."""
+    mock_bq.query.return_value = [
+        {
+            "id": "1",
+            "title": "Hello World",
+            "description": "",
+            "image": "",
+            "tags": [],
+            "disabled": False,
+            "views": 0,
+            "likes": 0,
+            "date": "2025-01-01T00:00:00Z",
+            "body": "",
+            "slug": "",
+        },
+        {
+            "id": "2",
+            "title": "Another Post",
+            "description": "",
+            "image": "",
+            "tags": [],
+            "disabled": False,
+            "views": 0,
+            "likes": 0,
+            "date": "2025-01-01T00:00:00Z",
+            "body": "",
+            "slug": "",
+        },
+    ]
+    service = ProjectService()
+    found = service.get_project_by_slug("hello-world")
+    assert found is not None
+    assert found.id == "1"
+    assert service.get_project_by_slug("does-not-exist") is None


### PR DESCRIPTION
Closes #113

Final PR of the 4-PR plan. Builds on D (#108), A (#110), B (#112). Adds slug URLs, OG/Twitter meta tags, an RSS feed, accessibility quick-wins, and the centerpiece: per-experience SVG diagrams as the BACKGROUND of each CV date column.

## What landed (5 tickets, 5 commits)

- [x] **C1** — Slug URLs additive to UUIDs. `Project.slug` auto-computed via `python-slugify` from title in `from_dict` if missing. New `@rt('/blogs/slug/{slug}')` route registered BEFORE the UUID route. New `ProjectService.get_project_by_slug` (client-side scan; comment notes SQL approach for >100 posts). `render_project_card` href uses slug when available with UUID fallback. UUID routes keep working — zero breakage. 2 tests.
- [x] **C2** — `StandardPage(meta=...)` accepts an optional dict; blog detail emits 11 social/SEO tags: 5× `og:*`, 4× `twitter:*`, 1× canonical `<link>`, 1× `og:site_name`. Hardcoded production URL `https://gabriel.navarro.bio`. 1 test.
- [x] **C3** — RSS 2.0 feed at `/feed.xml`. New `src/features/feed/rss.py`. Pure stdlib XML build, capped at 50 items, CDATA-wrapped titles/descriptions, RFC 822 `<pubDate>` via `email.utils.format_datetime`, `<atom:link rel=self>` self-link. **Caught a FastHTML route-ordering trap**: `.xml` is in fast_app's static-asset extensions; without explicit reordering the route is shadowed by the static catch-all. Fixed in `register_routes` with a comment. 2 tests.
- [x] **C4** — **The centerpiece.** Each CV experience card now has a per-role SVG diagram as the BACKGROUND of its date column. New `src/features/cv/diagrams.py` with 5 background functions:
  - `genome_lm_bg()` — Triplebar (transformer blocks → 4 GPU nodes with DDP arrows, "2B" label)
  - `multiomics_bg()` — Amyris (3 lanes converging into candidate gene)
  - `lcms_bg()` — Hexagon Bio (chromatogram peaks → CNN box → spectral match)
  - `forager_bg()` — Brightseed (funnel 20K → 50, "100×" callout)
  - `qc_bg()` — Mondelez (factory nodes → ML gate → "90%" callout)

  All SVGs use `viewBox 0 0 200 200`, `currentColor`, `<title>`+`<desc>` for screen readers. Date renders as a circular pill on top of the SVG (border + blur backdrop) so it stays legible at the SVG's 35% opacity. Mobile (< 768px): SVG collapses to a fixed 8rem top banner with overflow hidden, pill stays vertically centered. 4 tests (8 runs with parametrize).
- [x] **C5** — A11y quick-wins. All `<Img>` calls in `src/features/` already had alt text from earlier epics — verified via test. `aria-label="Primary navigation"` added to `<nav>`; `aria-label="Footer navigation"` on the footer link group. New `:focus-visible` outline rule in `_base.py` (uses `--color-accent-100` so keyboard focus rings match the brand). 4 tests assert `<img>` lacks-alt count is 0 on hero, /blogs, and /cv.

## Test results

```
$ pytest -q
.................................................                       [100%]
============================== 49 passed in 0.58s ==============================

$ ruff check . && ruff format --check .
All checks passed!
73 files already formatted
```

## Manual smoke

| Route | Status | Notes |
|---|---|---|
| `/` | 200 | hero unchanged; footer + a11y improvements |
| `/blogs` | 200 | masonry from B; cards use slug hrefs |
| `/blogs/<uuid>` | 200 | back-compat preserved |
| `/blogs/slug/nonexistent` | 200 | styled "PROJECT NOT FOUND" page |
| `/blogs/slug/<real-slug>` | 200 (after BQ slug backfill — see below) | |
| `/cv` | 200 | 5 unique SVGs render behind 5 date pills |
| `/feed.xml` | 200 | `Content-Type: application/rss+xml`; 11 real items in body |

## ⚠ One-time manual step required after merge

Run once against BigQuery to enable slug-based URLs (until then, the slug route returns the styled 404 page; UUID URLs work):

```sql
ALTER TABLE \`noble-office-299208.portfolio.gn-blog\` ADD COLUMN slug STRING;
UPDATE \`noble-office-299208.portfolio.gn-blog\`
SET slug = LOWER(REGEXP_REPLACE(title, r'[^a-zA-Z0-9]+', '-'))
WHERE slug IS NULL;
```

Then verify in the deployed app: open `/blogs`, click any card — the URL should be `/blogs/slug/<title-slug>` and the page should render normally. The Python-side fallback (`from_dict` slugifies title) means the cards' hrefs already point to slug URLs even before the backfill — but those URLs 404 until BQ has matching slug data, so backfill before re-deploy is recommended.

## Diff stats

- 20 files touched
- +760 / -17 lines
- 5 new test modules (a11y, cv_diagrams, feed, meta_tags, plus additions to project_service)
- 5 new SVG diagram functions
- 1 new feature module (`src/features/feed/`)

## Plan complete

Epic D + A + B + C all merged → the 4-epic implementation plan from `/root/.claude/plans/hey-claude-please-use-playful-papert.md` is done. Out-of-scope items (deferred to future plans):
- `/projects` placeholder still says "UNDER CONSTRUCTION" (intentional)
- Admin web UI for blog editing
- BigQuery → markdown migration
- Lockfile / pinned-deps reproducibility