### PR TITLE
fix(cv): align date pill with role title; bottom-align VIEW PATENT links

### DIFF
--- a/src/features/cv/components.py
+++ b/src/features/cv/components.py
@@ -217,6 +217,7 @@ def cv_patents():
                     P(p["authors"], cls="cv-patent-authors"),
                     A("VIEW PATENT →", href=p["link"], cls="cv-patent-link"),
                     padding="md",
+                    cls="cv-patent-card",
                 )
                 for p in patents
             ],

--- a/src/styles/_components.py
+++ b/src/styles/_components.py
@@ -327,10 +327,11 @@ pre.shiki::after, .uk-codeblock::after {
     position: relative;
     z-index: 1;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     height: 100%;
     min-height: 12rem;
+    padding-top: 0.25rem;
 }
 .cv-date-pill {
     display: inline-block;
@@ -350,6 +351,10 @@ pre.shiki::after, .uk-codeblock::after {
         min-height: 8rem;
         max-height: 8rem;
     }
-    .cv-date-pill-wrap { min-height: 8rem; }
+    .cv-date-pill-wrap {
+        min-height: 8rem;
+        align-items: center;
+        padding-top: 0;
+    }
 }
 """

--- a/src/styles/_pages.py
+++ b/src/styles/_pages.py
@@ -162,6 +162,19 @@ PAGES_CSS = """
     font-size: 0.75rem;
     text-decoration: none;
     letter-spacing: 0.05em;
+    margin-top: auto;
+}
+/* Patent cards stretch to equal grid-row height and use a flex column so */
+/* the VIEW PATENT link can be pushed to the bottom (margin-top: auto). */
+.cv-patent-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+.cv-patent-card .factory-card-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
 }
 
 /* CV publication entry (borderless; uses bottom border separator). */


### PR DESCRIPTION
Two CSS-only polish tweaks identified after Epic C merged.

## Fix 1 — Date pill aligns with role title (work experience)

Before: pill was vertically centered in the date column (12rem tall), so it visually dropped below the H3 role title at the top of the right column.

After: `.cv-date-pill-wrap` uses \`align-items: flex-start\` with a 0.25rem top nudge so the pill sits at the top, level with the H3 title. The SVG diagram still fills the full column as background. Mobile (< 768px) keeps centering since the SVG collapses to a fixed 8rem top banner.

```diff
 .cv-date-pill-wrap {
     position: relative;
     z-index: 1;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     height: 100%;
     min-height: 12rem;
+    padding-top: 0.25rem;
 }
```

## Fix 2 — VIEW PATENT links align to the bottom of each patent card

Before: links sat right after the authors line. Author-line length varied (1 vs 2 vs 3 vs 4 names), so the four "VIEW PATENT →" links landed at different vertical positions across the row.

After: tag the patent Card with \`cls="cv-patent-card"\`, make the card a flex column that stretches to equal grid-row height, and \`margin-top: auto\` on the link pushes it to the bottom. All four links now align horizontally regardless of body content.

```diff
 Card(
     P(p["year"], cls="cv-period-tight"),
     H3(p["title"].upper(), cls="cv-patent-title"),
     P(p["authors"], cls="cv-patent-authors"),
     A("VIEW PATENT →", href=p["link"], cls="cv-patent-link"),
     padding="md",
+    cls="cv-patent-card",
 )
```

```css
.cv-patent-link { ...; margin-top: auto; }
.cv-patent-card { height: 100%; display: flex; flex-direction: column; }
.cv-patent-card .factory-card-body { flex: 1; display: flex; flex-direction: column; }
```

## Verification

- 49 tests pass; ruff clean
- \`/cv\` returns 200; rendered HTML contains 4 \`cv-patent-card\` instances (one per patent) and the new flex CSS in the bundle

## Diff stats

- 3 files touched
- +21 / -2 lines