### PR TITLE
ci(deploy): auto-deploy to Cloud Run on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,93 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Required for Workload Identity Federation
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  GCP_PROJECT_ID: noble-office-299208
+  GCP_REGION: us-central1
+  AR_HOST: us-central1-docker.pkg.dev
+  AR_REPO: us-central1-docker.pkg.dev/noble-office-299208/mercy-of-toren
+  IMAGE_NAME: gnbio
+  CLOUD_RUN_SERVICE: gnbio
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Ruff check
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .
+
+      - name: Pytest
+        run: pytest -v
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.AR_HOST }} --quiet
+
+      - name: Build image
+        run: |
+          docker build \
+            -f assets/build/Dockerfile.prod \
+            -t "${AR_REPO}/${IMAGE_NAME}:prod" \
+            -t "${AR_REPO}/${IMAGE_NAME}:sha-${{ steps.sha.outputs.short }}" \
+            .
+
+      - name: Push image (both tags)
+        run: |
+          docker push "${AR_REPO}/${IMAGE_NAME}:prod"
+          docker push "${AR_REPO}/${IMAGE_NAME}:sha-${{ steps.sha.outputs.short }}"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy "${CLOUD_RUN_SERVICE}" \
+            --image "${AR_REPO}/${IMAGE_NAME}:sha-${{ steps.sha.outputs.short }}" \
+            --region "${GCP_REGION}" \
+            --platform managed \
+            --quiet
+
+      - name: Print deployed revision URL
+        run: |
+          gcloud run services describe "${CLOUD_RUN_SERVICE}" \
+            --region "${GCP_REGION}" \
+            --format='value(status.url)'

--- a/README.md
+++ b/README.md
@@ -67,34 +67,42 @@ The site will be available at http://localhost:8080.
 
 
 ### 🚢 Deployment to Google Cloud Run
-Authenticate with Google Cloud:
+
+**Pushes to `main` automatically deploy to Cloud Run** via the [`Deploy to Cloud Run`](.github/workflows/deploy.yml) workflow:
+1. Run lint + tests (must pass)
+2. Build Docker image from `assets/build/Dockerfile.prod`
+3. Push to Artifact Registry tagged both `:prod` and `:sha-<short-sha>`
+4. Deploy to the `gnbio` Cloud Run service in `us-central1`
+
+The workflow authenticates to GCP via Workload Identity Federation (no long-lived JSON keys).
+
+#### Manual deploy (rollback or local testing)
+
 ```bash
+# Authenticate and configure Docker
 gcloud auth login
-```
-Configure Docker to use Google Cloud:
-```bash
-gcloud auth configure-docker
-```
+gcloud auth configure-docker us-central1-docker.pkg.dev
 
-Build and tag the image:
-```bash
-# Build the Docker image for production
-docker build -f ./assets/build/Dockerfile.prod -t gnbio:prod .
-# Tag the image for Google Container Registry
-docker tag gnbio:prod us-central1-docker.pkg.dev/noble-office-299208/mercy-of-toren/gnbio:prod
-```
+# Build and tag
+docker build -f ./assets/build/Dockerfile.prod \
+  -t us-central1-docker.pkg.dev/noble-office-299208/mercy-of-toren/gnbio:prod .
 
-Push the image to Google Container Registry:
-```bash
+# Push and deploy
 docker push us-central1-docker.pkg.dev/noble-office-299208/mercy-of-toren/gnbio:prod
+gcloud run deploy gnbio \
+  --image us-central1-docker.pkg.dev/noble-office-299208/mercy-of-toren/gnbio:prod \
+  --platform managed \
+  --region us-central1
 ```
 
-Deploy to Cloud Run:
+#### Rolling back
+
+Each automated deploy tags the image with the commit SHA. To roll back:
+
 ```bash
-gcloud run deploy gabriel-navarro-bio \
-  --image gcr.io/YOUR_PROJECT_ID/gabriel-navarro-bio \
-  --platform managed \
-  --allow-unauthenticated \
+# Pick a known-good <short-sha> from `git log` or the GH Actions run history
+gcloud run deploy gnbio \
+  --image us-central1-docker.pkg.dev/noble-office-299208/mercy-of-toren/gnbio:sha-<short-sha> \
   --region us-central1
 ```
 


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds, pushes, and deploys to Cloud Run on every push to main. Authenticates via Workload Identity Federation (no long-lived JSON keys).

## What lands

- New [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) with two jobs:
  - **test**: ruff check + ruff format --check + pytest -v on Python 3.13
  - **deploy** (depends on test): WIF auth → build `assets/build/Dockerfile.prod` → push to Artifact Registry tagged `:prod` and `:sha-<short>` → `gcloud run deploy gnbio` (region `us-central1`) using the SHA-tagged image
- README updated: documents the auto-deploy, the manual gcloud commands (kept for local/rollback), and a one-line rollback example using the SHA tags

## ⚠ One-time GCP setup required before this works

After merging, run these gcloud commands once (you'll need owner/IAM admin on `noble-office-299208`):

# 1) Enable required APIs
gcloud services enable iamcredentials.googleapis.com run.googleapis.com artifactregistry.googleapis.com \\
  --project=\$PROJECT_ID

# 2) Create Workload Identity Pool
gcloud iam workload-identity-pools create github-pool \\
  --project=\$PROJECT_ID --location=global \\
  --display-name="GitHub Actions Pool"

# 3) Capture the pool resource name
POOL_NAME=\$(gcloud iam workload-identity-pools describe github-pool \\
  --project=\$PROJECT_ID --location=global --format="value(name)")
echo \$POOL_NAME

# 4) Create the OIDC provider for GitHub. Lock to your GitHub org/user.
gcloud iam workload-identity-pools providers create-oidc github-provider \\
  --project=\$PROJECT_ID --location=global \\
  --workload-identity-pool=github-pool \\
  --display-name="GitHub OIDC" \\
  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \\
  --attribute-condition="assertion.repository_owner == '\$REPO_OWNER'" \\
  --issuer-uri="https://token.actions.githubusercontent.com"

# 5) Create the deploy Service Account
gcloud iam service-accounts create github-actions-deployer \\
  --project=\$PROJECT_ID \\
  --display-name="GitHub Actions Cloud Run Deployer"

DEPLOYER_SA=github-actions-deployer@\${PROJECT_ID}.iam.gserviceaccount.com

# 6) Grant the deploy SA the roles it needs
for ROLE in roles/run.admin roles/artifactregistry.writer roles/iam.serviceAccountUser ; do
  gcloud projects add-iam-policy-binding \$PROJECT_ID \\
    --member="serviceAccount:\$DEPLOYER_SA" --role=\$ROLE
done

# 7) Allow the GitHub repo to impersonate the SA via WIF
gcloud iam service-accounts add-iam-policy-binding \$DEPLOYER_SA \\
  --project=\$PROJECT_ID \\
  --role=roles/iam.workloadIdentityUser \\
  --member="principalSet://iam.googleapis.com/\${POOL_NAME}/attribute.repository/\${REPO_OWNER}/\${REPO_NAME}"

# 8) Get the provider full resource name to put in GitHub secrets
gcloud iam workload-identity-pools providers describe github-provider \\
  --project=\$PROJECT_ID --location=global \\
  --workload-identity-pool=github-pool --format="value(name)"
\`\`\`

Then in GitHub repo settings → Secrets and variables → Actions, add:
- \`GCP_WIF_PROVIDER\` = output of step 8 (looks like \`projects/.../locations/global/workloadIdentityPools/github-pool/providers/github-provider\`)
- \`GCP_SERVICE_ACCOUNT\` = \`github-actions-deployer@noble-office-299208.iam.gserviceaccount.com\`

After both secrets exist, the next push to main will auto-deploy. You can also trigger manually via Actions → \"Deploy to Cloud Run\" → Run workflow.

## Verification

- 49 tests pass; ruff clean
- \`deploy.yml\` parses as valid YAML

The \`deploy\` job will fail at the auth step on the first PR-merge run if the WIF setup above hasn't happened yet — that's expected. The \`test\` job runs regardless and gives you the lint+test signal.

## Cloud Run runtime config (untouched)

Image targets the existing \`gnbio\` service in \`us-central1\` with the existing runtime SA (BigQuery access already configured). Domain Mapping + HTTPS cert untouched.