### PR TITLE
chore(docker): commit unified Dockerfile; install from pyproject; add gcloud to PATH

### DIFF
--- a/assets/build/Dockerfile
+++ b/assets/build/Dockerfile
@@ -1,0 +1,108 @@
+# =============================================================
+# Unified Dockerfile for gabriel-navarro-bio
+#
+# Build a target with:
+#   docker build --target dev  -t app:dev  -f assets/build/Dockerfile .
+#   docker build --target prod -t app:prod -f assets/build/Dockerfile .
+#
+# Packages are installed via `pip install --prefix=/install` in a
+# builder stage and then COPY'd into /usr/local in the runtime
+# stages. This puts them in Python's default search path
+# (/usr/local/lib/python3.13/site-packages), so no venv or PATH
+# manipulation is needed for site-packages.
+#
+# Source of truth for dependencies: pyproject.toml (no requirements
+# files; legacy requirements.{prod,dev}.txt were removed in Epic D's
+# pyproject migration).
+# =============================================================
+
+
+# -------------------------------------------------------------
+# STAGE 1: prod-builder — compile production deps into /install
+# -------------------------------------------------------------
+FROM python:3.13-alpine AS prod-builder
+
+WORKDIR /app
+
+RUN apk add --no-cache --virtual .build-deps \
+        gcc \
+        musl-dev \
+        python3-dev
+
+# Copy only the metadata needed to resolve runtime deps. The src/
+# tree is copied so the editable install can find the package layout.
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir --prefix=/install . && \
+    find /install -type d -name __pycache__ -exec rm -rf {} + && \
+    find /install -name "*.py[co]" -delete && \
+    apk del .build-deps
+
+
+# -------------------------------------------------------------
+# STAGE 2: dev-builder — layer dev deps on top of prod deps
+# -------------------------------------------------------------
+FROM prod-builder AS dev-builder
+
+RUN apk add --no-cache --virtual .build-deps \
+        gcc \
+        musl-dev \
+        python3-dev
+
+# Re-install with [dev] extras to pull in pytest, ruff, mypy, etc.
+RUN pip install --no-cache-dir --prefix=/install ".[dev]" && \
+    apk del .build-deps
+
+
+# -------------------------------------------------------------
+# STAGE 3: dev — development runtime with tooling
+# -------------------------------------------------------------
+FROM python:3.13-alpine AS dev
+
+WORKDIR /app
+
+# Developer tooling: shell, VCS, network, GitHub CLI, Node (for
+# Claude Code), and the Google Cloud SDK for local auth against
+# GCP services.
+RUN apk add --no-cache \
+        bash \
+        git \
+        curl \
+        wget \
+        github-cli \
+        nodejs \
+        npm && \
+    npm install -g @anthropic-ai/claude-code && \
+    curl -sSL https://sdk.cloud.google.com | bash
+
+# Put gcloud on PATH so `gcloud`, `gsutil`, `bq`, etc. work without
+# the full `/root/google-cloud-sdk/bin/...` prefix in any shell.
+ENV PATH="/root/google-cloud-sdk/bin:${PATH}"
+
+# Pull in prod + dev Python packages staged by dev-builder.
+COPY --from=dev-builder /install /usr/local
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+
+# -------------------------------------------------------------
+# STAGE 4: prod — minimal runtime image (default build target)
+# -------------------------------------------------------------
+FROM python:3.13-alpine AS prod
+
+WORKDIR /app
+
+COPY --from=prod-builder /install /usr/local
+COPY app.py /app/app.py
+COPY src /app/src
+COPY assets/ico/favicon.ico /app/assets/ico/favicon.ico
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 80
+
+CMD ["python", "/app/app.py"]


### PR DESCRIPTION
The unified multi-stage Dockerfile at \`assets/build/Dockerfile\` existed in the local working tree but was never committed to git. As it stood it was broken: the prod-builder/dev-builder stages \`COPY\`'d \`requirements.prod.txt\` and \`requirements.dev.txt\`, both of which were deleted in Epic D's pyproject.toml migration (PR #108).

## Three changes in one PR

### 1. Replace requirements-file installs with pyproject installs
\`prod-builder\` runs \`pip install . --prefix=/install\`; \`dev-builder\` layers \`.[dev]\` extras to pull in pytest/ruff/mypy. Source of truth is now \`pyproject.toml\` everywhere (Dockerfile.prod, Dockerfile.dev, and this unified Dockerfile).

### 2. Add gcloud to PATH in the dev stage
\`\`\`dockerfile
ENV PATH="/root/google-cloud-sdk/bin:\${PATH}"
\`\`\`
So \`gcloud\`, \`gsutil\`, \`bq\` are usable without the full path prefix in any shell inside the dev container.

### 3. Add \`github-cli\` to the dev stage
Adds \`gh\` to the dev container alongside gcloud — matches how the dev env is actually used.

## What's NOT in scope

- \`Dockerfile.dev\` (debian-slim, no gcloud) — different stack, different purpose
- \`Dockerfile.prod\` (no dev tooling, used by deploy.yml) — already correct after Epic D

## Verification

- 49 tests pass; ruff clean (Python code unaffected — Dockerfile-only change)
- Static checks confirm: no references to deleted requirements files; pyproject install path correct; gcloud PATH ENV present; all 4 stages present
- A real \`docker build\` should be run on your side after merge to confirm — Docker isn't available in this dev container

## Diff stats

- 1 file (newly tracked)
- +108 lines

## Companion change

I also symlinked gcloud → \`/usr/local/bin/gcloud\` in the *currently running* dev container so it's immediately on PATH without rebuilding the image. Future \`docker run\`s of \`app:dev\` will get gcloud on PATH via the new ENV line in this PR.