### PR TITLE
fix(layout): nav and footer links no longer stack vertically

### DIFF
--- a/src/components/layout/footer.py
+++ b/src/components/layout/footer.py
@@ -36,7 +36,12 @@ def Footer():
                     )
                     for link in settings.SOCIAL_LINKS
                 ],
-                cls="factory-footer-col factory-footer-row",
+                # NOTE: was `factory-footer-col factory-footer-row` — both classes
+                # set `display: flex` but col forces `flex-direction: column`,
+                # which won the cascade and stacked the social links vertically.
+                # Drop the col class so the row's default horizontal layout wins.
+                cls="factory-footer-row",
+                aria_label="Social links",
             ),
             cls="factory-footer-row",
         ),

--- a/src/components/layout/navigation.py
+++ b/src/components/layout/navigation.py
@@ -5,23 +5,25 @@ from src.config.settings import settings
 
 
 def navigation(logo: str = "GABRIEL"):
-    """Returns the Factory-style navigation bar."""
+    """Returns the Factory-style navigation bar.
+
+    Passes nav links as positional `A(...)` items per MonsterUI's documented
+    `NavBar(*c, brand=...)` API. The previous `Ul(Li(A(...)), cls="uk-navbar-nav")`
+    pattern was an old UIkit-3 idiom that FrankenUI 2 (MonsterUI's underlying
+    CSS framework) dropped: the `.uk-navbar-nav` class is a no-op there, so
+    Tailwind's preflight reset left the UL as `display: block`, stacking the
+    links into a 61px-wide vertical column at the right edge of the viewport.
+    """
     return NavBar(
-        DivRAligned(
-            Ul(
-                *[
-                    Li(A(link["label"], href=link["href"], cls="factory-nav-link"))
-                    for link in settings.NAV_LINKS
-                ],
-                cls="uk-navbar-nav uk-visible@m",
-            ),
-        ),
+        *[
+            A(link["label"], href=link["href"], cls="factory-nav-link")
+            for link in settings.NAV_LINKS
+        ],
         brand=DivLAligned(
             A(
                 logo,
                 href="/",
-                cls="uk-navbar-item uk-logo",
-                style="font-family: 'Geist', sans-serif; font-weight: 900; letter-spacing: -0.05em; color: #FFFFFF;",
+                cls="uk-navbar-item uk-logo factory-brand",
             ),
         ),
         sticky=True,

--- a/src/styles/_layout.py
+++ b/src/styles/_layout.py
@@ -8,12 +8,14 @@ LAYOUT_CSS = """
 /* Navigation */
 .factory-nav {
     background-color: transparent !important;
-    padding: 1.5rem 0;
+    padding: 1.5rem 2rem !important;
 }
 
-.factory-nav {
-    padding-right: 2rem !important;
-    padding-left: 2rem !important;
+.factory-brand {
+    font-family: 'Geist', sans-serif;
+    font-weight: 900;
+    letter-spacing: -0.05em;
+    color: var(--color-white) !important;
 }
 
 .factory-nav-link {

--- a/tests/test_footer.py
+++ b/tests/test_footer.py
@@ -27,3 +27,17 @@ def test_footer_contains_current_year_copyright():
     """Footer shows the current year in the copyright line."""
     html = to_xml(Footer())
     assert f"© {datetime.now().year}" in html
+
+
+def test_social_links_container_does_not_combine_col_and_row_classes():
+    """The social-links container must not carry both factory-footer-col and
+    factory-footer-row.
+
+    Both classes set `display: flex`, but col forces `flex-direction: column`
+    which won the cascade and stacked the social links into a vertical
+    column at the right edge of the footer. The row class alone (with its
+    default horizontal direction) is what we want.
+    """
+    html = to_xml(Footer())
+    assert 'cls="factory-footer-col factory-footer-row"' not in html
+    assert "factory-footer-col factory-footer-row" not in html

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,55 @@
+"""Regression tests for the navbar layout.
+
+The first cut of `navigation()` wrapped nav links in `Ul(Li(A(...)), cls="uk-navbar-nav")`,
+an old UIkit-3 pattern. FrankenUI 2 (MonsterUI's underlying CSS framework)
+dropped the `.uk-navbar-nav` class entirely, so the UL silently fell back to
+Tailwind's preflight `display: block` and the links stacked into a 61px-wide
+vertical column. These tests assert the canonical MonsterUI shape so the
+regression can't sneak back in.
+"""
+
+from fasthtml.common import to_xml
+
+from src.components.layout.navigation import navigation
+from src.config.settings import settings
+
+
+def test_nav_links_render_as_top_level_anchors_not_wrapped_in_ul():
+    """Every link from settings.NAV_LINKS appears as a top-level <a> in the navbar.
+
+    Concretely: the rendered HTML must NOT contain `class="uk-navbar-nav"`
+    (the dead class) and must contain one `<a class="factory-nav-link">` per
+    settings.NAV_LINKS entry.
+    """
+    html = to_xml(navigation())
+
+    assert "uk-navbar-nav" not in html, (
+        "uk-navbar-nav is a no-op in FrankenUI 2; nav links must be passed "
+        "as positional A(...) args to NavBar, not wrapped in Ul(Li(...))."
+    )
+
+    # One factory-nav-link <a> per configured nav link.
+    assert html.count('class="factory-nav-link"') == len(settings.NAV_LINKS)
+
+    # Every label and href makes it into the markup.
+    for link in settings.NAV_LINKS:
+        assert link["label"] in html
+        assert f'href="{link["href"]}"' in html
+
+
+def test_navbar_carries_aria_label_for_screen_readers():
+    """The <nav> wrapper must carry aria-label='Primary navigation' (a11y from C5)."""
+    html = to_xml(navigation())
+    assert 'aria-label="Primary navigation"' in html
+
+
+def test_brand_uses_factory_brand_class_no_inline_style():
+    """Brand styling lives in the .factory-brand CSS class, not as an inline style.
+
+    Inline styles in layout components were eliminated in Epic A; this test
+    locks in that posture for the navbar brand specifically.
+    """
+    html = to_xml(navigation())
+    assert "factory-brand" in html
+    # No leaked inline style on the brand link
+    assert "font-family: 'Geist'" not in html


### PR DESCRIPTION
## What the user reported

> "When using trackpad to go back to previous page, the page renders off sided ... only when I scroll down does the page re-center."

## What was actually happening (systematic-debugging)

The reported "off-center" was a misattribution of a real-but-different layout bug. Live inspection via headless Chromium against the production site revealed the navbar's UL with class \`uk-navbar-nav\` was rendering at **61×63px** — a narrow vertical column of stacked links — instead of a horizontal row. The vertically-stacked nav floating at the right edge of the viewport made the page look "skewed". Scrolling didn't actually fix anything: the broken navbar just scrolled out of view.

Two related root causes:

### Bug 1 — Navbar (the one the user noticed)

\`navigation.py\` used the UIkit-3 idiom:

\`\`\`python
NavBar(DivRAligned(Ul(Li(A(...)), cls="uk-navbar-nav uk-visible@m")))
\`\`\`

But MonsterUI's underlying CSS framework, **FrankenUI 2, dropped the \`.uk-navbar-nav\` class entirely** — verified by direct \`curl\` of \`franken-ui@2.0.0/dist/css/core.min.css\`: zero rules contain \`uk-navbar-nav\`. With no flex rule applied, Tailwind's preflight reset left the UL as \`display: block\`, and the LIs stacked.

Fix: pass nav links as positional \`A(...)\` args per MonsterUI's documented \`NavBar(*c, brand=...)\` API (matches the \`top_nav = NavBar(*map(A, [...]), brand=...)\` example in the docs).

### Bug 2 — Footer (related, surfaced while investigating)

The social-links container carried two contradictory classes:

\`\`\`python
cls="factory-footer-col factory-footer-row"
\`\`\`

Both set \`display: flex\`, but \`.factory-footer-col\` adds \`flex-direction: column\` and won the cascade — so LinkedIn / GitHub / Email also rendered as a vertical column at the right edge.

Fix: drop the col class. The row class alone gives the intended horizontal layout.

## What changed

| File | Change |
|---|---|
| [navigation.py](src/components/layout/navigation.py) | Use MonsterUI's \`NavBar(*A_items, brand=...)\` pattern; move brand inline-style to a new \`.factory-brand\` class |
| [_layout.py](src/styles/_layout.py) | Add \`.factory-brand\`; consolidate the doubled \`.factory-nav\` rule into one |
| [footer.py](src/components/layout/footer.py) | Drop \`factory-footer-col\` from the social-links container; add explanatory comment + \`aria-label="Social links"\` |
| [tests/test_navigation.py](tests/test_navigation.py) | New: 3 regression tests asserting no \`uk-navbar-nav\`, one \`<a class="factory-nav-link">\` per nav link, aria-label present, no inline brand style |
| [tests/test_footer.py](tests/test_footer.py) | New assertion: \`factory-footer-col factory-footer-row\` combo never re-appears |

## Verification

\`\`\`
$ pytest -q
.....................................................                    [100%]
============================== 53 passed in 0.61s ==============================

$ ruff check . && ruff format --check .
All checks passed!
74 files already formatted
\`\`\`

**Live verification** (booted local server, queried with playwright):
- Nav links: \`Projects\` x=1090, \`Blogs\` x=1163, \`CV\` x=1217 — all at y=26 (same row ✓)
- Footer social links: \`LinkedIn\` x=989, \`GitHub\` x=1090, \`Email\` x=1178 — all at y=2775 (same row ✓)
- Footer nav links: \`Projects\` x=1018, \`Blogs\` x=1119, \`CV\` x=1201 — all at y=2854 (same row ✓)
- \`document.querySelectorAll(".uk-navbar-nav").length === 0\` ✓
- \`document.querySelectorAll(".factory-footer-col.factory-footer-row").length === 0\` ✓

After merge, the auto-deploy pipeline will fire and Cloud Run will pick up revision \`gnbio-00022\` (or next sequence) within ~3 minutes.

## Diff stats

- 5 files (4 modified, 1 new test module)
- +95 / -17 lines