### PR TITLE
fix(layout): lock horizontal scrolling; reset scrollX on BFCache restore

### DIFF
--- a/src/components/layout/page.py
+++ b/src/components/layout/page.py
@@ -2,6 +2,7 @@ from fasthtml.common import *
 from monsterui.all import *
 from .footer import Footer
 from .navigation import navigation
+from src.services.javascript.bfcache_scroll import BFCACHE_SCROLL_RESET_JS
 from src.styles import FACTORY_CSS, THEME_CSS
 
 
@@ -64,6 +65,7 @@ def StandardPage(
             ),
         ),
         Style(THEME_CSS + FACTORY_CSS + extra_styles),
+        BFCACHE_SCROLL_RESET_JS,
         *scripts,
         navigation(),
         Container(

--- a/src/services/javascript/__init__.py
+++ b/src/services/javascript/__init__.py
@@ -1,5 +1,10 @@
+from .bfcache_scroll import BFCACHE_SCROLL_RESET_JS
 from .scroll_animations import SCROLL_JS
 from .masonry import MasonryJS
-from .marked import MarkedJS
 
-__all__ = ["SCROLL_JS", "MasonryJS", "MarkedJS"]
+# NOTE: `marked.py` does NOT export a `MarkedJS` symbol — the previous
+# `from .marked import MarkedJS` here raised ImportError on first access
+# but went undetected because nothing in src/ imported this package until
+# `BFCACHE_SCROLL_RESET_JS` joined it.
+
+__all__ = ["BFCACHE_SCROLL_RESET_JS", "SCROLL_JS", "MasonryJS"]

--- a/src/services/javascript/bfcache_scroll.py
+++ b/src/services/javascript/bfcache_scroll.py
@@ -1,0 +1,23 @@
+"""Reset horizontal scroll on BFCache restore.
+
+Edge's BFCache (and Safari's) restores scroll position on
+back-navigation. If the page was *briefly* horizontally scrolled at any
+point — for instance during the trackpad swipe-back gesture itself — the
+browser may restore the page with `scrollX > 0`, leaving the entire layout
+shifted right and the navbar nav-links cut off the right edge.
+
+`html { overflow-x: clip }` in `_base.py` already prevents NEW horizontal
+scroll. This handler clears any scrollX value the browser tries to restore
+on `pageshow` events with `event.persisted === true` (BFCache restore), as
+a defense-in-depth belt-and-braces.
+"""
+
+from fasthtml.common import Script
+
+BFCACHE_SCROLL_RESET_JS = Script("""
+window.addEventListener('pageshow', function (event) {
+    if (event.persisted && window.scrollX !== 0) {
+        window.scrollTo(0, window.scrollY);
+    }
+});
+""")

--- a/src/styles/_base.py
+++ b/src/styles/_base.py
@@ -122,6 +122,7 @@ html, body {
     border: 0 solid;
     margin: 0;
     padding: 0;
+    width: 100%;
     border-color: var(--color-base-800);
     outline-color: var(--color-base-800);
     background-color: #000000 !important;
@@ -132,6 +133,24 @@ html, body {
     text-rendering: optimizeLegibility;
     --font-geist-sans: "Geist","Geist Fallback";
     --font-geist-mono: "Geist Mono","Geist Mono Fallback";
+}
+
+/* Lock the page to vertical-only scrolling. Without this, any element that
+ * for any reason renders even one pixel wider than the viewport (timing of
+ * scrollbar appearance, sticky-navbar measurement, BFCache restore in Edge,
+ * a stray 100vw that leaks in) makes the page horizontally scrollable, and
+ * Edge's BFCache will sometimes restore a non-zero scrollX after a
+ * trackpad-back gesture — leaving the whole layout shifted horizontally
+ * with the navbar links cut off the right edge until a hard refresh.
+ *
+ * `overflow-x: clip` is the modern equivalent of `hidden` that does NOT
+ * create a new containing block for `position: fixed/sticky` descendants —
+ * important so the sticky navbar keeps sticking. Fall back to `hidden` for
+ * the small slice of browsers without `clip` support.
+ */
+html {
+    overflow-x: hidden;
+    overflow-x: clip;
 }
 
 /* Keyboard focus rings (visible only on keyboard nav, not on click) */

--- a/tests/test_horizontal_overflow_lock.py
+++ b/tests/test_horizontal_overflow_lock.py
@@ -1,0 +1,57 @@
+"""Regression tests for horizontal-overflow lock.
+
+User-reported symptom on Edge desktop: after a trackpad swipe-back gesture,
+the page renders shifted horizontally — cards extend past the viewport's
+right edge and the navbar links are cut off. The bug couldn't be
+reproduced in headless Chromium; the working hypothesis is Edge's BFCache
+restoring a non-zero scrollX on back-navigation when ANY element renders
+even one pixel wider than the viewport.
+
+The defensive fix locks horizontal scrolling at the html level
+(`overflow-x: clip` with `hidden` fallback) and resets `scrollX` to 0 in
+the `pageshow` handler when the page is restored from BFCache. These tests
+lock both pieces in place so they can't drift back out.
+"""
+
+from fasthtml.common import to_xml
+
+from src.components.layout.page import StandardPage
+from src.services.javascript.bfcache_scroll import BFCACHE_SCROLL_RESET_JS
+from src.styles import FACTORY_CSS
+
+
+def test_factory_css_locks_horizontal_overflow_on_html():
+    """html element gets `overflow-x: hidden` (with `clip` upgrade) so any
+    accidental pixel of overflow can never become a scrollable area."""
+    assert "overflow-x: hidden" in FACTORY_CSS
+    assert "overflow-x: clip" in FACTORY_CSS
+
+
+def test_html_and_body_have_explicit_full_width():
+    """Belt-and-braces: html/body explicitly width:100% so they never
+    expand beyond the viewport (e.g., to fit a too-wide child)."""
+    # Find the `html, body { ... }` block and confirm `width: 100%` is in it.
+    block_start = FACTORY_CSS.find("html, body {")
+    assert block_start != -1, "html, body rule block missing"
+    block_end = FACTORY_CSS.find("}", block_start)
+    block = FACTORY_CSS[block_start:block_end]
+    assert "width: 100%" in block
+
+
+def test_bfcache_scroll_reset_script_exists_and_handles_persisted_pageshow():
+    """The pageshow handler resets scrollX when persisted (BFCache restore)."""
+    html = to_xml(BFCACHE_SCROLL_RESET_JS)
+    # Listens for pageshow and checks event.persisted
+    assert "pageshow" in html
+    assert "persisted" in html
+    # Resets scrollX to 0 (preserving scrollY)
+    assert "scrollTo(0," in html
+
+
+def test_standard_page_includes_bfcache_script():
+    """StandardPage emits the BFCACHE_SCROLL_RESET_JS so every rendered
+    page gets the safety net, not just the ones that opt in."""
+    html = to_xml(StandardPage("Test", "body content"))
+    # The hallmark of the script is the persisted-pageshow guard.
+    assert "event.persisted" in html
+    assert "scrollTo(0," in html


### PR DESCRIPTION
## Re-investigation of the off-center bug

PR #118 fixed a real but **different** bug (vertical-stacked nav links). Looking at your three new screenshots more carefully:

| Image | What I see |
|---|---|
| 1 (after trackpad-back) | Cards extend off the right edge; navbar links cut off (\"PROJECTS BLOG…\" truncated) |
| 2 (after scrolling) | Same horizontal shift persists |
| 3 (\"good\" state) | Cards centered, full nav visible |

The cards aren't being shifted *left* — they're being shifted *right*, with the navbar cut off the right edge. That's the symptom of a **non-zero `scrollX`** being applied to the page after BFCache restoration.

## Why I couldn't reproduce in headless Chromium

I drove the live site through the back-navigation flow with playwright:

\`\`\`
horizontalOverflow: 0
canActuallyScrollHorizontally: false
\`\`\`

…on every page, before/after \`page.goBack()\`. The bug needs **Edge's specific BFCache implementation + a real trackpad swipe** that briefly accepts horizontal pan during the back animation. Headless Chromium's \`goBack()\` does a clean re-fetch without the swipe component.

## Defensive fix (3 layers, no-regret)

The site is designed for vertical-only scrolling. Locking horizontal scroll at the root makes this entire class of bug impossible.

### Layer 1 — \`html { overflow-x: clip }\` in `_base.py`

\`\`\`css
html {
    overflow-x: hidden;       /* fallback for older browsers */
    overflow-x: clip;         /* modern; doesn't create a new containing block */
}
\`\`\`

\`clip\` is preferred because, unlike \`hidden\`, it does **not** create a new containing block for \`position: fixed\`/\`sticky\` descendants — the sticky navbar keeps sticking. \`hidden\` is the fallback line for the small slice of browsers without \`clip\` support (cascade order matters).

### Layer 2 — \`width: 100%\` on html, body

So neither expands to fit a too-wide child element. Belt-and-braces; layer 1 already handles the symptom but layer 2 prevents the overflow from ever happening.

### Layer 3 — \`BFCACHE_SCROLL_RESET_JS\` in `StandardPage`

\`\`\`js
window.addEventListener('pageshow', function (event) {
    if (event.persisted && window.scrollX !== 0) {
        window.scrollTo(0, window.scrollY);
    }
});
\`\`\`

If Edge restores a stale non-zero \`scrollX\` from an old BFCache snapshot (e.g., from a session before this fix landed), this snaps it back to 0 on the next pageshow.

## Verification

Local chromium against \`python app.py\`:
- \`getComputedStyle(html).overflowX === \"clip\"\` ✓
- \`window.scrollBy(200, 0)\` → scrollX stays at 0 ✓
- pageshow handler present in DOM listening for \`event.persisted\` ✓
- 53 tests pass (49 + 4 new regression tests in [test_horizontal_overflow_lock.py](tests/test_horizontal_overflow_lock.py))
- ruff clean

## Bonus fix (latent)

\`src/services/javascript/__init__.py\` had a broken \`from .marked import MarkedJS\` import (\`marked.py\` exports no such symbol). Went undetected because nothing in src/ imported the package until \`bfcache_scroll\` joined it. Removed the broken line + documented why.

## What I need from you to confirm the fix actually solves your symptom

Since I can't reproduce in headless Chromium, please verify on Edge after merge + auto-deploy completes (~3 min):

1. Load https://gabriel.navarro.bio/blogs in Edge
2. Navigate elsewhere (e.g., /cv)
3. Trackpad-swipe back to /blogs
4. **Expected**: page renders centered, navbar links fully visible, no horizontal shift

If it's STILL broken, open dev tools (F12) on the broken page and screenshot:
- Console tab (any errors?)
- \`document.documentElement.scrollLeft\` value
- \`window.innerWidth\` and \`document.documentElement.scrollWidth\`

That'll let me pin down whatever Edge is doing differently.

## Diff stats

- 5 files (2 new, 3 modified)
- +108 / -2 lines