### PR TITLE
feat: blog HTML pipeline — render at submit time, store HTML in BigQuery

### DIFF
--- a/assets/blogs/0020-fm-purturb.md
+++ b/assets/blogs/0020-fm-purturb.md
@@ -1,0 +1,1059 @@
+@{id = "de0ddce7-b63b-4c12-a554-bdbafd5eedb5"
+  title = "Foundation Models Improve Perturbation Response Prediction"
+  date = "2026-01-20T00:00:00Z"
+  tags = ['journal club', 'machine learning', 'arxiv', 'language models']
+  views = 0
+  likes = 0
+  image = "https://storage.googleapis.com/gn-portfolio/images/cover_art_0020.svg"
+  description = ""This entry is a summary of the paper "Foundation Models Improve Perturbation Response Prediction" where Cole et al. tackles a central question in computational biology: can foundation models — large pretrained neural networks — actually help predict how cells respond to genetic or chemical perturbations? ""
+  type = "note"
+  disabled = "False"
+}
+
+<p align="center">
+  <img src="https://storage.googleapis.com/gn-portfolio/images/cover_art_0020.svg" max-width="700">
+</p>
+
+
+# Foundation Models Improve Perturbation Response Prediction
+
+*Analysis of Cole et al. (2026), GenBio AI — bioRxiv preprint*
+*Generated on March 20, 2026*
+
+---
+
+## Table of Contents
+
+- [Abstract](#abstract)
+- [Introduction](#introduction)
+- [Results](#results)
+  - [Embeddings Vary Dramatically in Utility](#embeddings-vary-dramatically-in-utility)
+  - [Fine-Tuning Improves Performance for Some Models](#fine-tuning-improves-performance-for-some-models)
+  - [Complex Translation Methods Don't Beat Simple Ones](#complex-translation-methods-dont-beat-simple-ones)
+  - [FMs Can Also Improve Small Molecule Predictions](#fms-can-also-improve-small-molecule-predictions)
+  - [Integrating Diverse FMs Further Improves Performance](#integrating-diverse-fms-further-improves-performance)
+- [Methods](#methods)
+  - [Log Fold-Change Regression Formulation](#log-fold-change-regression-formulation)
+  - [Differentially Expressed Gene (DEG) Classification](#differentially-expressed-gene-deg-classification)
+  - [Datasets](#datasets)
+  - [Embedding Sources](#embedding-sources)
+  - [Fusion Architecture](#fusion-architecture)
+- [Discussion](#discussion)
+- [Key Takeaways](#key-takeaways-summary)
+
+---
+
+## Abstract
+
+### Overview
+
+This paper tackles a central question in computational biology: can foundation models (FMs) — large pretrained neural networks — actually help predict how cells respond to genetic or chemical perturbations? Recent literature has given contradictory answers, with some groups claiming FMs are no better than simple baselines like PCA. The authors resolve this by running an exhaustive benchmark of over 600 models.
+
+The key finding is nuanced: **some** FMs do fail to beat baselines, but **others** — particularly those trained on protein-protein interaction networks (interactome data) — significantly outperform simple methods. Furthermore, combining embeddings from multiple FMs through an attention-based fusion model pushes performance even further, in some cases reaching the theoretical limit set by experimental noise.
+
+This matters because accurate perturbation prediction is foundational for drug discovery, understanding disease mechanisms, and building "virtual cell" models that simulate biology in silico.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 420" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="fm-1-title">
+  <title id="fm-1-title">The central question: can foundation models predict cellular response to perturbations?</title>
+  <defs>
+    <marker id="arrow1" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#64748b"/></marker>
+    <marker id="arrow1g" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#22c55e"/></marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="16" font-weight="700" fill="#1e293b">The Central Question</text>
+  <!-- Perturbation box -->
+  <rect x="40" y="50" width="180" height="70" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="130" y="78" text-anchor="middle" font-weight="600" fill="#1e40af">Perturbation</text>
+  <text x="130" y="96" text-anchor="middle" font-size="11" fill="#64748b">(gene KO or drug)</text>
+  <!-- Arrow with ? -->
+  <line x1="220" y1="85" x2="370" y2="85" stroke="#64748b" stroke-width="1.5" stroke-dasharray="6,4" marker-end="url(#arrow1)"/>
+  <text x="295" y="78" text-anchor="middle" font-size="20" font-weight="700" fill="#ef4444">?</text>
+  <!-- Response box -->
+  <rect x="380" y="50" width="200" height="70" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="480" y="78" text-anchor="middle" font-weight="600" fill="#92400e">Cellular Response</text>
+  <text x="480" y="96" text-anchor="middle" font-size="11" fill="#64748b">(gene expression)</text>
+  <!-- Down arrow -->
+  <line x1="130" y1="120" x2="130" y2="170" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow1)"/>
+  <text x="230" y="152" font-size="11" fill="#64748b">Represented as...</text>
+  <!-- Embedding box -->
+  <rect x="55" y="178" width="150" height="55" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="130" y="200" text-anchor="middle" font-weight="600" fill="#166534">Embedding</text>
+  <text x="130" y="218" text-anchor="middle" font-size="11" fill="#64748b">from FM</text>
+  <!-- Branch lines -->
+  <line x1="130" y1="233" x2="130" y2="270" stroke="#22c55e" stroke-width="1.5"/>
+  <line x1="130" y1="270" x2="90" y2="270" stroke="#22c55e" stroke-width="1.5"/>
+  <line x1="130" y1="270" x2="630" y2="270" stroke="#22c55e" stroke-width="1.5"/>
+  <!-- DNA -->
+  <line x1="90" y1="270" x2="90" y2="300" stroke="#22c55e" stroke-width="1.5" marker-end="url(#arrow1g)"/>
+  <rect x="30" y="308" width="120" height="80" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="90" y="332" text-anchor="middle" font-weight="600" fill="#991b1b">DNA FMs</text>
+  <text x="90" y="352" text-anchor="middle" font-size="12" fill="#dc2626">weak</text>
+  <text x="90" y="372" text-anchor="middle" font-size="16">✗</text>
+  <!-- Protein -->
+  <line x1="270" y1="270" x2="270" y2="300" stroke="#22c55e" stroke-width="1.5" marker-end="url(#arrow1g)"/>
+  <rect x="210" y="308" width="120" height="80" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="270" y="332" text-anchor="middle" font-weight="600" fill="#991b1b">Protein FMs</text>
+  <text x="270" y="352" text-anchor="middle" font-size="12" fill="#dc2626">weak</text>
+  <text x="270" y="372" text-anchor="middle" font-size="16">✗</text>
+  <!-- Expression -->
+  <line x1="450" y1="270" x2="450" y2="300" stroke="#22c55e" stroke-width="1.5" marker-end="url(#arrow1g)"/>
+  <rect x="390" y="308" width="120" height="80" rx="8" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text x="450" y="332" text-anchor="middle" font-weight="600" fill="#854d0e">scRNA FMs</text>
+  <text x="450" y="352" text-anchor="middle" font-size="12" fill="#ca8a04">medium</text>
+  <text x="450" y="372" text-anchor="middle" font-size="16">◐</text>
+  <!-- Interactome -->
+  <line x1="630" y1="270" x2="630" y2="300" stroke="#22c55e" stroke-width="1.5" marker-end="url(#arrow1g)"/>
+  <rect x="560" y="308" width="140" height="80" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="630" y="332" text-anchor="middle" font-weight="700" fill="#166534">Interactome FMs</text>
+  <text x="630" y="352" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">STRONG</text>
+  <text x="630" y="372" text-anchor="middle" font-size="16">✓</text>
+  <!-- Side label -->
+  <text x="480" y="148" font-size="11" fill="#475569" font-style="italic">Which FM embeddings actually</text>
+  <text x="480" y="164" font-size="11" fill="#475569" font-style="italic">help predict the response?</text>
+</svg>
+
+### Key Takeaways
+
+- **Not all FMs are equal**: Prior knowledge / interactome-based FMs dramatically outperform sequence-based and expression-based FMs for perturbation prediction.
+- **Over 600 models tested**: The most comprehensive benchmark of FM embeddings for perturbation response to date.
+- **Fusion helps**: Combining multiple FM embeddings with attention-based fusion reaches experimental error limits in some cell lines.
+- **Simple predictors suffice**: Even kNN regression works well when paired with the right embedding — the embedding choice matters more than model complexity.
+
+---
+
+## Introduction
+
+### Overview
+
+Predicting how cells respond to perturbations — whether you knock out a gene, overexpress it, or treat the cell with a drug — is one of the holy grails of molecular biology. If we could accurately simulate these responses computationally, it would transform drug discovery by letting researchers screen interventions *in silico* before running expensive wet-lab experiments.
+
+The field has evolved from differential equation-based models of gene regulatory networks, through classical ML approaches (ElasticNet, matrix factorization), to deep learning methods (Dr.VAE, scGen, CPA, GEARS). Most recently, transformer-based foundation models pretrained on massive single-cell atlases — Geneformer, scGPT, scFoundation — have entered the scene, claiming strong results. But a counter-narrative has emerged: papers like PerturbBench and Ahlmann-Eltze et al. argue that FMs don't outperform simple linear baselines.
+
+This paper resolves the contradiction by showing that **the answer depends on which FM you use**. The authors take an "embedding-centric" view: rather than comparing complex end-to-end architectures, they extract embeddings from various FMs and feed them into simple predictors (kNN). This isolates the quality of the embedding itself — the core biological knowledge captured by the FM.
+
+### Concept Diagram
+
+<svg viewBox="0 0 700 340" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="fm-2-title">
+  <title id="fm-2-title">Evolution of Perturbation Prediction Methods</title>
+  <defs>
+    <marker id="arrow2" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#64748b"/></marker>
+    <marker id="arrow2b" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#3b82f6"/></marker>
+  </defs>
+  <text x="350" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Evolution of Perturbation Prediction Methods</text>
+  <!-- Row 1: Three eras -->
+  <rect x="20" y="50" width="170" height="65" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="105" y="74" text-anchor="middle" font-weight="600" fill="#334155">Differential Eqns</text>
+  <text x="105" y="92" text-anchor="middle" font-size="11" fill="#64748b">(GRNs)</text>
+  <line x1="190" y1="82" x2="240" y2="82" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <rect x="250" y="50" width="170" height="65" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="335" y="74" text-anchor="middle" font-weight="600" fill="#334155">Classical ML</text>
+  <text x="335" y="92" text-anchor="middle" font-size="11" fill="#64748b">(ElasticNet, MatFact)</text>
+  <line x1="420" y1="82" x2="470" y2="82" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <rect x="480" y="50" width="190" height="65" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="575" y="74" text-anchor="middle" font-weight="600" fill="#334155">Deep Learning</text>
+  <text x="575" y="92" text-anchor="middle" font-size="11" fill="#64748b">(scGen, CPA, GEARS)</text>
+  <!-- Arrow down -->
+  <line x1="575" y1="115" x2="575" y2="155" stroke="#3b82f6" stroke-width="2" marker-end="url(#arrow2b)"/>
+  <!-- Foundation Models box -->
+  <rect x="460" y="162" width="230" height="60" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <text x="575" y="187" text-anchor="middle" font-weight="700" font-size="14" fill="#1e40af">Foundation Models</text>
+  <text x="575" y="205" text-anchor="middle" font-size="11" fill="#3b82f6">(This work)</text>
+  <!-- Branch down -->
+  <line x1="575" y1="222" x2="575" y2="255" stroke="#3b82f6" stroke-width="2"/>
+  <line x1="350" y1="255" x2="680" y2="255" stroke="#3b82f6" stroke-width="1.5"/>
+  <!-- Three outcomes -->
+  <line x1="350" y1="255" x2="350" y2="275" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#arrow2b)"/>
+  <rect x="280" y="282" width="140" height="45" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="350" y="304" text-anchor="middle" font-size="12" fill="#991b1b">Some FMs fail</text>
+  <text x="350" y="318" text-anchor="middle" font-size="10" fill="#b91c1c">✗ No gain over baselines</text>
+  <line x1="520" y1="255" x2="520" y2="275" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#arrow2b)"/>
+  <rect x="440" y="282" width="160" height="45" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="520" y="304" text-anchor="middle" font-size="12" fill="#166534">Some FMs excel</text>
+  <text x="520" y="318" text-anchor="middle" font-size="10" fill="#16a34a">✓ Interactome-based</text>
+  <line x1="680" y1="255" x2="680" y2="275" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#arrow2b)"/>
+  <rect x="605" y="282" width="150" height="45" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="680" y="304" text-anchor="middle" font-size="12" fill="#6b21a8">Fusion is best</text>
+  <text x="680" y="318" text-anchor="middle" font-size="10" fill="#7c3aed">★ Multi-modal</text>
+</svg>
+
+### Key Takeaways
+
+- **Perturbation prediction** connects to both basic biology (understanding networks) and applied biology (drug discovery, side effect detection).
+- **Contradictory claims** in the literature motivated this comprehensive study.
+- **Embedding-centric approach** decouples the FM representation from the prediction model, enabling fair comparison.
+
+---
+
+## Results
+
+### Embeddings Vary Dramatically in Utility
+
+#### Overview
+
+The most striking finding is that embedding quality varies enormously across FM types, and this variation is primarily explained by the **modality** of the training data. The authors benchmarked embeddings on the Essential dataset (4 cell lines, ~2000 perturbations each) — much larger than the commonly used Norman dataset, which had masked real performance differences.
+
+Interactome-based embeddings (WaveGC, STRING GNN, GenotypeVAE, GenePT) consistently rank at the top. These capture how genes interact with each other in cellular networks. Expression-based FMs (scGPT, AIDO.Cell) are middling, while protein sequence and DNA sequence FMs generally perform worst. The intuition is that knowing what a gene's protein *looks like* matters less than knowing what it *does* and *who it talks to* in the cell.
+
+Remarkably, on the K562 cell line, the best single embedding closes 77% of the gap between a naive baseline and the estimated experimental error limit — using nothing more than kNN regression. This tells us the embedding is doing the heavy lifting, not the prediction algorithm.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 680 460" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="fm-3-title">
+  <title id="fm-3-title">Embedding Performance Ranking (Best to Worst)</title>
+  <text x="340" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Embedding Performance Ranking (Best → Worst)</text>
+  <text x="340" y="42" text-anchor="middle" font-size="11" fill="#64748b">Key insight: Modality matters more than model architecture</text>
+  <!-- Category 1: Prior Knowledge -->
+  <rect x="30" y="60" width="620" height="115" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="50" y="82" font-weight="700" fill="#166534" font-size="14">★ PRIOR KNOWLEDGE (Interactome)</text>
+  <circle cx="60" cy="100" r="5" fill="#22c55e"/><text x="75" y="105" fill="#334155">STRING WaveGC</text>
+  <rect x="230" y="93" width="160" height="16" rx="3" fill="#22c55e" opacity="0.8"/><text x="400" y="105" font-size="11" fill="#16a34a" font-weight="600">← Best overall</text>
+  <circle cx="60" cy="120" r="5" fill="#22c55e"/><text x="75" y="125" fill="#334155">STRING GNN</text>
+  <rect x="230" y="113" width="148" height="16" rx="3" fill="#22c55e" opacity="0.65"/>
+  <circle cx="60" cy="140" r="5" fill="#22c55e"/><text x="75" y="145" fill="#334155">GenotypeVAE</text>
+  <rect x="230" y="133" width="140" height="16" rx="3" fill="#22c55e" opacity="0.55"/>
+  <circle cx="60" cy="160" r="5" fill="#22c55e"/><text x="75" y="165" fill="#334155">GenePT variants</text>
+  <rect x="230" y="153" width="132" height="16" rx="3" fill="#22c55e" opacity="0.45"/>
+  <!-- Category 2: Expression -->
+  <rect x="30" y="190" width="620" height="95" rx="10" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text x="50" y="212" font-weight="700" fill="#854d0e" font-size="14">● EXPRESSION (scRNA-seq FMs)</text>
+  <circle cx="60" cy="232" r="5" fill="#eab308"/><text x="75" y="237" fill="#334155">scGPT</text>
+  <rect x="230" y="225" width="100" height="16" rx="3" fill="#eab308" opacity="0.6"/>
+  <circle cx="60" cy="252" r="5" fill="#eab308"/><text x="75" y="257" fill="#334155">AIDO.Cell 100M</text>
+  <rect x="230" y="245" width="94" height="16" rx="3" fill="#eab308" opacity="0.5"/>
+  <text x="400" y="257" font-size="11" fill="#ca8a04" font-style="italic">Bigger = better</text>
+  <circle cx="60" cy="272" r="5" fill="#eab308"/><text x="75" y="277" fill="#334155">scPRINT</text>
+  <rect x="230" y="265" width="88" height="16" rx="3" fill="#eab308" opacity="0.4"/>
+  <!-- Category 3: Protein -->
+  <rect x="30" y="300" width="620" height="75" rx="10" fill="#fff1f2" stroke="#f97316" stroke-width="1.5"/>
+  <text x="50" y="322" font-weight="700" fill="#9a3412" font-size="14">○ PROTEIN SEQUENCE</text>
+  <circle cx="60" cy="342" r="5" fill="#f97316"/><text x="75" y="347" fill="#334155">STRING Sequence / ESM2 / AIDO.ProteinRAG</text>
+  <rect x="330" y="335" width="64" height="16" rx="3" fill="#f97316" opacity="0.4"/>
+  <!-- Category 4: DNA -->
+  <rect x="30" y="390" width="620" height="55" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="50" y="412" font-weight="700" fill="#991b1b" font-size="14">△ DNA SEQUENCE</text>
+  <circle cx="60" cy="432" r="5" fill="#ef4444"/><text x="75" y="437" fill="#334155">AIDO.DNA</text>
+  <rect x="230" y="425" width="42" height="16" rx="3" fill="#ef4444" opacity="0.4"/>
+  <text x="282" y="437" font-size="11" fill="#dc2626" font-style="italic">← Weakest</text>
+</svg>
+
+#### Implementation
+
+```python
+import numpy as np
+from typing import Dict, List, Tuple
+
+def knn_perturbation_prediction(
+    train_embeddings: np.ndarray,   # (N_train, d) - embeddings of training perturbations
+    train_lfc: np.ndarray,          # (N_train, G) - observed LFC for training perturbations
+    test_embeddings: np.ndarray,    # (N_test, d)  - embeddings of test perturbations
+    k: int = 20
+) -> np.ndarray:
+    """
+    Predict perturbation response using kNN in embedding space.
+
+    The core idea: perturbations with similar embeddings should
+    produce similar cellular responses. The FM embedding encodes
+    biological similarity — kNN leverages that to predict LFC.
+
+    Args:
+        train_embeddings: FM embeddings for seen perturbations
+        train_lfc: Log fold-change vectors for seen perturbations
+        test_embeddings: FM embeddings for unseen perturbations
+        k: Number of neighbors
+
+    Returns:
+        Predicted LFC vectors for test perturbations (N_test, G)
+    """
+    predictions = []
+
+    for test_emb in test_embeddings:
+        # Step 1: Compute distances in embedding space
+        distances = np.linalg.norm(train_embeddings - test_emb, axis=1)
+
+        # Step 2: Find k nearest neighbors
+        nn_indices = np.argsort(distances)[:k]
+
+        # Step 3: Average their observed responses
+        predicted_lfc = train_lfc[nn_indices].mean(axis=0)
+        predictions.append(predicted_lfc)
+
+    return np.array(predictions)
+
+# Example: evaluate with L2 error
+def evaluate_l2(true_lfc: np.ndarray, pred_lfc: np.ndarray) -> float:
+    """Average L2 error across perturbations."""
+    return np.mean(np.linalg.norm(true_lfc - pred_lfc, axis=1))
+```
+
+#### Key Takeaways
+
+- **Interactome-based FMs dominate**: The top 10 embeddings in ranked performance are all derived from prior knowledge (interaction networks, functional annotations, or text descriptions of genes).
+- **Modality matters more than architecture**: Models trained on the same data type cluster together in performance, even when their architectures differ substantially.
+- **Bigger models help**: Within the expression FM category, AIDO.Cell 100M > 10M > 3M, suggesting scaling laws apply.
+- **Simple baselines can mislead**: On the small Norman dataset, differences are hard to detect; larger datasets like Essential reveal robust trends.
+
+---
+
+### Fine-Tuning Improves Performance for Some Models
+
+#### Overview
+
+Can you improve an FM's perturbation predictions by fine-tuning it on the actual perturbation data? The answer is: it depends. The authors tested two approaches for AIDO.Cell (3M) and one for STRING GNN.
+
+For AIDO.Cell, the "In-Silico KO" method — where the target gene's expression is masked and the model predicts the downstream effect — provided a significant boost, outperforming both the frozen kNN baseline and an MLP ablation. However, a simpler "Indexing" approach (extracting the gene's embedding and training a head on top) actually hurt performance. For STRING GNN, fine-tuning degraded results relative to using frozen embeddings.
+
+The takeaway is sobering: current perturbation datasets may be too small to reliably fine-tune large models. Overfitting is a real risk. Using frozen FM embeddings as features for simple predictors is often the safer bet.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 680 340" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="fm-4-title">
+  <title id="fm-4-title">Fine-Tuning Results on K562</title>
+  <text x="340" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Fine-Tuning Results on K562</text>
+  <!-- Axis labels -->
+  <text x="100" y="56" font-size="11" fill="#64748b" font-weight="600">Method</text>
+  <text x="630" y="56" font-size="11" fill="#64748b" font-weight="600" text-anchor="end">L2 Error (lower = better)</text>
+  <!-- Bars -->
+  <!-- STRING GNN Frozen -->
+  <text x="240" y="85" text-anchor="end" fill="#334155" font-size="12">STRING GNN Frozen + kNN</text>
+  <rect x="250" y="72" width="280" height="20" rx="4" fill="#3b82f6" opacity="0.7"/>
+  <text x="538" y="87" font-size="11" fill="#1e40af" font-weight="600">Good</text>
+  <!-- STRING GNN FT -->
+  <text x="240" y="115" text-anchor="end" fill="#334155" font-size="12">STRING GNN Fine-Tuned</text>
+  <rect x="250" y="102" width="320" height="20" rx="4" fill="#ef4444" opacity="0.6"/>
+  <text x="578" y="117" font-size="11" fill="#dc2626" font-weight="600">Worse ✗</text>
+  <!-- Spacer -->
+  <line x1="30" y1="135" x2="650" y2="135" stroke="#e2e8f0" stroke-width="1"/>
+  <!-- AIDO.Cell Frozen kNN -->
+  <text x="240" y="160" text-anchor="end" fill="#334155" font-size="12">AIDO.Cell 3M Frozen + kNN</text>
+  <rect x="250" y="147" width="300" height="20" rx="4" fill="#94a3b8" opacity="0.5"/>
+  <text x="558" y="162" font-size="11" fill="#64748b">Baseline</text>
+  <!-- AIDO.Cell Frozen MLP -->
+  <text x="240" y="190" text-anchor="end" fill="#334155" font-size="12">AIDO.Cell 3M Frozen + MLP</text>
+  <rect x="250" y="177" width="274" height="20" rx="4" fill="#3b82f6" opacity="0.55"/>
+  <text x="532" y="192" font-size="11" fill="#1e40af">Better</text>
+  <!-- AIDO.Cell FT Indexing -->
+  <text x="240" y="220" text-anchor="end" fill="#334155" font-size="12">AIDO.Cell 3M FT (Indexing)</text>
+  <rect x="250" y="207" width="330" height="20" rx="4" fill="#ef4444" opacity="0.5"/>
+  <text x="588" y="222" font-size="11" fill="#dc2626" font-weight="600">Worse ✗</text>
+  <!-- AIDO.Cell FT In-Silico KO -->
+  <text x="240" y="250" text-anchor="end" fill="#334155" font-size="12">AIDO.Cell 3M FT (In-Silico KO)</text>
+  <rect x="250" y="237" width="248" height="20" rx="4" fill="#22c55e" opacity="0.7"/>
+  <text x="506" y="252" font-size="11" fill="#166534" font-weight="700">Best ✓</text>
+  <!-- Experimental Error line -->
+  <line x1="470" y1="62" x2="470" y2="270" stroke="#a855f7" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <text x="475" y="280" font-size="10" fill="#7c3aed">Exptl. Error Limit</text>
+  <!-- Legend box -->
+  <rect x="30" y="298" width="620" height="32" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="50" y="318" font-size="11" fill="#475569" font-style="italic">Lesson: Fine-tuning can help OR hurt depending on method and architecture. Data scarcity makes overfitting a major risk.</text>
+</svg>
+
+#### Implementation
+
+```python
+import numpy as np
+from typing import Optional
+
+def in_silico_ko_prediction(
+    control_expression: np.ndarray,  # (G,) mean expression of control cells
+    target_gene_idx: int,            # index of knocked-out gene
+    encoder_fn,                      # FM encoder: (G,) → (G, d)
+    prediction_head_fn               # head: (d,) → (G,)
+) -> np.ndarray:
+    """
+    In-Silico Knockout: mask the target gene, encode with FM,
+    then predict LFC from the contextualized embedding.
+
+    This approach works because the FM learns to propagate
+    information through gene-gene relationships. When a gene
+    is masked, the FM's output captures what the network
+    'expects' should change.
+
+    Args:
+        control_expression: Average control cell profile
+        target_gene_idx: Which gene to knock out
+        encoder_fn: Foundation model encoder
+        prediction_head_fn: Learned prediction head
+
+    Returns:
+        Predicted log fold-change vector (G,)
+    """
+    # Step 1: Mask the target gene (simulate knockout)
+    masked_expression = control_expression.copy()
+    masked_expression[target_gene_idx] = 0.0
+
+    # Step 2: Run through FM encoder to get gene embeddings
+    gene_embeddings = encoder_fn(masked_expression)  # (G, d)
+
+    # Step 3: Extract embedding at target position
+    # The FM contextualizes this based on other genes
+    target_embedding = gene_embeddings[target_gene_idx]  # (d,)
+
+    # Step 4: Predict LFC from contextualized embedding
+    predicted_lfc = prediction_head_fn(target_embedding)  # (G,)
+
+    return predicted_lfc
+```
+
+#### Key Takeaways
+
+- **Fine-tuning is a double-edged sword**: In-Silico KO for AIDO.Cell helps; other approaches hurt.
+- **Overfitting is the main risk**: Perturbation datasets have ~2000 perturbations — tiny by deep learning standards.
+- **Frozen embeddings are robust**: For most practical purposes, using fixed FM embeddings with simple predictors is the safest choice.
+
+---
+
+### Complex Translation Methods Don't Beat Simple Ones
+
+#### Overview
+
+Given a perturbation embedding, how should you translate it into a predicted expression change? The literature proposes sophisticated generative approaches — Latent Diffusion, Flow Matching, Schrödinger Bridge — that model the full distribution of perturbed single cells. The authors benchmarked simple implementations of each against kNN.
+
+The result: **none of these advanced methods outperform kNN paired with the best embedding**. This is remarkable because the generative methods use the same embedding as input but are far more computationally expensive (~1000 GPU-hours each to train). Similarly, GEARS, a published GNN-based perturbation model, didn't beat the embedding+kNN approach.
+
+The implication is clear: for predicting average perturbation effects, the bottleneck is the embedding quality, not the prediction model complexity.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 700 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="fm-5-title">
+  <title id="fm-5-title">Same Embedding, Different Prediction Methods</title>
+  <defs>
+    <marker id="arrow5" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#64748b"/></marker>
+  </defs>
+  <text x="350" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Same Embedding, Different Prediction Methods</text>
+  <!-- Source embedding -->
+  <rect x="250" y="48" width="200" height="55" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <text x="350" y="72" text-anchor="middle" font-weight="700" fill="#1e40af">Perturbation Embedding</text>
+  <text x="350" y="90" text-anchor="middle" font-size="11" fill="#3b82f6">(e.g. WaveGC)</text>
+  <!-- Branch lines -->
+  <line x1="350" y1="103" x2="350" y2="130" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="90" y1="130" x2="610" y2="130" stroke="#64748b" stroke-width="1.5"/>
+  <!-- kNN -->
+  <line x1="90" y1="130" x2="90" y2="155" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow5)"/>
+  <rect x="30" y="163" width="120" height="45" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="90" y="188" text-anchor="middle" font-weight="700" fill="#166534">kNN</text>
+  <!-- Latent Diffusion -->
+  <line x1="260" y1="130" x2="260" y2="155" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow5)"/>
+  <rect x="190" y="163" width="140" height="45" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="260" y="188" text-anchor="middle" fill="#475569">Latent Diffusion</text>
+  <!-- Flow Matching -->
+  <line x1="430" y1="130" x2="430" y2="155" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow5)"/>
+  <rect x="360" y="163" width="140" height="45" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="430" y="188" text-anchor="middle" fill="#475569">Flow Matching</text>
+  <!-- Schrödinger Bridge -->
+  <line x1="590" y1="130" x2="590" y2="155" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow5)"/>
+  <rect x="510" y="163" width="160" height="45" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="590" y="188" text-anchor="middle" fill="#475569">Schrödinger Bridge</text>
+  <!-- Results arrows -->
+  <line x1="90" y1="208" x2="90" y2="245" stroke="#22c55e" stroke-width="2" marker-end="url(#arrow5)"/>
+  <line x1="260" y1="208" x2="260" y2="245" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow5)"/>
+  <line x1="430" y1="208" x2="430" y2="245" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow5)"/>
+  <line x1="590" y1="208" x2="590" y2="245" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow5)"/>
+  <!-- Result boxes -->
+  <rect x="40" y="252" width="100" height="50" rx="8" fill="#dcfce7" stroke="#22c55e" stroke-width="2"/>
+  <text x="90" y="273" text-anchor="middle" font-weight="700" fill="#166534">~4.2 L2</text>
+  <text x="90" y="292" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">BEST!</text>
+  <rect x="210" y="252" width="100" height="50" rx="8" fill="#fef2f2" stroke="#fca5a5" stroke-width="1.5"/>
+  <text x="260" y="273" text-anchor="middle" fill="#991b1b">~4.3 L2</text>
+  <text x="260" y="292" text-anchor="middle" font-size="11" fill="#dc2626">Worse</text>
+  <rect x="380" y="252" width="100" height="50" rx="8" fill="#fef2f2" stroke="#fca5a5" stroke-width="1.5"/>
+  <text x="430" y="273" text-anchor="middle" fill="#991b1b">~4.3 L2</text>
+  <text x="430" y="292" text-anchor="middle" font-size="11" fill="#dc2626">Worse</text>
+  <rect x="540" y="252" width="100" height="50" rx="8" fill="#fef2f2" stroke="#fca5a5" stroke-width="1.5"/>
+  <text x="590" y="273" text-anchor="middle" fill="#991b1b">~4.3 L2</text>
+  <text x="590" y="292" text-anchor="middle" font-size="11" fill="#dc2626">Worse</text>
+  <!-- GPU hours row -->
+  <text x="90" y="326" text-anchor="middle" font-size="11" fill="#22c55e" font-weight="600">~0 GPU-hrs</text>
+  <text x="260" y="326" text-anchor="middle" font-size="11" fill="#dc2626">~1000 GPU-hrs</text>
+  <text x="430" y="326" text-anchor="middle" font-size="11" fill="#dc2626">~1000 GPU-hrs</text>
+  <text x="590" y="326" text-anchor="middle" font-size="11" fill="#dc2626">~1000 GPU-hrs</text>
+  <!-- Bottom note -->
+  <rect x="80" y="345" width="540" height="26" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="350" y="363" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">The embedding quality is the bottleneck — not the prediction model complexity.</text>
+</svg>
+
+#### Key Takeaways
+
+- **kNN wins**: Simple kNN regression with the right embedding beats expensive generative models.
+- **Embedding quality is the bottleneck**: Improving the input representation matters more than improving the decoder.
+- **Computational cost matters**: Generative models are orders of magnitude more expensive with no accuracy gain for average effect prediction.
+
+---
+
+### FMs Can Also Improve Small Molecule Predictions
+
+#### Overview
+
+Chemical perturbations present a harder prediction problem than genetic ones. A small molecule may hit multiple targets, the chemical space is enormous (~10^60 possible molecules), and we have less network knowledge for drugs.
+
+The authors tested molecular fingerprints, SMILES-based FMs (ChemBERTa, Uni-Mol, MiniMol), target-based embeddings (embedding the drug's predicted protein target with a gene FM), and LLM-based text embeddings of drug descriptions.
+
+In the LFC regression formulation, no embedding clearly outperformed baselines — the signal was weak. But in the DEG (differentially expressed gene) classification formulation, target-based embeddings worked best: if you know (or can predict) what protein a drug binds, embedding that protein with an scRNA-seq FM gives you useful information. Traditional molecular structure fingerprints (ECPF:2) were also competitive. Interestingly, SMILES-based FMs generally underperformed, likely because they were trained for chemical — not biological — property prediction.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 700 420" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="fm-6-title">
+  <title id="fm-6-title">Small Molecule Embedding Strategies</title>
+  <defs>
+    <marker id="arrow6" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#64748b"/></marker>
+  </defs>
+  <text x="350" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Small Molecule Embedding Strategies</text>
+  <!-- Drug pill icon -->
+  <rect x="20" y="55" width="120" height="50" rx="25" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <text x="80" y="85" text-anchor="middle" font-weight="700" fill="#1e40af">Drug</text>
+  <!-- Branch lines -->
+  <line x1="140" y1="80" x2="195" y2="80" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="195" y1="80" x2="195" y2="370" stroke="#64748b" stroke-width="1"/>
+  <!-- Strategy 1: SMILES -->
+  <line x1="195" y1="80" x2="240" y2="80" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow6)"/>
+  <rect x="250" y="55" width="160" height="50" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="330" y="76" text-anchor="middle" font-weight="600" fill="#334155">SMILES String</text>
+  <text x="330" y="94" text-anchor="middle" font-size="10" fill="#64748b">CC(=O)Oc1ccccc1...</text>
+  <line x1="410" y1="80" x2="460" y2="80" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow6)"/>
+  <rect x="470" y="58" width="130" height="44" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="535" y="78" text-anchor="middle" font-size="12" fill="#475569">ChemBERTa</text>
+  <text x="535" y="94" text-anchor="middle" font-size="10" fill="#64748b">Uni-Mol, MiniMol</text>
+  <rect x="610" y="62" width="72" height="28" rx="6" fill="#fef2f2" stroke="#ef4444" stroke-width="1"/>
+  <text x="646" y="81" text-anchor="middle" font-size="11" font-weight="600" fill="#dc2626">weak</text>
+  <!-- Strategy 2: Fingerprint -->
+  <line x1="195" y1="160" x2="240" y2="160" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow6)"/>
+  <rect x="250" y="135" width="160" height="50" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="330" y="156" text-anchor="middle" font-weight="600" fill="#334155">Molecular Structure</text>
+  <text x="330" y="174" text-anchor="middle" font-size="10" fill="#64748b">Morgan Fingerprints</text>
+  <line x1="410" y1="160" x2="460" y2="160" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow6)"/>
+  <rect x="470" y="138" width="130" height="44" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="535" y="164" text-anchor="middle" font-size="12" fill="#475569">ECPF:2</text>
+  <rect x="610" y="142" width="72" height="28" rx="6" fill="#fefce8" stroke="#eab308" stroke-width="1"/>
+  <text x="646" y="161" text-anchor="middle" font-size="11" font-weight="600" fill="#ca8a04">decent</text>
+  <!-- Strategy 3: Target -->
+  <line x1="195" y1="250" x2="240" y2="250" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow6)"/>
+  <rect x="250" y="222" width="160" height="56" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="330" y="244" text-anchor="middle" font-weight="700" fill="#166534">Protein Target</text>
+  <text x="330" y="262" text-anchor="middle" font-size="10" fill="#16a34a">COX-1 / COX-2 etc.</text>
+  <line x1="410" y1="250" x2="460" y2="250" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow6)"/>
+  <rect x="470" y="228" width="130" height="44" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="535" y="248" text-anchor="middle" font-size="12" fill="#166534">scRNA FM</text>
+  <text x="535" y="264" text-anchor="middle" font-size="10" fill="#16a34a">(AIDO.Cell)</text>
+  <rect x="610" y="232" width="72" height="28" rx="6" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="646" y="251" text-anchor="middle" font-size="11" font-weight="700" fill="#16a34a">BEST</text>
+  <!-- Strategy 4: Text -->
+  <line x1="195" y1="340" x2="240" y2="340" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow6)"/>
+  <rect x="250" y="315" width="160" height="50" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="330" y="336" text-anchor="middle" font-weight="600" fill="#334155">Text Description</text>
+  <text x="330" y="354" text-anchor="middle" font-size="10" fill="#64748b">"NSAID, inhibits..."</text>
+  <line x1="410" y1="340" x2="460" y2="340" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow6)"/>
+  <rect x="470" y="318" width="130" height="44" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="535" y="344" text-anchor="middle" font-size="12" fill="#475569">LLM Embed</text>
+  <rect x="610" y="322" width="72" height="28" rx="6" fill="#fefce8" stroke="#eab308" stroke-width="1"/>
+  <text x="646" y="341" text-anchor="middle" font-size="11" font-weight="600" fill="#ca8a04">variable</text>
+</svg>
+
+#### Key Takeaways
+
+- **Chemical perturbation is harder** than genetic perturbation: weaker signals across all methods.
+- **Target-based embeddings work best**: Representing a drug by its protein target (embedded with a gene FM) outperforms direct molecular embeddings.
+- **SMILES FMs underperform**: Models trained on chemical properties don't capture biological function well.
+- **DEG formulation reveals signal** that LFC regression misses for chemical perturbations.
+
+---
+
+### Integrating Diverse FMs Further Improves Performance
+
+#### Overview
+
+Since different FM types capture different aspects of gene biology (sequence, structure, interactions, function), the authors hypothesized that combining them could be more powerful than any single embedding. They designed an attention-based fusion model that ingests embeddings from all sources and learns to weight them dynamically.
+
+The results are impressive: fusion consistently beats the best unimodal embedding (WaveGC) on all four cell lines in Essential. For K562 and Jurkat, the fusion model actually matches the estimated experimental error limit — meaning **the model is as accurate as the experiment itself**. For the other two cell lines, it bridges 86% (Hep-G2) and 53% (hTERT-RPE1) of the gap between random performance and the experimental error bound.
+
+However, fusion did not help for chemical perturbations, likely because individual drug embeddings were too weak to provide meaningful complementary information.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 700 520" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="fm-7-title">
+  <title id="fm-7-title">Attention-Based Embedding Fusion</title>
+  <defs>
+    <marker id="arrow7" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#64748b"/></marker>
+    <marker id="arrow7p" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#a855f7"/></marker>
+  </defs>
+  <text x="350" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Attention-Based Embedding Fusion</text>
+  <!-- Source embedding boxes -->
+  <rect x="30" y="48" width="120" height="50" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="90" y="70" text-anchor="middle" font-weight="600" fill="#166534" font-size="12">WaveGC</text>
+  <text x="90" y="86" text-anchor="middle" font-size="10" fill="#64748b">(d₁)</text>
+  <rect x="175" y="48" width="120" height="50" rx="8" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text x="235" y="70" text-anchor="middle" font-weight="600" fill="#854d0e" font-size="12">scGPT</text>
+  <text x="235" y="86" text-anchor="middle" font-size="10" fill="#64748b">(d₂)</text>
+  <rect x="320" y="48" width="120" height="50" rx="8" fill="#fff1f2" stroke="#f97316" stroke-width="1.5"/>
+  <text x="380" y="70" text-anchor="middle" font-weight="600" fill="#9a3412" font-size="12">ESM2</text>
+  <text x="380" y="86" text-anchor="middle" font-size="10" fill="#64748b">(d₃)</text>
+  <rect x="465" y="48" width="120" height="50" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="525" y="70" text-anchor="middle" font-weight="600" fill="#166534" font-size="12">GenePT</text>
+  <text x="525" y="86" text-anchor="middle" font-size="10" fill="#64748b">(d₄)</text>
+  <text x="620" y="76" text-anchor="middle" font-size="16" fill="#94a3b8">...</text>
+  <!-- Projection arrows -->
+  <line x1="90" y1="98" x2="90" y2="138" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow7)"/>
+  <line x1="235" y1="98" x2="235" y2="138" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow7)"/>
+  <line x1="380" y1="98" x2="380" y2="138" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow7)"/>
+  <line x1="525" y1="98" x2="525" y2="138" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow7)"/>
+  <!-- Projection boxes -->
+  <rect x="40" y="146" width="100" height="35" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="90" y="168" text-anchor="middle" font-size="11" fill="#475569">Project → d</text>
+  <rect x="185" y="146" width="100" height="35" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="235" y="168" text-anchor="middle" font-size="11" fill="#475569">Project → d</text>
+  <rect x="330" y="146" width="100" height="35" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="380" y="168" text-anchor="middle" font-size="11" fill="#475569">Project → d</text>
+  <rect x="475" y="146" width="100" height="35" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="525" y="168" text-anchor="middle" font-size="11" fill="#475569">Project → d</text>
+  <!-- Merge line -->
+  <line x1="90" y1="181" x2="90" y2="210" stroke="#64748b" stroke-width="1"/>
+  <line x1="235" y1="181" x2="235" y2="210" stroke="#64748b" stroke-width="1"/>
+  <line x1="380" y1="181" x2="380" y2="210" stroke="#64748b" stroke-width="1"/>
+  <line x1="525" y1="181" x2="525" y2="210" stroke="#64748b" stroke-width="1"/>
+  <line x1="90" y1="210" x2="525" y2="210" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="310" y1="210" x2="310" y2="232" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow7)"/>
+  <!-- Cell line token addition -->
+  <rect x="210" y="240" width="200" height="40" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="310" y="264" text-anchor="middle" font-weight="600" fill="#6b21a8">+ Cell Line Token</text>
+  <line x1="310" y1="280" x2="310" y2="310" stroke="#a855f7" stroke-width="2" marker-end="url(#arrow7p)"/>
+  <!-- Transformer -->
+  <rect x="170" y="318" width="280" height="55" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <text x="310" y="342" text-anchor="middle" font-weight="700" fill="#1e40af" font-size="14">Transformer Encoder</text>
+  <text x="310" y="362" text-anchor="middle" font-size="11" fill="#3b82f6">Self-attention across embedding sources</text>
+  <line x1="310" y1="373" x2="310" y2="403" stroke="#3b82f6" stroke-width="2" marker-end="url(#arrow7)"/>
+  <!-- CLS output -->
+  <rect x="210" y="410" width="200" height="40" rx="8" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text x="310" y="430" text-anchor="middle" font-size="12" fill="#854d0e">[CLS] → Prediction Head</text>
+  <line x1="310" y1="450" x2="310" y2="478" stroke="#eab308" stroke-width="2" marker-end="url(#arrow7)"/>
+  <!-- Output -->
+  <rect x="210" y="484" width="200" height="30" rx="8" fill="#dcfce7" stroke="#22c55e" stroke-width="2"/>
+  <text x="310" y="504" text-anchor="middle" font-weight="700" fill="#166534">Predicted LFC (G dims)</text>
+</svg>
+
+#### Implementation
+
+```python
+import numpy as np
+from typing import List, Dict, Optional
+
+class EmbeddingFusionModel:
+    """
+    Simplified attention-based fusion of multiple FM embeddings.
+    
+    Each perturbation is represented by J embeddings from different 
+    FMs. A transformer learns to attend across these sources and 
+    produce a unified prediction.
+    """
+    
+    def __init__(self, embedding_dims: List[int], common_dim: int = 100,
+                 n_heads: int = 5, n_genes: int = 1000):
+        """
+        Args:
+            embedding_dims: Dimension of each source embedding
+            common_dim: Shared projection dimension
+            n_heads: Attention heads in transformer
+            n_genes: Number of genes to predict
+        """
+        self.common_dim = common_dim
+        self.n_sources = len(embedding_dims)
+        
+        # Per-source projection matrices: map each to common_dim
+        self.projections = [
+            np.random.randn(d, common_dim) * 0.1
+            for d in embedding_dims
+        ]
+        
+        # Learnable cell line embeddings
+        self.cell_line_embeddings: Dict[str, np.ndarray] = {}
+        
+        # Prediction head weights (simplified)
+        self.pred_weights = np.random.randn(common_dim, n_genes) * 0.01
+    
+    def project_embeddings(
+        self, 
+        embeddings: List[Optional[np.ndarray]]
+    ) -> np.ndarray:
+        """
+        Project each source embedding to the common space.
+        Handles missing embeddings (not all sources cover all genes).
+        
+        Returns:
+            tokens: (n_valid + 1, common_dim) including CLS token
+        """
+        tokens = []
+        
+        # CLS token for aggregation
+        cls_token = np.zeros(self.common_dim)
+        tokens.append(cls_token)
+        
+        # Project each available embedding
+        for i, emb in enumerate(embeddings):
+            if emb is not None:
+                projected = emb @ self.projections[i]
+                tokens.append(projected)
+        
+        return np.array(tokens)  # (n_tokens, common_dim)
+    
+    def predict(
+        self, 
+        embeddings: List[Optional[np.ndarray]],
+        cell_line: str
+    ) -> np.ndarray:
+        """
+        Predict LFC by fusing all available embeddings.
+        
+        Returns:
+            predicted_lfc: (n_genes,) vector
+        """
+        # Step 1: Project to common space + add cell line embedding
+        tokens = self.project_embeddings(embeddings)
+        if cell_line in self.cell_line_embeddings:
+            tokens += self.cell_line_embeddings[cell_line]
+        
+        # Step 2: Self-attention (simplified as mean for illustration)
+        # In practice: multi-head self-attention transformer layers
+        cls_output = tokens.mean(axis=0)  # (common_dim,)
+        
+        # Step 3: Predict LFC from CLS output
+        predicted_lfc = cls_output @ self.pred_weights  # (n_genes,)
+        
+        return predicted_lfc
+```
+
+#### Key Takeaways
+
+- **Fusion always beats the best single embedding** for genetic perturbations on Essential.
+- **Two cell lines hit the experimental error ceiling**: K562 and Jurkat predictions are as good as replicate experiments.
+- **Attention-based integration** learns to weight different modalities dynamically, outperforming simple concatenation.
+- **Fusion doesn't help for drugs**: Individual chemical embeddings are too weak to provide complementary signal.
+
+---
+
+## Methods
+
+### Log Fold-Change Regression Formulation
+
+#### Overview
+
+The paper frames perturbation prediction as a regression problem: given a perturbation (gene knockout or drug treatment), predict the vector of per-gene expression changes. Specifically, they predict the "batch-aware average treatment effect" (BA-ATE), which they call log fold-change (LFC) for simplicity.
+
+The key idea is to compare the average expression of perturbed cells to the average expression of control cells, accounting for batch effects by weighting each batch equally. For datasets with large batches, per-batch control means are subtracted. For datasets with small batches (like Essential), a global control mean is used instead to avoid noisy per-batch estimates.
+
+The primary evaluation metric is the L2 error between predicted and observed LFC vectors, averaged across all test perturbations.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 700 340" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="fm-8-title">
+  <title id="fm-8-title">Computing Log Fold-Change (LFC)</title>
+  <defs>
+    <marker id="arrow8" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#64748b"/></marker>
+  </defs>
+  <text x="350" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Computing Log Fold-Change (LFC)</text>
+  <!-- Batch 1 -->
+  <rect x="30" y="52" width="260" height="90" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="160" y="74" text-anchor="middle" font-weight="700" fill="#1e40af">Batch 1</text>
+  <text x="105" y="98" text-anchor="middle" font-size="12" fill="#334155">Control cells: x̄₁</text>
+  <text x="105" y="118" text-anchor="middle" font-size="12" fill="#334155">Perturbed:     x̄'₁</text>
+  <!-- Batch 2 -->
+  <rect x="410" y="52" width="260" height="90" rx="10" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="540" y="74" text-anchor="middle" font-weight="700" fill="#6b21a8">Batch 2</text>
+  <text x="490" y="98" text-anchor="middle" font-size="12" fill="#334155">Control cells: x̄₂</text>
+  <text x="490" y="118" text-anchor="middle" font-size="12" fill="#334155">Perturbed:     x̄'₂</text>
+  <!-- Arrows down -->
+  <line x1="160" y1="142" x2="160" y2="178" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#arrow8)"/>
+  <line x1="540" y1="142" x2="540" y2="178" stroke="#a855f7" stroke-width="1.5" marker-end="url(#arrow8)"/>
+  <!-- Per-batch delta -->
+  <rect x="80" y="185" width="160" height="35" rx="8" fill="#dbeafe" stroke="#3b82f6" stroke-width="1"/>
+  <text x="160" y="207" text-anchor="middle" font-size="12" fill="#1e40af">δ₁ = x̄'₁ − x̄₁</text>
+  <rect x="460" y="185" width="160" height="35" rx="8" fill="#ede9fe" stroke="#a855f7" stroke-width="1"/>
+  <text x="540" y="207" text-anchor="middle" font-size="12" fill="#6b21a8">δ₂ = x̄'₂ − x̄₂</text>
+  <!-- Merge -->
+  <line x1="160" y1="220" x2="160" y2="245" stroke="#64748b" stroke-width="1"/>
+  <line x1="540" y1="220" x2="540" y2="245" stroke="#64748b" stroke-width="1"/>
+  <line x1="160" y1="245" x2="540" y2="245" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="350" y1="245" x2="350" y2="268" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow8)"/>
+  <!-- LFC result -->
+  <rect x="220" y="275" width="260" height="45" rx="10" fill="#dcfce7" stroke="#22c55e" stroke-width="2"/>
+  <text x="350" y="296" text-anchor="middle" font-weight="700" fill="#166534">LFC = mean(δ₁, δ₂)</text>
+  <text x="350" y="312" text-anchor="middle" font-size="11" fill="#16a34a">∆ₖ ∈ ℝᴳ  (one value per gene)</text>
+  <!-- Metric -->
+  <text x="350" y="340" text-anchor="middle" font-size="12" fill="#475569">Evaluation:  L2 = (1/K) Σₖ ‖∆ₖ − ∆̂ₖ‖₂</text>
+</svg>
+
+#### Implementation
+
+```python
+import numpy as np
+from typing import Dict, List
+
+def compute_batch_aware_ate(
+    expression_matrix: np.ndarray,       # (N, G) normalized expression
+    cell_labels: np.ndarray,             # (N,) perturbation ID or 'ctrl'
+    batch_labels: np.ndarray,            # (N,) batch assignment
+    perturbation_id: str,
+    use_global_control: bool = False     # True for small-batch datasets
+) -> np.ndarray:
+    """
+    Compute Batch-Aware Average Treatment Effect (BA-ATE).
+
+    For large batches: per-batch control subtraction
+    For small batches: global control subtraction (more stable)
+
+    Args:
+        expression_matrix: log1p-normalized scRNA-seq data
+        cell_labels: Which perturbation each cell received
+        batch_labels: Batch assignment for each cell
+        perturbation_id: Target perturbation to compute ATE for
+        use_global_control: Use global vs per-batch control mean
+
+    Returns:
+        lfc: (G,) vector of per-gene treatment effects
+    """
+    ctrl_mask = cell_labels == 'ctrl'
+    pert_mask = cell_labels == perturbation_id
+    G = expression_matrix.shape[1]
+
+    if use_global_control:
+        # Small-batch mode: compute global control mean
+        batches = np.unique(batch_labels)
+        global_ctrl = np.mean([
+            expression_matrix[ctrl_mask & (batch_labels == b)].mean(axis=0)
+            for b in batches
+            if np.any(ctrl_mask & (batch_labels == b))
+        ], axis=0)
+
+    # Find batches containing both control and perturbed cells
+    valid_batches = []
+    for b in np.unique(batch_labels):
+        has_ctrl = np.any(ctrl_mask & (batch_labels == b))
+        has_pert = np.any(pert_mask & (batch_labels == b))
+        if has_ctrl and has_pert:
+            valid_batches.append(b)
+
+    # Average treatment effect across batches
+    batch_effects = []
+    for b in valid_batches:
+        pert_mean = expression_matrix[pert_mask & (batch_labels == b)].mean(axis=0)
+        if use_global_control:
+            batch_effects.append(pert_mean - global_ctrl)
+        else:
+            ctrl_mean = expression_matrix[ctrl_mask & (batch_labels == b)].mean(axis=0)
+            batch_effects.append(pert_mean - ctrl_mean)
+
+    return np.mean(batch_effects, axis=0)  # (G,)
+```
+
+#### Key Takeaways
+
+- **BA-ATE** accounts for batch effects by averaging per-batch deltas, preventing confounding.
+- **Two variants** handle datasets with different batch sizes: per-batch control for large batches, global control for small ones.
+- **L2 error** is the primary metric, though the paper also considers MAE, MSE, and correlation metrics.
+
+---
+
+### Differentially Expressed Gene (DEG) Classification
+
+#### Overview
+
+An alternative to predicting exact expression changes is to classify each gene as upregulated (+1), downregulated (−1), or unchanged (0). This is the DEG formulation. For large-batch datasets, a Student's t-test with Benjamini-Hochberg correction is run per batch, then majority-voted. For small-batch datasets, all cells are pooled. The metric is macro F1 score.
+
+This formulation is particularly useful for chemical perturbations where the continuous LFC signal is weak but discrete changes can still be detected.
+
+#### Key Takeaways
+
+- **DEG classification** captures perturbation effects that LFC regression may miss, especially for drugs.
+- **Majority voting across batches** ensures robust classification.
+- **Macro F1** accounts for class imbalance (most genes are unchanged).
+
+---
+
+### Datasets
+
+#### Overview
+
+Four datasets span different perturbation types, cell lines, and scales:
+
+<svg viewBox="0 0 700 220" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="fm-9-title">
+  <title id="fm-9-title">Perturbation datasets compared by type, scale, and cell coverage</title>
+  <!-- Header row -->
+  <rect x="20" y="10" width="660" height="36" rx="6" fill="#1e293b"/>
+  <text x="95" y="33" text-anchor="middle" font-weight="700" fill="white">Dataset</text>
+  <text x="230" y="33" text-anchor="middle" font-weight="700" fill="white">Type</text>
+  <text x="365" y="33" text-anchor="middle" font-weight="700" fill="white">Cell Lines</text>
+  <text x="490" y="33" text-anchor="middle" font-weight="700" fill="white">Perturbations</text>
+  <text x="620" y="33" text-anchor="middle" font-weight="700" fill="white">Cells</text>
+  <!-- Row 1 -->
+  <rect x="20" y="48" width="660" height="36" rx="0" fill="#f8fafc"/>
+  <text x="95" y="71" text-anchor="middle" fill="#334155" font-weight="600">Norman</text>
+  <text x="230" y="71" text-anchor="middle" fill="#64748b">CRISPRa</text>
+  <text x="365" y="71" text-anchor="middle" fill="#64748b">1 (K562)</text>
+  <text x="490" y="71" text-anchor="middle" fill="#64748b">105 single</text>
+  <text x="620" y="71" text-anchor="middle" fill="#64748b">~100K</text>
+  <!-- Row 2 (highlighted) -->
+  <rect x="20" y="86" width="660" height="36" rx="0" fill="#eff6ff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="95" y="109" text-anchor="middle" fill="#1e40af" font-weight="700">Essential</text>
+  <text x="230" y="109" text-anchor="middle" fill="#1e40af">CRISPRkd</text>
+  <text x="365" y="109" text-anchor="middle" fill="#1e40af">4</text>
+  <text x="490" y="109" text-anchor="middle" fill="#1e40af">~2000/line</text>
+  <text x="620" y="109" text-anchor="middle" fill="#1e40af">~964K</text>
+  <!-- Row 3 -->
+  <rect x="20" y="124" width="660" height="36" rx="0" fill="#f8fafc"/>
+  <text x="95" y="147" text-anchor="middle" fill="#334155" font-weight="600">Sciplex-3</text>
+  <text x="230" y="147" text-anchor="middle" fill="#64748b">Chemical</text>
+  <text x="365" y="147" text-anchor="middle" fill="#64748b">3</text>
+  <text x="490" y="147" text-anchor="middle" fill="#64748b">188 drugs</text>
+  <text x="620" y="147" text-anchor="middle" fill="#64748b">~800K</text>
+  <!-- Row 4 -->
+  <rect x="20" y="162" width="660" height="36" rx="0" fill="#f8fafc"/>
+  <text x="95" y="185" text-anchor="middle" fill="#334155" font-weight="600">Tahoe-100M</text>
+  <text x="230" y="185" text-anchor="middle" fill="#64748b">Chemical</text>
+  <text x="365" y="185" text-anchor="middle" fill="#64748b">50</text>
+  <text x="490" y="185" text-anchor="middle" fill="#64748b">379 drugs</text>
+  <text x="620" y="185" text-anchor="middle" fill="#64748b">~100M</text>
+  <!-- Note -->
+  <text x="350" y="215" text-anchor="middle" font-size="11" fill="#3b82f6" font-style="italic">Essential (highlighted) is the primary benchmark for genetic perturbation evaluation</text>
+</svg>
+
+Essential is the primary benchmark for genetic perturbations because it has enough perturbations (~2000 per cell line) to reliably distinguish embedding quality. Norman is included for comparison with prior work, but its small size masks performance differences. Tahoe is the largest chemical perturbation dataset, enabling more robust evaluation of drug embeddings.
+
+#### Key Takeaways
+
+- **Dataset size matters**: Small datasets (Norman) don't distinguish FMs from baselines; larger ones (Essential) do.
+- **Essential** is the key genetic perturbation benchmark: 4 cell lines × ~2000 perturbations each.
+- **Tahoe-100M** is the largest single-cell chemical perturbation dataset (~100M cells, 379 drugs, 50 cell lines).
+
+---
+
+### Embedding Sources
+
+#### Overview
+
+The paper evaluates embeddings from four modalities for genetic perturbation prediction: expression (scRNA-seq FMs), DNA sequence, protein sequence/structure, and prior knowledge (interaction networks, annotations, text). For chemical perturbations, additional sources include molecular fingerprints, SMILES-based FMs, target-based embeddings, and text embeddings from LLMs.
+
+A key methodological contribution is the systematic evaluation across all these sources using a unified framework (same datasets, metrics, cross-validation splits).
+
+#### Key Takeaways
+
+- **Expression FMs**: AIDO.Cell, scGPT, scPRINT, Geneformer, TranscriptFormer — contextualized on control cells.
+- **Interactome FMs**: WaveGC, STRING GNN, STRING Spectral — trained on protein-protein interaction networks.
+- **GenePT**: Embeds textual gene descriptions with GPT-3.5 — a "soft" form of interactome knowledge.
+- **Chemical embeddings**: Morgan fingerprints, ChemBERTa, Uni-Mol, and target-based approaches using gene FMs.
+
+---
+
+### Fusion Architecture
+
+#### Overview
+
+The fusion model uses a transformer encoder to integrate variable numbers of embeddings per perturbation. Each embedding is projected to a common 100-dimensional space, a learnable cell line token is added, and a CLS token aggregates information through self-attention. The CLS output feeds into a prediction head that outputs the LFC vector.
+
+A key design choice is handling missing embeddings — not every FM produces an embedding for every gene. The attention mechanism naturally handles this by operating on variable-length input sets. Training uses L2 loss with Optuna hyperparameter tuning (100 trials), and the model is trained jointly across cell lines.
+
+#### Key Takeaways
+
+- **Transformer-based attention** enables flexible integration of variable numbers of embeddings.
+- **Cell line tokens** allow the same model to predict across different cell types.
+- **100 Optuna trials** for hyperparameter tuning; same hyperparameters used across all CV folds.
+- **Full fusion model** (more complex architecture) outperforms simple fusion on Essential.
+
+---
+
+## Discussion
+
+### Overview
+
+The authors conclude that foundation models **do** improve perturbation prediction — but only when you choose the right ones. The key findings paint a nuanced picture:
+
+For genetic perturbations, interactome-based embeddings are the single most valuable information source. This has practical implications: organizations building "virtual cell" models should invest in **interaction data across contexts** (cell types, diseases, developmental stages), potentially even more than in additional single-cell expression data. Fusion of multiple FM types pushes performance to the experimental noise floor.
+
+For chemical perturbations, the picture is harder. Genetic perturbations are specific (one gene → one knockout), while drugs can hit multiple targets through complex pharmacology. The search space is vastly larger (~10^60 molecules vs ~20K genes), and we have much less interaction network data for small molecules. Off-the-shelf SMILES-based FMs perform poorly because they were trained to predict chemical, not biological, properties. The field needs a **biological function-aware molecular FM**.
+
+Fine-tuning remains a challenge due to limited perturbation data. The authors suggest that jointly fine-tuning multiple FMs within a fusion framework could help, but overfitting risk is high without more training data.
+
+### Concept Diagram
+
+<svg viewBox="0 0 700 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="fm-10-title">
+  <title id="fm-10-title">Summary: What Works and What Doesn't</title>
+  <text x="350" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Summary: What Works and What Doesn't</text>
+  <!-- Column headers -->
+  <rect x="30" y="42" width="200" height="30" rx="6" fill="#1e293b"/>
+  <text x="130" y="62" text-anchor="middle" font-weight="700" fill="white" font-size="12">Approach</text>
+  <rect x="240" y="42" width="200" height="30" rx="6" fill="#166534"/>
+  <text x="340" y="62" text-anchor="middle" font-weight="700" fill="white" font-size="12">Genetic Perturbations</text>
+  <rect x="450" y="42" width="220" height="30" rx="6" fill="#92400e"/>
+  <text x="560" y="62" text-anchor="middle" font-weight="700" fill="white" font-size="12">Chemical Perturbations</text>
+  <!-- Row 1: Single FM -->
+  <rect x="30" y="78" width="200" height="32" rx="4" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="130" y="99" text-anchor="middle" fill="#334155" font-weight="600">Single FM</text>
+  <rect x="240" y="78" width="200" height="32" rx="4" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="340" y="99" text-anchor="middle" fill="#166534">★★★ interactome</text>
+  <rect x="450" y="78" width="220" height="32" rx="4" fill="#fefce8" stroke="#fde047" stroke-width="1"/>
+  <text x="560" y="99" text-anchor="middle" fill="#854d0e">★★ target-based</text>
+  <!-- Row 2: Fusion -->
+  <rect x="30" y="116" width="200" height="32" rx="4" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="130" y="137" text-anchor="middle" fill="#334155" font-weight="600">FM Fusion</text>
+  <rect x="240" y="116" width="200" height="32" rx="4" fill="#bbf7d0" stroke="#4ade80" stroke-width="1.5"/>
+  <text x="340" y="137" text-anchor="middle" fill="#166534" font-weight="700">★★★★★</text>
+  <rect x="450" y="116" width="220" height="32" rx="4" fill="#fef2f2" stroke="#fca5a5" stroke-width="1"/>
+  <text x="560" y="137" text-anchor="middle" fill="#991b1b">★ no gain</text>
+  <!-- Row 3: Fine-tuning -->
+  <rect x="30" y="154" width="200" height="32" rx="4" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="130" y="175" text-anchor="middle" fill="#334155" font-weight="600">Fine-tuning</text>
+  <rect x="240" y="154" width="200" height="32" rx="4" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="340" y="175" text-anchor="middle" fill="#166534">★★★ risky</text>
+  <rect x="450" y="154" width="220" height="32" rx="4" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="560" y="175" text-anchor="middle" fill="#64748b">Not tested</text>
+  <!-- Row 4: Complex decoders -->
+  <rect x="30" y="192" width="200" height="32" rx="4" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="130" y="213" text-anchor="middle" fill="#334155" font-weight="600">Complex decoders</text>
+  <rect x="240" y="192" width="200" height="32" rx="4" fill="#fefce8" stroke="#fde047" stroke-width="1"/>
+  <text x="340" y="213" text-anchor="middle" fill="#854d0e">★★ no gain</text>
+  <rect x="450" y="192" width="220" height="32" rx="4" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="560" y="213" text-anchor="middle" fill="#64748b">Not tested</text>
+  <!-- Key bottlenecks -->
+  <text x="350" y="260" text-anchor="middle" font-size="14" font-weight="700" fill="#1e293b">Key Bottlenecks</text>
+  <rect x="30" y="274" width="310" height="90" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="185" y="298" text-anchor="middle" font-weight="700" fill="#166534" font-size="13">Genetic</text>
+  <text x="185" y="318" text-anchor="middle" font-size="12" fill="#334155">Nearly solved for some cell lines!</text>
+  <text x="185" y="338" text-anchor="middle" font-size="12" fill="#334155">Need harder benchmarks.</text>
+  <rect x="360" y="274" width="310" height="90" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="515" y="298" text-anchor="middle" font-weight="700" fill="#991b1b" font-size="13">Chemical</text>
+  <text x="515" y="318" text-anchor="middle" font-size="12" fill="#334155">Need biology-aware molecular FMs.</text>
+  <text x="515" y="338" text-anchor="middle" font-size="12" fill="#334155">Multi-target effects are hard.</text>
+  <text x="515" y="355" text-anchor="middle" font-size="12" fill="#334155">Limited network data for drugs.</text>
+</svg>
+
+### Key Takeaways
+
+- **Interactome data is king** for genetic perturbation prediction — invest in interaction networks.
+- **Chemical perturbation prediction** remains an open challenge; current molecular FMs lack biological grounding.
+- **Fusion reaches experimental limits** for some genetic perturbation settings, suggesting the need for harder benchmarks.
+- **The field needs more perturbation data** to unlock the potential of fine-tuning and joint training.
+- **Simple prediction methods suffice** — the embedding quality is the bottleneck, not model complexity.
+
+---
+
+## Key Takeaways Summary
+
+### The Big Picture
+
+1. **Foundation models DO improve perturbation prediction** — but only certain types. Interactome-based FMs (WaveGC, GenePT, GenotypeVAE) significantly outperform baselines, while DNA and protein sequence FMs add little value for this task.
+
+2. **Embedding quality > model complexity**: kNN with the right embedding beats Latent Diffusion, Flow Matching, Schrödinger Bridge, and GEARS — all at a fraction of the compute cost.
+
+3. **Multi-modal fusion reaches experimental limits**: Combining embeddings from diverse FMs via attention-based fusion matches the noise floor in 2 of 4 cell lines tested.
+
+4. **Chemical perturbations remain hard**: Drug response prediction is fundamentally more difficult due to multi-target effects and the lack of biology-aware molecular FMs.
+
+5. **Data and benchmarks need to scale up**: Small datasets mask real differences between methods; larger benchmarks like Essential reveal robust trends. The field needs both more perturbation data and harder evaluation splits.
+
+---
+
+## References
+
+Original paper: Cole, E. et al. (2026). "Foundation Models Improve Perturbation Response Prediction." bioRxiv. DOI: 10.64898/2026.02.18.706454
+
+Code and Data: https://github.com/genbio-ai/foundation-models-perturbation
+
+## About This Analysis
+
+This analysis was generated to make complex academic concepts more accessible. For complete technical details, mathematical formulations, supplementary figures, and all 600+ model results, please refer to the original paper.

--- a/assets/blogs/0021-portello.md
+++ b/assets/blogs/0021-portello.md
@@ -1,0 +1,761 @@
+@{id = "69f05224-a229-4c51-8555-22eee53c0d20"
+  title = "Portello: Making Global Assembly More Effective for Rare-Disease Whole Genome Sequencing"
+  date = "2026-04-29T00:00:00Z"
+  tags = ['journal club', 'genomics', 'biorxiv', 'long-read sequencing', 'rare disease']
+  views = 0
+  likes = 0
+  image = "https://storage.googleapis.com/gn-portfolio/images/portello-thumb.svg"
+  description = "Saunders et al. introduce portello: transfer HiFi read alignments from the sample's own de novo contigs onto GRCh38, and DeepVariant removes 47% of small-variant basecall errors compared with conventional read mapping."
+  type = "note"
+  disabled = "false"
+}
+
+<p align="center">
+  <img src="https://storage.googleapis.com/gn-portfolio/images/portello-thumb.svg" max-width="700">
+</p>
+
+
+# Portello: Making Global Assembly More Effective for Rare-Disease Whole Genome Sequencing
+
+*Analysis of Saunders, Kronenberg, Holt, Rowell, Eberle (2026), PacBio — bioRxiv preprint*
+*Generated on April 29, 2026*
+
+---
+
+## Table of Contents
+
+- [Abstract](#abstract)
+- [A Quick Primer on Long-Read Genomics](#a-quick-primer-on-long-read-genomics)
+- [Introduction](#introduction)
+- [Results](#results)
+  - [Improved Read Representation](#improved-read-representation)
+  - [Small Variant Calling Accuracy](#small-variant-calling-accuracy)
+  - [Phasing and Haplotagging](#phasing-and-haplotagging)
+  - [CNV Interpretation in Segmental Duplications](#cnv-interpretation-in-segmental-duplications)
+- [Methods](#methods)
+  - [Read Mapping Transfer Algorithm](#read-mapping-transfer-algorithm)
+  - [Phase Set Construction](#phase-set-construction)
+- [Discussion](#discussion)
+- [Key Takeaways (Summary)](#key-takeaways-summary)
+
+---
+
+## Abstract
+
+### Overview
+
+Long-read *de novo* assembly is the right tool for rare-disease whole-genome sequencing. Rare variants — the ones rare-disease patients carry by definition — are also the ones most likely to be wildly different from the reference genome. A sample-specific assembly catches what a reference-based pipeline misses, because the assembler doesn't have to fight the reference at all; it builds the patient's own genome up from raw reads. Yet in clinical practice, assembly remains the *backup* approach. Almost every diagnostic pipeline still funnels reads straight to GRCh38 and calls variants from that mapping.
+
+This paper diagnoses *why* assembly is under-used and proposes a fix. The two complaints from real users are concrete: (1) when a variant is called from the assembly, it lives in *contig coordinates*, which makes it hard to view the read-level evidence that a clinician needs to sign off on (basecall quality, methylation, mosaic support); and (2) reconciling assembly-based calls with the lab's existing reference-based pipeline is awkward — you can end up with two views of the same locus that disagree, and no easy way to decide which is right.
+
+Portello (named for the small Italian word for "hatch" or "porthole" — a window through which to look at the same thing from a new angle) is a small idea with a big payoff: instead of choosing between assembly-based calls and reference-based calls, *transfer* the read alignments. The reads are first aligned to the sample's own assembly contigs (so they benefit from the long-range haplotype structure the assembler discovered); the contigs are mapped to GRCh38; and portello composes those two mapping functions to produce read alignments that *land on GRCh38 coordinates* but were *placed via the assembly*. Standard tools — DeepVariant, structural-variant callers, IGV — consume the resulting BAM file without modification.
+
+The headline number: when DeepVariant is run on portello-remapped HG002 reads instead of pbmm2-mapped reads (same reads, same model, only the mapping changed), it removes **47% of small-variant basecall errors**. False negatives drop by 52%; false positives stay essentially flat. On NA12878 the total error reduction is 29%. None of this required retraining DeepVariant.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="abs-portello-title">
+  <title id="abs-portello-title">Portello composes read-to-contig and contig-to-reference alignments to land reads on GRCh38 via the assembly.</title>
+  <defs>
+    <marker id="abs-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+    <marker id="abs-arrow-g" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#22c55e"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Portello: read alignment via the assembly</text>
+  <!-- Reads -->
+  <rect x="30" y="60" width="160" height="70" rx="10" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="110" y="90" text-anchor="middle" font-weight="600" fill="#92400e">HiFi reads</text>
+  <text x="110" y="110" text-anchor="middle" font-size="11" fill="#64748b">~15–25 kb each</text>
+  <!-- Contigs -->
+  <rect x="270" y="60" width="180" height="70" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="360" y="90" text-anchor="middle" font-weight="600" fill="#1e40af">de novo contigs</text>
+  <text x="360" y="110" text-anchor="middle" font-size="11" fill="#64748b">hifiasm dual-assembly</text>
+  <!-- Reference -->
+  <rect x="530" y="60" width="160" height="70" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="610" y="90" text-anchor="middle" font-weight="600" fill="#166534">GRCh38 reference</text>
+  <text x="610" y="110" text-anchor="middle" font-size="11" fill="#64748b">standard target</text>
+  <!-- Read-to-contig arrow -->
+  <line x1="190" y1="95" x2="270" y2="95" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <text x="230" y="84" text-anchor="middle" font-size="10" fill="#475569">pbmm2</text>
+  <!-- Contig-to-ref arrow -->
+  <line x1="450" y1="95" x2="530" y2="95" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <text x="490" y="84" text-anchor="middle" font-size="10" fill="#475569">minimap2</text>
+  <!-- Composition (the trick) -->
+  <rect x="180" y="180" width="360" height="70" rx="10" fill="#faf5ff" stroke="#a855f7" stroke-width="2"/>
+  <text x="360" y="208" text-anchor="middle" font-weight="700" fill="#6b21a8">portello: compose mappings</text>
+  <text x="360" y="228" text-anchor="middle" font-size="11" fill="#64748b">(read → contig) ° (contig → reference)</text>
+  <!-- Inputs flowing in -->
+  <line x1="230" y1="130" x2="280" y2="180" stroke="#a855f7" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <line x1="490" y1="130" x2="440" y2="180" stroke="#a855f7" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <!-- Output -->
+  <line x1="360" y1="250" x2="360" y2="285" stroke="#22c55e" stroke-width="2" marker-end="url(#abs-arrow-g)"/>
+  <rect x="190" y="290" width="340" height="55" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="360" y="313" text-anchor="middle" font-weight="700" fill="#166534">read → reference BAM</text>
+  <text x="360" y="332" text-anchor="middle" font-size="11" fill="#64748b">consumable by DeepVariant, IGV, … unchanged</text>
+</svg>
+
+### Key Takeaways
+
+- **Two-step alignment beats one-step**: Splitting "reads to reference" into "reads to contigs ° contigs to reference" puts each sub-problem in a regime where standard mappers excel, instead of asking one mapper to handle both sequencing error and biological variation simultaneously.
+- **47% fewer small-variant errors, free**: DeepVariant on the same HG002 reads loses about half its basecall errors when the input BAM comes from portello instead of pbmm2 — without any retraining.
+- **Phasing for free**: Because reads were placed via specific contigs, portello can carry haplotype tags and phase sets through to the reference-coordinate BAM in one step.
+- **Coverage you can trust**: In segmental duplications, conventional mapping produces coverage spikes of 12,000× followed by gene-level dropouts; portello produces a clean 3-fold profile that matches the underlying biology.
+
+---
+
+## A Quick Primer on Long-Read Genomics
+
+If you mostly work with short-read or non-genomic data, this section gives you the scaffolding for what follows. Skip if you already speak HiFi.
+
+**Sequencing.** A modern PacBio HiFi instrument reads single DNA molecules of ~15–25 kb at >99.9% per-base accuracy. ONT (Oxford Nanopore) reads are longer (often >100 kb) but historically less accurate, though that gap has been closing. "Long-read sequencing" in this paper means HiFi unless otherwise specified.
+
+**Reads vs. assembly vs. reference.** A *read* is one sequenced molecule. A *reference* (GRCh38) is the public consensus human genome — one assembly built from many people, used as a coordinate system. *De novo assembly* takes a sample's reads and stitches them into long *contigs* (contiguous sequences) without using the reference at all. With HiFi data and a modern assembler (`hifiasm`, `Verkko`), a human assembly is typically *partially phased* or *dual-assembly*: you get two contig sets representing both haplotypes of the diploid genome, but the contigs are not perfectly switched to the right haplotype throughout (there are *switch errors*).
+
+**Conventional read mapping.** The standard variant-calling pipeline aligns each read to the reference (`pbmm2` for PacBio HiFi, `minimap2` more generally), then runs a caller like DeepVariant on those alignments. This is fast, scales easily, and produces variants in standard reference coordinates. The downside: when the patient's true sequence is wildly different from GRCh38 (large insertions, structural variants, divergent haplotypes), the mapper struggles — reads are split, soft-clipped, or misplaced, and the caller sees garbage.
+
+**Variant types.** *Small variants* are SNVs and short indels (typically ≤ 50 bp). *Structural variants* (SVs) are larger insertions, deletions, inversions, and translocations. *Copy-number variants* (CNVs) are gains or losses of larger chromosomal regions. Rare-disease patients carry both classes; small variants are easier to call but SVs and CNVs are often the actual diagnosis.
+
+**Phasing.** A diploid human carries two copies of (most of) each chromosome, one from each parent. *Phasing* assigns each variant to its parental haplotype. The bam tags `HP` (haplotype 1 or 2) and `PS` (phase set ID, marking the contiguous region within which the phasing is internally consistent) are the standard way to record this on individual reads.
+
+**Why this paper exists.** Assembly captures the patient's genome better than reference-based mapping in hard regions, but assembly-based variant calls are awkward to integrate with the rest of the standard pipeline. Portello bridges the two worlds.
+
+---
+
+## Introduction
+
+### Overview
+
+Predicting which variants caused a patient's disease is one of the central tasks of clinical genomics, and for rare disease it is unusually hard. The variants in question, by definition, are not in any common-variant database. They are also more likely than common variants to live in regions where the patient's sequence diverges substantially from GRCh38 — segmental duplications, repeat expansions, structural rearrangements. These are exactly the regions where conventional reference-based mapping has the most trouble: a read drawn from a region that doesn't really exist in GRCh38 has nowhere good to land.
+
+The field has worked through several paradigms over the last two decades. Short-read sequencing (Illumina) plus reference mapping (BWA) plus a probabilistic caller (GATK) became the workhorse in the 2010s, and it solved most of the easy genome. The hard regions remained hard. Long-read sequencing — first PacBio CLR and ONT R9, then HiFi and ONT R10 — arrived with two answers: longer reads make repeat-spanning unambiguous, and high-accuracy long reads make whole-genome assembly feasible from a single library. Tools like `hifiasm` (Cheng et al. 2021) and `Verkko` (Rautiainen et al. 2023) routinely produce diploid human assemblies in days. Recent rare-disease studies have shown that a meaningful fraction of candidate causal variants — both *de novo* and recessive — are *only* recoverable from assembly-based calling.
+
+So why isn't every rare-disease lab running assembly? Because the operational story is messy. Assembly produces contigs in their own coordinate system. Variants called against contigs need to be lifted to GRCh38 to be talked about, reviewed, or compared with prior data. Read-level evidence — the kind a clinician squints at in IGV before signing off — is hidden behind an extra coordinate translation. Mosaic variants (present in only a fraction of cells, important for cancer and developmental disorders) are unlikely to make it into a haploid assembly consensus at all. And when an assembly-based call disagrees with the lab's existing reference-based pipeline, there is no obvious adjudicator.
+
+Portello's framing is that you don't have to pick. The reference-based pipeline gets to keep its variant callers, its coordinates, and its review tools, but the *read alignments* feeding the pipeline now ride on top of the patient's assembly. The two halves of the alignment problem — "where is this read on the patient's genome?" and "where is the patient's genome on GRCh38?" — are decoupled and solved separately, then composed back into one BAM in reference coordinates. The mapper handling each sub-problem only has to deal with one source of difficulty: sequencing error for read-to-contig, biological variation for contig-to-reference. Each sub-problem is what its mapper was actually built for.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="intro-evolution-title">
+  <title id="intro-evolution-title">Evolution from short-read reference mapping to assembly-based read mapping.</title>
+  <defs>
+    <marker id="intro-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">From reference mapping to assembly mapping</text>
+  <!-- Era 1 -->
+  <rect x="20" y="60" width="200" height="80" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="120" y="86" text-anchor="middle" font-weight="600" fill="#334155">Short-read mapping</text>
+  <text x="120" y="106" text-anchor="middle" font-size="11" fill="#64748b">BWA + GATK</text>
+  <text x="120" y="124" text-anchor="middle" font-size="11" fill="#dc2626">hard regions: blind</text>
+  <line x1="220" y1="100" x2="260" y2="100" stroke="#64748b" stroke-width="1.5" marker-end="url(#intro-arrow)"/>
+  <!-- Era 2 -->
+  <rect x="260" y="60" width="200" height="80" rx="8" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text x="360" y="86" text-anchor="middle" font-weight="600" fill="#854d0e">Long-read mapping</text>
+  <text x="360" y="106" text-anchor="middle" font-size="11" fill="#64748b">pbmm2 / minimap2</text>
+  <text x="360" y="124" text-anchor="middle" font-size="11" fill="#ca8a04">spans repeats; SVs ok</text>
+  <line x1="460" y1="100" x2="500" y2="100" stroke="#64748b" stroke-width="1.5" marker-end="url(#intro-arrow)"/>
+  <!-- Era 3 -->
+  <rect x="500" y="60" width="200" height="80" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="600" y="86" text-anchor="middle" font-weight="600" fill="#1e40af">Assembly only</text>
+  <text x="600" y="106" text-anchor="middle" font-size="11" fill="#64748b">hifiasm / Verkko</text>
+  <text x="600" y="124" text-anchor="middle" font-size="11" fill="#3b82f6">finds rare variants;</text>
+  <text x="600" y="138" text-anchor="middle" font-size="11" fill="#3b82f6">awkward to integrate</text>
+  <!-- Era 4 -->
+  <line x1="360" y1="180" x2="360" y2="210" stroke="#a855f7" stroke-width="2" marker-end="url(#intro-arrow)"/>
+  <rect x="200" y="220" width="320" height="100" rx="10" fill="#faf5ff" stroke="#a855f7" stroke-width="2"/>
+  <text x="360" y="248" text-anchor="middle" font-weight="700" fill="#6b21a8">Assembly-based read mapping</text>
+  <text x="360" y="270" text-anchor="middle" font-size="12" fill="#6b21a8">portello (this paper)</text>
+  <text x="360" y="292" text-anchor="middle" font-size="11" fill="#64748b">read-level evidence kept;</text>
+  <text x="360" y="308" text-anchor="middle" font-size="11" fill="#64748b">unifies assembly + reference views</text>
+</svg>
+
+### Key Takeaways
+
+- **The hard regions are the rare-disease regions**: SVs, segmental duplications, and divergent haplotypes are exactly where reference-based mapping breaks down — and where rare-disease causal variants are most likely to live.
+- **Assembly already exists, it's just hard to use**: Modern HiFi assemblers produce diploid human genomes routinely. The barrier is operational integration with the rest of the lab, not assembly quality.
+- **Composition is the move**: By solving "read → contig" and "contig → reference" as separate problems and composing them, each mapper handles only one source of disagreement — sequencing error or biological variation, never both.
+- **Reference coordinates as a UI**: Portello's output looks like a normal reference-coordinate BAM. The integration story is "no integration": existing tools just work.
+
+---
+
+## Results
+
+The paper presents four results, two of which carry quantitative head-to-heads (small-variant accuracy and phasing) and two of which are qualitative demonstrations on illustrative loci (read representation and CNV interpretation). I treat them in the order the paper does.
+
+### Improved Read Representation
+
+#### Overview
+
+Before the result, a quick orientation: a *VNTR* is a *variable number tandem repeat* — a short sequence motif that is repeated end-to-end, with the number of repeats varying between people. VNTRs are notoriously hard for mappers because the read can plausibly align to many positions within the repeat block at very similar scores; the mapper has to pick one, and small differences in scoring (or in the read's own sequencing errors) can flip the choice. The result is a "messy pileup": within a few hundred base pairs you'll see indels at slightly different reference positions, soft-clips that don't agree with each other, and split alignments fighting over the same reads.
+
+Portello's contribution here is structural rather than quantitative. The authors don't put a number on read-representation quality in this section; they show side-by-side IGV-style views of a VNTR locus mapped two ways. With pbmm2 (Figure 1B in the paper), each read is doing its own thing. With portello (Figure 1C), the reads agree with each other. The mechanism is the same one that drives the variant-calling result later: portello aligns each read against the patient's *own* contigs first, in which the VNTR has a single, consistent representation; only then does the contig-to-reference alignment have to grapple with how that representation differs from GRCh38, and it does so once per contig instead of once per read.
+
+There is also a more subtle gain: the patient's contigs act as a *sample-specific decoy*. In conventional mapping, reads from a region that's been duplicated in the sample but not in the reference end up scattered across the closest reference homologs, creating phantom variants. With portello, those reads first align to the *correct* sample-specific contig — their actual home — and the contig-to-reference step decides where to deposit the contig. Reads that genuinely don't have a good home in the sample assembly are kept in a separate "unassembled" output.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="rep-vntr-title">
+  <title id="rep-vntr-title">Schematic of read alignment in a VNTR: pbmm2 vs portello pileups.</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">VNTR pileup: noisy vs consistent</text>
+  <!-- pbmm2 panel -->
+  <rect x="20" y="60" width="320" height="280" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="180" y="86" text-anchor="middle" font-weight="700" fill="#991b1b">conventional (pbmm2)</text>
+  <!-- Reference bar -->
+  <rect x="40" y="110" width="280" height="10" fill="#cbd5e1"/>
+  <text x="40" y="106" font-size="10" fill="#64748b">GRCh38</text>
+  <!-- Reads (varying offsets, many indel marks) -->
+  <rect x="40" y="135" width="120" height="6" fill="#3b82f6"/>
+  <rect x="166" y="135" width="100" height="6" fill="#3b82f6"/>
+  <circle cx="162" cy="138" r="3" fill="#dc2626"/>
+  <rect x="50" y="150" width="110" height="6" fill="#3b82f6"/>
+  <rect x="170" y="150" width="120" height="6" fill="#3b82f6"/>
+  <circle cx="165" cy="153" r="3" fill="#dc2626"/>
+  <rect x="40" y="165" width="100" height="6" fill="#3b82f6"/>
+  <rect x="148" y="165" width="130" height="6" fill="#3b82f6"/>
+  <circle cx="144" cy="168" r="3" fill="#dc2626"/>
+  <rect x="55" y="180" width="90" height="6" fill="#3b82f6"/>
+  <rect x="155" y="180" width="120" height="6" fill="#3b82f6"/>
+  <circle cx="150" cy="183" r="3" fill="#dc2626"/>
+  <rect x="40" y="195" width="100" height="6" fill="#3b82f6"/>
+  <rect x="148" y="195" width="130" height="6" fill="#3b82f6"/>
+  <circle cx="144" cy="198" r="3" fill="#dc2626"/>
+  <rect x="50" y="210" width="115" height="6" fill="#3b82f6"/>
+  <rect x="173" y="210" width="100" height="6" fill="#3b82f6"/>
+  <circle cx="169" cy="213" r="3" fill="#dc2626"/>
+  <text x="180" y="248" text-anchor="middle" font-size="11" fill="#dc2626" font-weight="600">indels at slightly different positions</text>
+  <text x="180" y="268" text-anchor="middle" font-size="11" fill="#dc2626">soft-clips disagree</text>
+  <text x="180" y="288" text-anchor="middle" font-size="11" fill="#dc2626">caller sees noise</text>
+  <text x="180" y="320" text-anchor="middle" font-size="11" fill="#991b1b" font-style="italic">each read negotiates the VNTR alone</text>
+  <!-- portello panel -->
+  <rect x="380" y="60" width="320" height="280" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="540" y="86" text-anchor="middle" font-weight="700" fill="#166534">portello (assembly-based)</text>
+  <rect x="400" y="110" width="280" height="10" fill="#cbd5e1"/>
+  <text x="400" y="106" font-size="10" fill="#64748b">GRCh38</text>
+  <!-- Reads aligned uniformly -->
+  <rect x="400" y="135" width="120" height="6" fill="#22c55e"/>
+  <rect x="525" y="135" width="100" height="6" fill="#22c55e"/>
+  <circle cx="522" cy="138" r="3" fill="#16a34a"/>
+  <rect x="400" y="150" width="120" height="6" fill="#22c55e"/>
+  <rect x="525" y="150" width="100" height="6" fill="#22c55e"/>
+  <circle cx="522" cy="153" r="3" fill="#16a34a"/>
+  <rect x="400" y="165" width="120" height="6" fill="#22c55e"/>
+  <rect x="525" y="165" width="100" height="6" fill="#22c55e"/>
+  <circle cx="522" cy="168" r="3" fill="#16a34a"/>
+  <rect x="400" y="180" width="120" height="6" fill="#22c55e"/>
+  <rect x="525" y="180" width="100" height="6" fill="#22c55e"/>
+  <circle cx="522" cy="183" r="3" fill="#16a34a"/>
+  <rect x="400" y="195" width="120" height="6" fill="#22c55e"/>
+  <rect x="525" y="195" width="100" height="6" fill="#22c55e"/>
+  <circle cx="522" cy="198" r="3" fill="#16a34a"/>
+  <rect x="400" y="210" width="120" height="6" fill="#22c55e"/>
+  <rect x="525" y="210" width="100" height="6" fill="#22c55e"/>
+  <circle cx="522" cy="213" r="3" fill="#16a34a"/>
+  <text x="540" y="248" text-anchor="middle" font-size="11" fill="#166534" font-weight="600">indels at the same position</text>
+  <text x="540" y="268" text-anchor="middle" font-size="11" fill="#166534">consistent alignments</text>
+  <text x="540" y="288" text-anchor="middle" font-size="11" fill="#166534">caller sees a clean variant</text>
+  <text x="540" y="320" text-anchor="middle" font-size="11" fill="#166534" font-style="italic">the contig negotiates the VNTR once</text>
+  <text x="360" y="362" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Schematic adapted from the paper's Figures 1B/1C; positions are illustrative, not literal.</text>
+</svg>
+
+### Key Takeaways
+
+- **VNTRs are where one-mapper-fits-all breaks**: The mapper has to settle a tie that doesn't really have an answer at the read level; portello deferring that tie to the contig step is the actual fix.
+- **Contigs as decoys**: A patient-specific assembly is the cleanest possible decoy sequence for the patient's own reads — no public decoy can match.
+- **Qualitative result, structural cause**: This section is illustrative rather than benchmarked, but it sets up the mechanism that the next two sections turn into hard numbers.
+
+---
+
+### Small Variant Calling Accuracy
+
+#### Overview
+
+Before the result, a quick orientation: *small variants* are SNVs and short indels (typically ≤ 50 bp), and they are scored against a *truth set* — a hand-curated, often assembly-confirmed list of variants for a benchmark sample. The two samples here are HG002 (an Ashkenazi Jewish reference sample with the GIAB draft T2T benchmark) and NA12878 (a CEPH reference sample with the Platinum Pedigree v1.2 truth set). The metric is *F1 of variant calls* against the benchmark, decomposed into *false negatives* (variants the truth set has but the caller missed) and *false positives* (calls the caller made that aren't in the truth set).
+
+The experiment is designed to isolate one variable. The same reads are used in both arms. The same caller (DeepVariant v1.9 with the standard HiFi model) is used in both arms. The DeepVariant model is *not retrained* on portello output. The only thing that changes between the two arms is the read mapper: pbmm2 v1.17 (conventional) vs portello (assembly-based). Anything that improves between the arms therefore comes purely from better alignment, not from a smarter caller or a model that has seen more of the input distribution.
+
+The result is large. On HG002, total basecall errors drop by **47%** (from 375,634 to 199,368 across both BASEPAIR FN and FP) — almost entirely driven by a 52% reduction in false negatives. False positives change by a small amount (-14%). On NA12878, the picture is similar in shape: a 55% drop in false negatives, little change in false positives, and a 29% drop in total errors. The absolute F1 on HG002 climbs from 0.9901 to 0.9948; on NA12878 from 0.9916 to 0.9940. The headline number sounds modest in F1 space (under one percentage point) because both methods are already near the ceiling, but the *error reduction* lens is the right one for clinical use: every one of those false negatives is a missing variant call that a clinician would have wanted to see.
+
+The asymmetry between samples is notable. HG002 sees a bigger total-error reduction than NA12878, mostly because NA12878 starts with a higher baseline of false positives (likely tied to using an externally produced Verkko assembly from the Platinum Pedigree project rather than a fresh hifiasm assembly built from these reads). Even so, the shape — recall up sharply, precision essentially flat — is consistent and is the expected signature of *better placement*: reads that previously missed their region (false negatives) get there, while reads that were going to call a wrong variant don't suddenly become more confident.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="var-bar-title">
+  <title id="var-bar-title">DeepVariant basecall errors: pbmm2 vs portello on HG002 and NA12878.</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">DeepVariant basecall errors (BASEPAIR)</text>
+  <text x="360" y="42" text-anchor="middle" font-size="11" fill="#64748b">Lower is better — reduction comes almost entirely from fewer false negatives.</text>
+  <!-- HG002 group -->
+  <text x="40" y="80" font-weight="700" fill="#1e293b">HG002</text>
+  <text x="180" y="108" text-anchor="end" fill="#334155" font-size="12">pbmm2</text>
+  <rect x="190" y="96" width="380" height="20" rx="4" fill="#ef4444" opacity="0.65"/>
+  <text x="580" y="111" font-size="11" fill="#dc2626">FN 326,253 + FP 49,381 = 375,634</text>
+  <text x="180" y="138" text-anchor="end" fill="#334155" font-size="12">portello</text>
+  <rect x="190" y="126" width="201" height="20" rx="4" fill="#22c55e" opacity="0.85"/>
+  <text x="400" y="141" font-size="11" fill="#166534" font-weight="700">FN 156,775 + FP 42,593 = 199,368  −47%</text>
+  <!-- NA12878 group -->
+  <text x="40" y="190" font-weight="700" fill="#1e293b">NA12878</text>
+  <text x="180" y="218" text-anchor="end" fill="#334155" font-size="12">pbmm2</text>
+  <rect x="190" y="206" width="287" height="20" rx="4" fill="#ef4444" opacity="0.65"/>
+  <text x="488" y="221" font-size="11" fill="#dc2626">FN 163,016 + FP 119,992 = 283,008</text>
+  <text x="180" y="248" text-anchor="end" fill="#334155" font-size="12">portello</text>
+  <rect x="190" y="236" width="204" height="20" rx="4" fill="#22c55e" opacity="0.85"/>
+  <text x="403" y="251" font-size="11" fill="#166534" font-weight="700">FN 73,114 + FP 128,362 = 201,476  −29%</text>
+  <!-- Caption box -->
+  <rect x="60" y="290" width="600" height="50" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="360" y="310" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Same reads, same DeepVariant model, no retraining; only the mapper changed.</text>
+  <text x="360" y="328" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">FN drop ≈ 52–55% in both samples; FP changes are small.</text>
+</svg>
+
+#### Try It Yourself
+
+The two key knobs that decide how big the portello win is on a given sample are (1) the *fraction of reads from hard regions* (VNTRs, segmental duplications, divergent haplotypes) and (2) the *quality of the assembly* the reads were aligned to first. Click through to feel how those interact. The numbers below are illustrative, anchored on the paper's HG002 vs NA12878 contrast.
+
+<style>
+  .ptb-portello-step {
+    border: 1px solid #e2e8f0; border-radius: 10px; padding: 16px 20px; margin: 16px 0;
+  }
+  .ptb-portello-step .ptb-label {
+    display: block; font-size: 13px; color: #475569; margin-bottom: 8px; font-weight: 600;
+  }
+  .ptb-portello-step .ptb-buttons { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+  .ptb-portello-step input[type="radio"] { display: none; }
+  .ptb-portello-step .ptb-btn {
+    padding: 6px 14px; border: 1px solid #cbd5e1; border-radius: 6px;
+    cursor: pointer; font-size: 13px; font-weight: 600; color: #475569;
+    background: #f8fafc; user-select: none;
+  }
+  .ptb-portello-step .ptb-btn:hover { border-color: #3b82f6; color: #1e40af; }
+  .ptb-portello-step .ptb-state { display: none; }
+  .ptb-portello-step input#prt-easy:checked ~ .ptb-buttons label[for="prt-easy"],
+  .ptb-portello-step input#prt-mid:checked  ~ .ptb-buttons label[for="prt-mid"],
+  .ptb-portello-step input#prt-hard:checked ~ .ptb-buttons label[for="prt-hard"],
+  .ptb-portello-step input#prt-bad:checked  ~ .ptb-buttons label[for="prt-bad"] {
+    background: #eff6ff; border-color: #3b82f6; color: #1e40af;
+  }
+  .ptb-portello-step input#prt-easy:checked ~ #prt-s-easy,
+  .ptb-portello-step input#prt-mid:checked  ~ #prt-s-mid,
+  .ptb-portello-step input#prt-hard:checked ~ #prt-s-hard,
+  .ptb-portello-step input#prt-bad:checked  ~ #prt-s-bad { display: block; }
+</style>
+
+<div class="ptb-portello-step">
+  <span class="ptb-label">Sample regime — pick the kind of sample:</span>
+  <input type="radio" name="prt" id="prt-easy">
+  <input type="radio" name="prt" id="prt-mid" checked>
+  <input type="radio" name="prt" id="prt-hard">
+  <input type="radio" name="prt" id="prt-bad">
+
+  <div class="ptb-buttons">
+    <label for="prt-easy" class="ptb-btn">Easy genome, fresh asm</label>
+    <label for="prt-mid"  class="ptb-btn">HG002-like</label>
+    <label for="prt-hard" class="ptb-btn">SV-rich rare-disease</label>
+    <label for="prt-bad"  class="ptb-btn">Externally-built asm</label>
+  </div>
+
+  <div class="ptb-state" id="prt-s-easy">
+    <svg viewBox="0 0 480 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="prt-s-easy-t">
+      <title id="prt-s-easy-t">Easy genome, fresh assembly: small absolute gain.</title>
+      <text x="20" y="22" font-size="12" fill="#64748b" font-weight="600">pbmm2 errors</text>
+      <rect x="120" y="12" width="120" height="18" rx="3" fill="#ef4444" opacity="0.6"/>
+      <text x="20" y="50" font-size="12" fill="#64748b" font-weight="600">portello errors</text>
+      <rect x="120" y="40" width="100" height="18" rx="3" fill="#22c55e" opacity="0.7"/>
+      <text x="240" y="92" font-size="12" fill="#475569">~17% reduction. Easy genomes have few hard regions, so the headroom is small.</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state" id="prt-s-mid">
+    <svg viewBox="0 0 480 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="prt-s-mid-t">
+      <title id="prt-s-mid-t">HG002-like sample: 47% total error reduction.</title>
+      <text x="20" y="22" font-size="12" fill="#64748b" font-weight="600">pbmm2 errors</text>
+      <rect x="120" y="12" width="320" height="18" rx="3" fill="#ef4444" opacity="0.65"/>
+      <text x="20" y="50" font-size="12" fill="#64748b" font-weight="600">portello errors</text>
+      <rect x="120" y="40" width="170" height="18" rx="3" fill="#22c55e" opacity="0.85"/>
+      <text x="240" y="92" font-size="12" fill="#475569">47% reduction (paper's HG002 result). FN drops 52%; FP barely moves.</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state" id="prt-s-hard">
+    <svg viewBox="0 0 480 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="prt-s-hard-t">
+      <title id="prt-s-hard-t">SV-rich rare-disease sample: bigger gain, qualitative.</title>
+      <text x="20" y="22" font-size="12" fill="#64748b" font-weight="600">pbmm2 errors</text>
+      <rect x="120" y="12" width="360" height="18" rx="3" fill="#ef4444" opacity="0.7"/>
+      <text x="20" y="50" font-size="12" fill="#64748b" font-weight="600">portello errors</text>
+      <rect x="120" y="40" width="160" height="18" rx="3" fill="#22c55e" opacity="0.9"/>
+      <text x="240" y="92" font-size="12" fill="#475569">Plausibly larger reduction (extrapolation from the paper's CNV example, not benchmarked).</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state" id="prt-s-bad">
+    <svg viewBox="0 0 480 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="prt-s-bad-t">
+      <title id="prt-s-bad-t">Externally-built assembly: gain still large but FP-heavy baseline.</title>
+      <text x="20" y="22" font-size="12" fill="#64748b" font-weight="600">pbmm2 errors</text>
+      <rect x="120" y="12" width="240" height="18" rx="3" fill="#ef4444" opacity="0.65"/>
+      <text x="20" y="50" font-size="12" fill="#64748b" font-weight="600">portello errors</text>
+      <rect x="120" y="40" width="170" height="18" rx="3" fill="#22c55e" opacity="0.85"/>
+      <text x="240" y="92" font-size="12" fill="#475569">29% reduction (paper's NA12878 result, externally produced Verkko assembly).</text>
+    </svg>
+  </div>
+</div>
+
+#### Implementation
+
+To reason quantitatively about "47% of basecall errors removed", here is the reduction calculation as the paper applies it — treating a *basecall error* as the union of false negatives and false positives, BASEPAIR-metric, summed across the sample.
+
+```python
+from typing import TypedDict
+
+
+class CountsBP(TypedDict):
+    fn: int  # false negatives in the BASEPAIR comparison
+    fp: int  # false positives in the BASEPAIR comparison
+
+
+def basecall_error_reduction(
+    pbmm2: CountsBP,    # FN/FP from conventional read mapping
+    portello: CountsBP, # FN/FP from assembly-based remapping
+) -> dict[str, float]:
+    """Fraction of small-variant basecall errors removed by switching mapper.
+
+    The paper defines `basecall errors = FN + FP` under the BASEPAIR metric,
+    and reports the fraction *removed* by the new mapper. The same caller
+    (DeepVariant v1.9, standard HiFi model) is used in both arms, so any
+    reduction is attributable to mapping, not modeling.
+
+    Returns the total reduction plus the FN- and FP-specific reductions
+    so you can see whether the gain is recall-driven (paper: yes) or
+    precision-driven.
+    """
+    # Step 1: total errors per arm
+    err_pbmm2    = pbmm2["fn"]    + pbmm2["fp"]
+    err_portello = portello["fn"] + portello["fp"]
+
+    # Step 2: relative reduction (positive = portello better)
+    total_red = 1.0 - err_portello / err_pbmm2
+
+    # Step 3: split by error type so you see *where* the win came from
+    fn_red = 1.0 - portello["fn"] / pbmm2["fn"]
+    fp_red = 1.0 - portello["fp"] / pbmm2["fp"]
+
+    return {"total_reduction": total_red, "fn_reduction": fn_red, "fp_reduction": fp_red}
+
+
+# HG002 numbers from Table S1, BASEPAIR row
+hg002 = basecall_error_reduction(
+    pbmm2   ={"fn": 326_253, "fp": 49_381},
+    portello={"fn": 156_775, "fp": 42_593},
+)
+# {'total_reduction': 0.469..., 'fn_reduction': 0.519..., 'fp_reduction': 0.137...}
+```
+
+### Key Takeaways
+
+- **Same reads, same caller, only the mapper changed**: This is the cleanest possible attribution — the gain is in alignment, not in the model.
+- **The win is recall, not precision**: False negatives drop ~52–55% in both samples; false positives barely move. Reads that previously couldn't find their region now do.
+- **F1 understates the clinical impact**: 0.9901 to 0.9948 sounds small until you frame it as 47% of errors removed; for clinical sign-off, every removed false negative is a recovered variant.
+- **Sample matters**: NA12878's 29% total reduction (vs HG002's 47%) is plausibly tied to using an external Verkko assembly rather than a fresh hifiasm assembly built from the same reads — a reasonable read of the data, though the paper does not directly attribute the gap.
+
+---
+
+### Phasing and Haplotagging
+
+#### Overview
+
+Before the result, a quick orientation: *phasing* assigns each variant to one of two parental haplotypes. *Haplotagging* puts that information on the individual reads (so you can color reads by haplotype in IGV, or feed haplotype-aware callers). The standard tags are `HP` (1 or 2, the haplotype) and `PS` (phase set, the contiguous region within which the assignment is internally consistent). Phasing quality is summarized by *block NG50* (a length statistic: the largest L such that 50% of the genome is contained in phase blocks of length ≥ L), *switch errors* (pairs of adjacent variants assigned to the wrong relative haplotype), and *flips* (single-variant inversions, less serious than a switch).
+
+What's nice about portello here is that phasing comes essentially for free. The reads have already been aligned to *specific* contigs from the assembly, and the assembly already encodes haplotype information — either implicitly (in dual-assembly mode, where each contig is *probably* one haplotype but with switch errors), or explicitly (in fully-phased mode, when the assembly was scaffolded with parental sequencing or optical mapping).
+
+In dual-assembly mode (the more common setting for unrelated patients), portello uses a small read-backed scheme: walk along the reference, and at each pair of adjacent heterozygous variants where the two contigs disagree, check that at least one read supports both contig alleles in the same way. If yes, extend the phase set across that pair. If no, end the phase set and start a new one. This is essentially a stripped-down `whatshap`-style phasing, but operating on the contig-derived heterozygous variant set rather than a separately-called variant set.
+
+The numbers reported are intentionally specific to a single sample (HG002), benchmarked with the GIAB T2T draft small-variant truth set: a phase block NG50 of **334,357 bp** with **274 switch errors** and **67 flips**. The authors are explicit that direct evaluation of read haplotag accuracy is fiddly, so they instead emit a phased VCF of heterozygous variants and benchmark *that* with `whatshap compare`. Those numbers are competitive with dedicated read-phasing tools, particularly given that portello obtained them as a side effect of the alignment process rather than a separate phasing step.
+
+The authors are also frank that "with further development, there is significant potential to improve this capability in coordination with a portello-integrated small-variant caller designed to more accurately call small variants from the read-to-contig alignments" — i.e., they think this can get better, and a more integrated phasing-aware caller is the next step.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="phase-tree-title">
+  <title id="phase-tree-title">Two phasing modes in portello: fully-phased contigs vs partially-phased dual assembly.</title>
+  <defs>
+    <marker id="phase-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Portello phasing modes</text>
+  <!-- Root -->
+  <rect x="270" y="50" width="180" height="50" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <text x="360" y="80" text-anchor="middle" font-weight="700" fill="#1e40af">input contigs</text>
+  <line x1="360" y1="100" x2="360" y2="125" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="180" y1="125" x2="540" y2="125" stroke="#64748b" stroke-width="1.5"/>
+  <!-- Fully-phased branch -->
+  <line x1="180" y1="125" x2="180" y2="160" stroke="#64748b" stroke-width="1.5" marker-end="url(#phase-arrow)"/>
+  <rect x="60" y="170" width="240" height="160" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="180" y="194" text-anchor="middle" font-weight="700" fill="#166534">fully-phased</text>
+  <text x="180" y="214" text-anchor="middle" font-size="11" fill="#16a34a">parental seq, optical map</text>
+  <text x="180" y="240" text-anchor="middle" font-size="11" fill="#475569">phase = which contig</text>
+  <text x="180" y="258" text-anchor="middle" font-size="11" fill="#475569">the read aligned to</text>
+  <text x="180" y="288" text-anchor="middle" font-size="11" fill="#16a34a" font-weight="600">no phasing alg needed</text>
+  <text x="180" y="308" text-anchor="middle" font-size="14">&#10003;</text>
+  <!-- Partially-phased branch -->
+  <line x1="540" y1="125" x2="540" y2="160" stroke="#64748b" stroke-width="1.5" marker-end="url(#phase-arrow)"/>
+  <rect x="420" y="170" width="240" height="160" rx="10" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text x="540" y="194" text-anchor="middle" font-weight="700" fill="#854d0e">partially-phased</text>
+  <text x="540" y="214" text-anchor="middle" font-size="11" fill="#ca8a04">hifiasm dual assembly</text>
+  <text x="540" y="240" text-anchor="middle" font-size="11" fill="#475569">walk adjacent het pairs;</text>
+  <text x="540" y="258" text-anchor="middle" font-size="11" fill="#475569">extend block when one read</text>
+  <text x="540" y="276" text-anchor="middle" font-size="11" fill="#475569">spans both</text>
+  <text x="540" y="305" text-anchor="middle" font-size="11" fill="#854d0e" font-weight="600">block NG50 = 334 kb</text>
+  <text x="360" y="362" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">HG002 partially-phased mode: 274 switch errors + 67 flips, GIAB T2T benchmark.</text>
+</svg>
+
+### Key Takeaways
+
+- **Phasing comes free with mapping**: Because portello already knows which contig each read came from, the haplotype tag is essentially a lookup — no separate phasing pass.
+- **Two modes, by assembly quality**: Fully-phased contigs (rare today) need no algorithm; partially-phased dual assemblies (the common case) get a small read-backed extension scheme.
+- **Quality is competitive, not state-of-the-art**: Block NG50 of 334 kb with 274 switches on HG002 is in the ballpark of dedicated tools; the authors explicitly flag room for improvement when a phasing-aware caller is added.
+
+---
+
+### CNV Interpretation in Segmental Duplications
+
+#### Overview
+
+Before the result, a quick orientation: *segmental duplications* are large (typically ≥ 10 kb) regions where two or more nearly-identical copies of a sequence appear elsewhere in the genome. They are notoriously hard for short-read mapping and even for long-read mapping, because a read's exact origin within the duplicate family is sometimes genuinely ambiguous — the copies are too similar. *Copy-number variants* (CNVs) in these regions are clinically meaningful; the example here, on chromosome 22, falls in a region implicated in the 22q11.2 deletion/duplication syndromes that affect heart, palate, and immune development.
+
+The result in this section is qualitative — a single locus, walked through — but it is the most clinically vivid result in the paper. The locus is a 225 kb duplication segment in NA21886, confirmed by a clinical microarray as a copy gain. The authors run conventional pbmm2 mapping and portello on the same reads and visualize the coverage profile.
+
+The pbmm2 view is unusable for CNV calling: a coverage spike of nearly **12,000-fold** (vs. an expected ~30× for the rest of the genome), followed by a coverage *dropout* across the genes DGCR6 and PRODH. This shape is characteristic of misplacement — reads from multiple copies of the segmental duplication pile onto a single reference homolog, while the reference homologs that should have received them are starved. A clinician looking at this in IGV would see noise.
+
+The portello view shows a *3-fold* coverage region tracking the array segment. That is (i) a clean ~3× bump (consistent with three total copies, i.e. one extra copy on one haplotype), (ii) sized to match the array call, and (iii) *partitionable* by contig: because the reads are tagged with the contig they aligned through, you can split the pileup into its source contigs and check whether the contigs themselves represent a sequence compression. That last property — a contig-aware view of a CNV — is the new diagnostic capability portello unlocks beyond just "cleaner coverage".
+
+#### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="cnv-coverage-title">
+  <title id="cnv-coverage-title">Coverage profile across the chr22 225 kb duplication: pbmm2 spike vs portello clean 3-fold.</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Coverage at the chr22 225 kb segdup CNV</text>
+  <!-- pbmm2 panel -->
+  <rect x="20" y="50" width="320" height="300" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="180" y="76" text-anchor="middle" font-weight="700" fill="#991b1b">pbmm2 (conventional)</text>
+  <!-- y-axis labels -->
+  <text x="34" y="240" font-size="10" fill="#64748b">30×</text>
+  <text x="34" y="200" font-size="10" fill="#64748b">90×</text>
+  <text x="34" y="120" font-size="10" fill="#64748b">12,000×</text>
+  <line x1="55" y1="100" x2="55" y2="320" stroke="#94a3b8" stroke-width="1"/>
+  <line x1="55" y1="320" x2="320" y2="320" stroke="#94a3b8" stroke-width="1"/>
+  <!-- Coverage trace: spike then dropout -->
+  <polyline points="60,240 110,240 130,238 150,232 170,108 190,108 200,232 220,316 240,316 260,316 280,232 320,240"
+            fill="none" stroke="#dc2626" stroke-width="2"/>
+  <!-- Annotation -->
+  <text x="180" y="98" text-anchor="middle" font-size="10" font-weight="600" fill="#dc2626">12,000× spike</text>
+  <text x="240" y="338" text-anchor="middle" font-size="10" font-weight="600" fill="#dc2626">dropout: DGCR6 / PRODH</text>
+  <!-- portello panel -->
+  <rect x="380" y="50" width="320" height="300" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="540" y="76" text-anchor="middle" font-weight="700" fill="#166534">portello (assembly-based)</text>
+  <text x="394" y="240" font-size="10" fill="#64748b">30×</text>
+  <text x="394" y="200" font-size="10" fill="#64748b">90×</text>
+  <line x1="415" y1="100" x2="415" y2="320" stroke="#94a3b8" stroke-width="1"/>
+  <line x1="415" y1="320" x2="680" y2="320" stroke="#94a3b8" stroke-width="1"/>
+  <!-- Coverage trace: clean ~3x bump -->
+  <polyline points="420,240 460,240 480,240 500,200 520,200 540,200 560,200 580,200 600,200 620,200 640,240 680,240"
+            fill="none" stroke="#16a34a" stroke-width="2"/>
+  <text x="540" y="190" text-anchor="middle" font-size="10" font-weight="600" fill="#166534">3× coverage = +1 copy</text>
+  <text x="540" y="338" text-anchor="middle" font-size="10" fill="#475569">tracks the 225 kb array segment</text>
+  <text x="360" y="368" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Schematic adapted from the paper's Figure 3; coverage shapes are representative, not pixel-exact.</text>
+</svg>
+
+### Key Takeaways
+
+- **Conventional mapping crashes on segdups**: A 12,000× spike + adjacent dropout is the signature of read misplacement, not of the underlying biology.
+- **Portello yields an interpretable 3×**: The CNV's true shape (one extra copy on one haplotype) shows up cleanly, sized to match the array call.
+- **Contig-grouped pileup is new diagnostic information**: Splitting the pileup by source contig is unique to assembly-based read mapping and lets you sanity-check whether the assembly itself compressed the region.
+- **Demonstration, not benchmark**: This is a single-locus illustration; the authors do not yet present a genome-wide CNV F1 number for portello.
+
+---
+
+## Methods
+
+### Read Mapping Transfer Algorithm
+
+#### Overview
+
+Before the algorithm, a quick orientation: think of read-to-contig alignment as a function `R: read → contig coordinates`, and contig-to-reference alignment as `C: contig coordinate → reference coordinate`. The composition `C ° R` gives `read → reference coordinates` — that's portello's job. The two practical complications are (1) split alignments (a single read can be split across several segments of contig coordinates, and a single contig can be split across several reference segments) and (2) inconsistent indel representations between the two coordinate systems.
+
+The algorithm, in three pieces:
+
+1. **Pre-process the contig-to-reference mapping**. Two cleanup steps. *Repeated matches trimming*: for each pair of overlapping contig alignments to the reference, retain the alignment with higher gap-compressed identity and clip the others, ensuring each contig base is mapped to the reference at most once. (`pbmm2`, the recommended read-to-contig mapper, does the analogous step on its side, so each *read* base also maps once.) *Joining co-linear segments*: when minimap2 splits a contig alignment into pieces because of a Z-drop dip, but the pieces are still in the same orientation and order, portello rejoins them into a single segment, encoding any unmapped intervening contig sequence as an insertion. This both improves variant calling accuracy and makes downstream visualization saner.
+
+2. **Compose the alignments**. For each read, walk through its alignment to its contig, and for each contig position the read covers, look up the contig-to-reference alignment to get a reference position. Concatenate the resulting per-position correspondences into a CIGAR string. Handle split contig alignments by emitting separate read-to-reference segments where appropriate.
+
+3. **Normalize indels**. Both inputs follow the convention that insertions and deletions are *left-shifted* (placed at the leftmost coordinate consistent with the alignment). When a contig segment was mapped to the reference in *reverse* orientation, the read's indels need to be re-left-shifted in the reference frame to preserve this property — otherwise a region whose two haplotypes are represented by oppositely-oriented contigs would emit a mixture of left- and right-shifted variants, which downstream callers handle inconsistently.
+
+The careful indel handling (step 3) is the kind of detail that doesn't show up until you actually run a caller on the output and notice that a region with two haplotypes pointing different directions is producing duplicated variants.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="meth-pipe-title">
+  <title id="meth-pipe-title">Portello read-mapping transfer pipeline.</title>
+  <defs>
+    <marker id="meth-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Read-mapping transfer pipeline</text>
+  <!-- Inputs -->
+  <rect x="20" y="60" width="200" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="120" y="86" text-anchor="middle" font-weight="600" fill="#92400e">read → contig BAM</text>
+  <text x="120" y="106" text-anchor="middle" font-size="11" fill="#64748b">pbmm2, --eqx</text>
+  <rect x="20" y="140" width="200" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="120" y="166" text-anchor="middle" font-weight="600" fill="#92400e">contig → reference BAM</text>
+  <text x="120" y="186" text-anchor="middle" font-size="11" fill="#64748b">minimap2 -x asm5 --eqx</text>
+  <!-- Step 1 -->
+  <line x1="220" y1="170" x2="270" y2="170" stroke="#64748b" stroke-width="1.5" marker-end="url(#meth-arrow)"/>
+  <rect x="280" y="135" width="160" height="70" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="360" y="160" text-anchor="middle" font-weight="600" fill="#1e40af">pre-process</text>
+  <text x="360" y="178" text-anchor="middle" font-size="11" fill="#475569">trim repeated matches</text>
+  <text x="360" y="194" text-anchor="middle" font-size="11" fill="#475569">join co-linear segments</text>
+  <!-- Step 2 -->
+  <line x1="120" y1="120" x2="120" y2="240" stroke="#64748b" stroke-width="1.5" stroke-dasharray="4,4"/>
+  <line x1="360" y1="205" x2="360" y2="240" stroke="#64748b" stroke-width="1.5" stroke-dasharray="4,4"/>
+  <rect x="220" y="240" width="280" height="60" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="2"/>
+  <text x="360" y="266" text-anchor="middle" font-weight="700" fill="#6b21a8">compose: (C ° R) per read</text>
+  <text x="360" y="284" text-anchor="middle" font-size="11" fill="#475569">handles split alignments; left-shifts indels</text>
+  <!-- Output -->
+  <line x1="500" y1="270" x2="540" y2="270" stroke="#64748b" stroke-width="1.5" marker-end="url(#meth-arrow)"/>
+  <rect x="540" y="240" width="160" height="60" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="620" y="266" text-anchor="middle" font-weight="700" fill="#166534">read → reference BAM</text>
+  <text x="620" y="284" text-anchor="middle" font-size="11" fill="#64748b">+ HP / PS tags</text>
+  <text x="360" y="338" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">--eqx CIGAR (= / X) is required; no model retraining downstream.</text>
+</svg>
+
+#### Implementation
+
+A toy of step 2 (composition) on a single read. The real implementation handles split alignments, reverse-strand mapping, and CIGAR encoding; this version exists to make the lookup geometry concrete.
+
+```python
+import numpy as np
+
+
+def transfer_read_alignment(
+    read_to_contig: np.ndarray,   # (L, 2) — (read_pos, contig_pos) per matched base
+    contig_to_ref: np.ndarray,    # (M, 2) — (contig_pos, ref_pos) per matched base
+) -> np.ndarray:
+    """Compose read->contig and contig->reference into read->reference.
+
+    Each input is a sorted table of base-level correspondences (the
+    expanded form of a CIGAR with --eqx). For each read base, we look
+    up the contig base it touches, then look up the reference base
+    that contig base maps to. Bases without a contig->reference
+    correspondence (insertions in the contig vs reference) are
+    dropped; in the real implementation they would be encoded as
+    insertions in the output CIGAR.
+    """
+    # Step 1: build a contig_pos -> ref_pos lookup. The contig table is
+    # already sorted; np.searchsorted gives O(log M) per query.
+    contig_keys = contig_to_ref[:, 0]
+
+    # Step 2: for each read base, find the contig position it touches,
+    # then resolve that contig position to a reference position.
+    out: list[tuple[int, int]] = []
+    for read_pos, contig_pos in read_to_contig:
+        idx = np.searchsorted(contig_keys, contig_pos)
+        # Drop read bases whose contig pos isn't in the contig->ref map
+        # (these are insertions in the contig relative to the reference).
+        if idx < len(contig_keys) and contig_keys[idx] == contig_pos:
+            out.append((int(read_pos), int(contig_to_ref[idx, 1])))
+
+    # Step 3: return as a (K, 2) array — sorted by read_pos by construction.
+    return np.array(out, dtype=np.int64) if out else np.empty((0, 2), dtype=np.int64)
+```
+
+### Phase Set Construction
+
+#### Overview
+
+Before the algorithm, a quick orientation: a *phase set* is the contiguous reference region within which haplotype assignments (`HP=1`/`HP=2`) are internally consistent. Within a phase set, all the reads with `HP=1` are believed to come from the same parental haplotype; *between* phase sets, the labels reset (so `HP=1` in phase set A does not mean the same parent as `HP=1` in phase set B). The bigger and longer your phase sets, the more useful the phasing.
+
+In partially-phased mode, portello builds phase sets by:
+
+1. Find regions of the reference where exactly two contigs cover the same span (these are the regions where a haplotype assignment is even possible).
+2. Within those regions, identify *heterozygous variants*: positions where the two contigs disagree with each other and at least one disagrees with the reference. Use these as anchor points.
+3. Walk along adjacent het-variant pairs; if at least one read's read-to-contig alignment supports both the upstream and downstream contig allele *in the same way*, the pair is "linked" — extend the current phase set across it. If no read supports the linkage, start a new phase set.
+
+Haplotype index (`HP=1` vs `HP=2`) is then assigned within each phase set by which of the two contigs each read aligned to. The conservative-overlap rule the paper describes — intervals overlap only if the intersection exceeds `min(24 kb, &#8531; of new interval length)` — is what stops a single small spurious overlap from collapsing two real contigs into one haplotype index.
+
+This is roughly *read-backed phasing* (the standard whatshap recipe) but with the heterozygous variant set coming directly from the contig-to-reference alignment rather than a separate variant calling pass. That is a small but meaningful shift — the heterozygous calls are *implicit* in the assembly, so portello inherits them without an extra step.
+
+### Key Takeaways
+
+- **Composition is mostly bookkeeping**: The hard parts are split alignments and indel left-shifting around inverted contig segments — not the matrix multiply you'd expect.
+- **`--eqx` is mandatory**: Both alignments must use `=`/`X` CIGAR ops, not `M`. The standard `M` op doesn't distinguish match from mismatch, which makes the composition ambiguous.
+- **Phase sets are walks over het-variant pairs**: A read-backed extension scheme over implicit-from-contigs heterozygous variants — no separate variant call required.
+
+---
+
+## Discussion
+
+### Overview
+
+The paper's framing of its own contribution is interesting and worth taking seriously. The variant-calling accuracy gain — the number people will quote — is deliberately positioned as *one* benefit, not *the* benefit. The authors argue that the *operational* improvement (assembly-based and reference-based pipelines unified onto a consistent view of the sample) may matter more in the long run, because it removes the integration friction that has kept assembly out of clinical workflows.
+
+There are two forward-looking claims the authors make that are worth holding lightly. First, they note that hybrid variant callers integrating contig and read inputs to portello are a natural next step — CNV calling being the most obvious target, since the chr22 example demonstrates how much information becomes available when reads are tagged with their source contig. They don't quantify this in the paper; they outline it as a direction. Second, they argue that with portello, a contig-based SV caller (PAV is cited) could be combined with a read-based small-variant caller, with all calls landing on the same coordinate system and the same review tools. This combination is *enabled* by portello rather than *demonstrated* by it.
+
+The honest limitation: this paper is a method paper with two sample evaluations (HG002 and NA12878), one demonstrative CNV locus (NA21886), and a phasing benchmark on one of those samples. It is not a clinical study. The claim is "this should help rare-disease analysis", and the evidence supports the *should*, particularly in segdups and VNTRs, but a real evaluation on a rare-disease cohort — with diagnostic yield as the endpoint — remains future work. The CNV story in particular is a single locus; the paper does not yet present a genome-wide CNV F1 vs conventional methods.
+
+There are also dependencies worth naming. Portello inherits the assembly's quality. If the assembly mis-resolves a haplotype switch, the read mapping inherits that error. The authors are explicit about this in the partially-phased section. A phasing-aware caller designed for portello inputs, plus better dual-assembly accuracy, are the two upstream shifts that would compound the wins shown here.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="disc-roadmap-title">
+  <title id="disc-roadmap-title">What portello unlocks: from current results to anticipated future capabilities.</title>
+  <defs>
+    <marker id="disc-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Portello: shown in this paper vs anticipated</text>
+  <!-- Now -->
+  <text x="80" y="64" font-weight="700" fill="#1e293b">Shown</text>
+  <rect x="20" y="80" width="280" height="60" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="160" y="104" text-anchor="middle" font-weight="600" fill="#166534">DeepVariant: -47% small-var errors (HG002)</text>
+  <text x="160" y="124" text-anchor="middle" font-size="11" fill="#475569">no model retraining</text>
+  <rect x="20" y="160" width="280" height="60" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="160" y="184" text-anchor="middle" font-weight="600" fill="#166534">phasing as a side effect</text>
+  <text x="160" y="204" text-anchor="middle" font-size="11" fill="#475569">block NG50 = 334 kb</text>
+  <rect x="20" y="240" width="280" height="60" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="160" y="264" text-anchor="middle" font-weight="600" fill="#166534">CNV interpretability: 1 locus</text>
+  <text x="160" y="284" text-anchor="middle" font-size="11" fill="#475569">illustrative, chr22 segdup</text>
+  <!-- Arrows -->
+  <line x1="300" y1="110" x2="380" y2="110" stroke="#64748b" stroke-width="1.5" marker-end="url(#disc-arrow)"/>
+  <line x1="300" y1="190" x2="380" y2="190" stroke="#64748b" stroke-width="1.5" marker-end="url(#disc-arrow)"/>
+  <line x1="300" y1="270" x2="380" y2="270" stroke="#64748b" stroke-width="1.5" marker-end="url(#disc-arrow)"/>
+  <!-- Anticipated -->
+  <text x="540" y="64" font-weight="700" fill="#1e293b">Anticipated</text>
+  <rect x="380" y="80" width="320" height="60" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="540" y="104" text-anchor="middle" font-weight="600" fill="#6b21a8">portello-aware small-variant caller</text>
+  <text x="540" y="124" text-anchor="middle" font-size="11" fill="#475569">jointly modeling read-to-contig + contig-to-ref</text>
+  <rect x="380" y="160" width="320" height="60" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="540" y="184" text-anchor="middle" font-weight="600" fill="#6b21a8">unified SV + small-var calling</text>
+  <text x="540" y="204" text-anchor="middle" font-size="11" fill="#475569">PAV (contigs) + DeepVariant (reads), one BAM</text>
+  <rect x="380" y="240" width="320" height="60" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="540" y="264" text-anchor="middle" font-weight="600" fill="#6b21a8">genome-wide CNV F1</text>
+  <text x="540" y="284" text-anchor="middle" font-size="11" fill="#475569">contig-grouped pileups as training signal</text>
+  <text x="360" y="340" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Right column: the authors flag these as natural directions; not benchmarked in this paper.</text>
+</svg>
+
+### Key Takeaways
+
+- **Operational unification may be the bigger story**: The variant-calling number is what gets quoted, but the authors explicitly frame the unification of assembly-based and reference-based pipelines as the deeper benefit.
+- **Hybrid callers are next**: A portello-aware caller that jointly models read-to-contig and contig-to-reference alignments is the natural follow-up; the paper outlines this rather than delivering it.
+- **Method, not clinical, evidence**: The 47% number is a benchmark result, not a diagnostic-yield result. Whether it translates to more rare-disease diagnoses per 100 cases is the right question for the next study.
+- **Quality compounds upstream**: Portello inherits assembly quality. A phasing-aware caller plus better dual-assembly accuracy would multiply with portello's gains rather than replacing them.
+
+---
+
+## Key Takeaways (Summary)
+
+- **Composition over mapping**: Portello replaces a single hard problem (read → reference, mixing sequencing error and biological variation) with two easy ones (read → contig + contig → reference) and composes them.
+- **47% / 29% small-variant error reduction, no model retraining**: DeepVariant on portello-remapped reads recovers about half of HG002's previously missed variants and a third of NA12878's, with false positives essentially flat.
+- **Phasing as a free side effect**: The contig that a read aligned through is also a haplotype hint; portello carries `HP` and `PS` tags through the alignment transfer in one step.
+- **Segdups become legible**: 12,000× pbmm2 spikes turn into clean 3× portello shoulders that match the array call — a qualitative leap for clinical CNV review.
+- **The integration story is the integration story**: A reference-coordinate BAM produced via the assembly is what makes assembly-based analysis usable inside an existing reference-based pipeline. The variant-calling improvements are real, but the operational unification is what closes the loop.

--- a/assets/blogs/0022-spike-sparse-sink-anatomy-massive.md
+++ b/assets/blogs/0022-spike-sparse-sink-anatomy-massive.md
@@ -1,0 +1,1081 @@
+@{id = "c093aed3-559a-4e9e-ac23-a4a81faa2315"
+  title = "The Spike, the Sparse and the Sink: Anatomy of Massive Activations and Attention Sinks"
+  date = "2026-04-29T00:00:00Z"
+  tags = ['journal club', 'machine learning', 'arxiv', 'language models', 'interpretability', 'quantization']
+  views = 0
+  likes = 0
+  image = "https://storage.googleapis.com/gn-portfolio/images/spike-sparse-sink-anatomy-massive-thumb.svg"
+  description = "Sun, Canziani, LeCun, and Zhu dissect why pre-norm LLMs grow giant outlier activations and attention sinks together, then show the two phenomena are decoupled architectural artifacts you can suppress independently."
+  type = "note"
+  disabled = "false"
+}
+
+<p align="center">
+  <img src="https://storage.googleapis.com/gn-portfolio/images/spike-sparse-sink-anatomy-massive-thumb.svg" max-width="700">
+</p>
+
+
+# The Spike, the Sparse and the Sink: Anatomy of Massive Activations and Attention Sinks
+
+*Analysis of Sun, Canziani, LeCun, Zhu (2026), New York University — arXiv preprint*
+*Generated on April 29, 2026*
+
+---
+
+## Table of Contents
+
+- [Abstract](#abstract)
+- [Introduction](#introduction)
+- [Preliminaries (Pre-Norm Transformer)](#preliminaries-pre-norm-transformer)
+- [The Emergence of Massive Activations](#the-emergence-of-massive-activations)
+- [The Emergence of Attention Sinks](#the-emergence-of-attention-sinks)
+- [Anatomy by Ablation](#anatomy-by-ablation)
+  - [Feed-Forward Block Design](#feed-forward-block-design)
+  - [Normalization Configuration](#normalization-configuration)
+  - [Attention Head Settings](#attention-head-settings)
+  - [Gated Attention](#gated-attention)
+  - [Training Context Length](#training-context-length)
+- [Discussion](#discussion)
+- [Key Takeaways (Summary)](#key-takeaways-summary)
+
+---
+
+## Abstract
+
+### Overview
+
+Two strange things keep showing up in large language models, and nobody has been able to explain why they travel together. The first is **massive activations**: a handful of tokens (almost always the very first token in a sequence, sometimes a period or a newline) carry hidden-state values *thousands* of times larger than the rest of the network. The second is **attention sinks**: those same tokens absorb a huge slice of attention probability across many heads, regardless of what the prompt is about. Sun, Canziani, LeCun and Zhu set out to ask whether these are two faces of the same mechanism, or two phenomena that just happen to land on the same tokens.
+
+If you have only worked at the application layer of LLMs, both terms can sound exotic, so a quick orientation. A modern decoder-only Transformer (think Llama or Qwen) is a stack of layers; each layer reads the running hidden state, applies a normalization step (RMSNorm — just rescale each row to unit RMS), and then either does multi-head attention or a SwiGLU feed-forward block. The output is added back to the running state via a residual connection. "Pre-norm" means the normalization happens *before* the block, not after; this design has become essentially universal because it trains more stably than the original "post-norm" Transformer. The catch — and this paper's central thesis — is that pre-norm has a side effect: the residual stream can accumulate unbounded values, and the model learns to use that.
+
+The headline finding is that the co-occurrence is *not* a fundamental property of Transformers. It is an artifact of the pre-norm design plus the training recipe. Massive activations and attention sinks serve **related but distinct** functions: spikes act *globally* (a few channels carry a near-constant signal across all intermediate layers, behaving like implicit bias parameters baked into the residual stream), while sinks act *locally* (specific heads route excess attention into the spike token to bias themselves toward short-range dependencies). Crucially, the authors show you can suppress either phenomenon without harming the model. Swap RMSNorm for a sandwich-norm or QKNorm and the spikes vanish but the sinks remain. Add per-head conditional gating and the sinks vanish but the spikes remain (sort of — they fall too in some configurations).
+
+That decoupling matters because both phenomena have caused real engineering pain. Quantization — squeezing model weights and activations into 8-bit or 4-bit integers to make inference fast — gets brittle when a few channels carry values in the thousands. KV-cache eviction strategies need special handling for sink tokens or model quality collapses. If we can choose to keep one and drop the other, the cost-quality frontier widens.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 420" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="abs-diag-title">
+  <title id="abs-diag-title">Massive activations and attention sinks: same tokens, different functions</title>
+  <defs>
+    <marker id="abs-arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    Two phenomena, one token
+  </text>
+  <!-- Center token -->
+  <rect x="290" y="170" width="140" height="60" rx="10" fill="#fef3c7" stroke="#92400e" stroke-width="2"/>
+  <text x="360" y="195" text-anchor="middle" font-weight="700" fill="#92400e">first token</text>
+  <text x="360" y="215" text-anchor="middle" font-size="11" fill="#92400e">(or a delimiter)</text>
+  <!-- Spike (global) on left -->
+  <rect x="30" y="80" width="220" height="70" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
+  <text x="140" y="106" text-anchor="middle" font-weight="700" fill="#991b1b">Massive activation</text>
+  <text x="140" y="126" text-anchor="middle" font-size="11" fill="#991b1b">few channels, magnitudes 1000+</text>
+  <text x="140" y="142" text-anchor="middle" font-size="11" fill="#991b1b" font-style="italic">role: global, implicit parameter</text>
+  <line x1="220" y1="150" x2="290" y2="190" stroke="#ef4444" stroke-width="1.5" marker-end="url(#abs-arr)"/>
+  <!-- Sink (local) on right -->
+  <rect x="470" y="80" width="220" height="70" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <text x="580" y="106" text-anchor="middle" font-weight="700" fill="#1e40af">Attention sink</text>
+  <text x="580" y="126" text-anchor="middle" font-size="11" fill="#1e40af">most attention mass routed here</text>
+  <text x="580" y="142" text-anchor="middle" font-size="11" fill="#1e40af" font-style="italic">role: local, per-head router</text>
+  <line x1="500" y1="150" x2="430" y2="190" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#abs-arr)"/>
+  <!-- Bridge: normalization -->
+  <rect x="200" y="270" width="320" height="60" rx="10" fill="#faf5ff" stroke="#a855f7" stroke-width="2"/>
+  <text x="360" y="296" text-anchor="middle" font-weight="700" fill="#6b21a8">Pre-norm RMSNorm bridges them</text>
+  <text x="360" y="315" text-anchor="middle" font-size="11" fill="#6b21a8">collapses spike tokens to a sparse near-constant vector</text>
+  <line x1="360" y1="230" x2="360" y2="270" stroke="#a855f7" stroke-width="1.5" marker-end="url(#abs-arr)"/>
+  <text x="360" y="365" text-anchor="middle" font-size="12" fill="#475569" font-style="italic">
+    Swap the normalizer and the two phenomena decouple.
+  </text>
+  <text x="360" y="385" text-anchor="middle" font-size="11" fill="#64748b">
+    They look like one thing because they share a token, but they are two.
+  </text>
+</svg>
+
+### Key Takeaways
+
+- **Two phenomena, one token, one bridge**: massive activations and attention sinks frequently land on the same first / delimiter tokens, but the bridge between them is normalization, not a single underlying mechanism.
+- **Different jobs**: spikes operate as global, near-constant implicit parameters in the residual stream; sinks operate as local, per-head attention routers.
+- **Suppressible independently**: swap RMSNorm for sandwich-norm or QKNorm and spikes vanish; add conditional gating and sinks vanish. Either is possible without measurable language-modeling cost.
+
+---
+
+## Introduction
+
+### Overview
+
+To see why this paper is more than an interpretability curiosity, it helps to walk through how the field arrived here. When the original Transformer was published in 2017, attention was a clean idea: every token computes a softmax over the keys of every other token, and the resulting weights say "attend here this much". Five or six years and many trillions of parameters later, we know the *behavior* of attention in trained LLMs is not always so clean. Two specific oddities have been documented and re-documented: certain hidden activations are gigantic compared to typical values, and certain tokens (especially the first one in a sequence) absorb most of the attention mass even when they are semantically irrelevant.
+
+The first hints of "outlier dimensions" came from BERT-era work in 2021 (Kovaleva et al.) and from Dettmers et al.'s 2022 quantization paper, which found that 8-bit quantization of GPT-3 only worked if you handled a few outlier channels in higher precision. The second oddity — attention sinks — was named and characterized by Xiao et al. in 2024, who showed that streaming inference works well only when you keep the first few tokens around as "sinks". Sun et al. (2024) brought the two together by showing the outlier tokens *are* the sink tokens, but framed the link as observational. This paper is the mechanistic follow-up: it asks *why* they share tokens, and *what each phenomenon is for*.
+
+The "why now?" is largely about practical pressure. Modern LLM serving lives or dies by quantization (FP16 weights and activations are too expensive at scale, so the field has driven hard into INT8, INT4, and now FP4 / NVFP4). Massive activations sabotage low-precision arithmetic because their magnitudes do not fit into the dynamic range of small integer types (BondarenkoĀ etĀ al., 2021; Wei et al., 2022). At the same time, the success of long-context inference techniques like StreamingLLM (Xiao et al., 2024b) and adaptive KV-cache eviction (Ge et al., 2024) hinges on protecting sink tokens. So if you are an LLM systems engineer in 2026, you have been simultaneously trying to *suppress* spikes (for quantization) and *preserve* sinks (for long-context fidelity). It would be very useful to know whether you have to trade off, or whether the two can be controlled independently. This paper says you can.
+
+The paper makes three central claims, which structure the rest of the post:
+
+1. **Normalization is the bridge.** Standard pre-norm RMSNorm allows residual values to grow unbounded across layers and then collapses spike tokens into a sparse, nearly-constant vector. That collapse is what *enables* sinks — without it, you cannot reliably separate sink keys from non-sink keys. Swap the normalizer and the bridge breaks.
+2. **Sinks are driven by attention dimensionality and training context length.** Larger per-head dimension gives the geometry room to separate sink keys from non-sink keys; mixed short / long context training makes sinks *useful* as a way to dump attention.
+3. **Independent suppression is possible without quality cost.** Architectural choices that eliminate spikes do not necessarily destroy sinks, and vice versa. The two are not functionally fused.
+
+A note on terminology used throughout: a **spike token** is a token where massive activations appear; a **spike channel** is one of the few hidden-state dimensions where the magnitudes get huge. A **sink token** is a token that absorbs disproportionate attention; a **sink head** is an attention head that routes most of its mass into the sink token. Empirically these largely overlap in pre-norm LLMs — that is the puzzle.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="intro-diag-title">
+  <title id="intro-diag-title">A short history of outliers and sinks in Transformer LLMs</title>
+  <defs>
+    <marker id="int-arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    Where this paper sits
+  </text>
+  <!-- Timeline axis -->
+  <line x1="60" y1="320" x2="660" y2="320" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="60" y="345" text-anchor="middle" font-size="11" fill="#64748b">2017</text>
+  <text x="200" y="345" text-anchor="middle" font-size="11" fill="#64748b">2021–22</text>
+  <text x="370" y="345" text-anchor="middle" font-size="11" fill="#64748b">2024</text>
+  <text x="540" y="345" text-anchor="middle" font-size="11" fill="#64748b">2024–25</text>
+  <text x="660" y="345" text-anchor="middle" font-size="11" fill="#64748b">2026</text>
+  <!-- Marker dots -->
+  <circle cx="60" cy="320" r="5" fill="#94a3b8"/>
+  <circle cx="200" cy="320" r="5" fill="#3b82f6"/>
+  <circle cx="370" cy="320" r="5" fill="#ef4444"/>
+  <circle cx="540" cy="320" r="5" fill="#a855f7"/>
+  <circle cx="660" cy="320" r="6" fill="#22c55e"/>
+  <!-- Boxes above markers -->
+  <rect x="20" y="60" width="120" height="80" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="80" y="82" text-anchor="middle" font-weight="600" fill="#334155" font-size="12">Transformer</text>
+  <text x="80" y="100" text-anchor="middle" font-size="11" fill="#64748b">Vaswani et al.</text>
+  <text x="80" y="118" text-anchor="middle" font-size="11" fill="#64748b">post-norm origin</text>
+  <rect x="150" y="60" width="120" height="80" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="210" y="82" text-anchor="middle" font-weight="600" fill="#1e40af" font-size="12">Outliers</text>
+  <text x="210" y="100" text-anchor="middle" font-size="11" fill="#1e40af">Kovaleva, Dettmers</text>
+  <text x="210" y="118" text-anchor="middle" font-size="11" fill="#64748b">quantization breaks</text>
+  <rect x="305" y="60" width="130" height="80" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="370" y="82" text-anchor="middle" font-weight="600" fill="#991b1b" font-size="12">Sinks named</text>
+  <text x="370" y="100" text-anchor="middle" font-size="11" fill="#991b1b">Xiao et al.</text>
+  <text x="370" y="118" text-anchor="middle" font-size="11" fill="#64748b">streaming LLMs</text>
+  <rect x="475" y="60" width="130" height="80" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="540" y="82" text-anchor="middle" font-weight="600" fill="#6b21a8" font-size="12">Co-occurrence</text>
+  <text x="540" y="100" text-anchor="middle" font-size="11" fill="#6b21a8">Sun et al. 2024</text>
+  <text x="540" y="118" text-anchor="middle" font-size="11" fill="#64748b">same tokens (descriptive)</text>
+  <rect x="600" y="160" width="100" height="100" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="650" y="184" text-anchor="middle" font-weight="700" fill="#166534" font-size="12">This paper</text>
+  <text x="650" y="204" text-anchor="middle" font-size="11" fill="#166534">mechanism +</text>
+  <text x="650" y="220" text-anchor="middle" font-size="11" fill="#166534">causal ablation</text>
+  <text x="650" y="240" text-anchor="middle" font-size="11" fill="#166534" font-style="italic">decouples them</text>
+  <!-- Connectors -->
+  <line x1="80" y1="140" x2="80" y2="315" stroke="#94a3b8" stroke-dasharray="3,3"/>
+  <line x1="210" y1="140" x2="210" y2="315" stroke="#3b82f6" stroke-dasharray="3,3"/>
+  <line x1="370" y1="140" x2="370" y2="315" stroke="#ef4444" stroke-dasharray="3,3"/>
+  <line x1="540" y1="140" x2="540" y2="315" stroke="#a855f7" stroke-dasharray="3,3"/>
+  <line x1="650" y1="260" x2="650" y2="315" stroke="#22c55e" stroke-dasharray="3,3"/>
+</svg>
+
+### Key Takeaways
+
+- **The puzzle is mechanistic, not observational**: previous work established that spikes and sinks share tokens. This paper explains *why* they share tokens and *what each phenomenon does*.
+- **Practical stakes are quantization and long-context inference**: spikes break low-precision arithmetic; sinks support short-range routing. Engineers want to control them separately.
+- **Three claims drive the paper**: normalization is the bridge, sinks live in head-dimension and context-length, and either can be suppressed alone.
+
+---
+
+## Preliminaries (Pre-Norm Transformer)
+
+### Overview
+
+Before diving into the mechanism, lock in the architecture the paper is studying. A modern Llama / Qwen-style decoder-only Transformer is a stack of `2L` blocks — alternating attention and feed-forward — with a single hidden-state matrix `H` flowing through. Each block applies the **pre-norm + residual** rule:
+
+```
+H_{i+1} = H_i + F_i(RMSNorm(H_i))
+```
+
+A few terms to defuse, since not everyone has stared at this equation for years.
+
+- **RMSNorm**: a simpler cousin of LayerNorm. It divides each row of `H` by its L2 norm and rescales to `sqrt(d_model)`. Where LayerNorm subtracts the mean and divides by the std, RMSNorm just divides by the RMS. It is faster and works just as well in practice (Zhang & Sennrich, 2019), which is why every modern LLM uses it.
+- **Pre-norm vs post-norm**: in pre-norm (every modern LLM), the normalization happens *before* the attention or FFN block, and the residual connection adds the un-normalized input. In post-norm (the original Transformer), normalization happens *after* the block. Pre-norm is much more stable to train at depth, but it has the side effect that the residual stream can accumulate unbounded values across layers — nothing normalizes the running sum until you hit the final norm before the prediction head. That accumulation is where massive activations live.
+- **Multi-head attention**: each layer has `N_head` heads, each of dimension `d_head`. For each head, `Q = H̃ W_Q`, `K = H̃ W_K`, `V = H̃ W_V` (where `H̃` is the RMSNormed input), and the head output is `softmax(Q K^T / sqrt(d_head)) V`. The per-head outputs are concatenated and projected by `W_O`.
+- **SwiGLU FFN**: the modern feed-forward block is `F_ffn(h) = W_down (SiLU(W_gate h) ⊙ (W_up h))`, where `⊙` is element-wise product. The gating structure (multiplying two parallel projections) is what makes SwiGLU more expressive than a standard MLP — and, as we will see, what lets it act as a *quadratic* amplifier when SiLU happens to be near identity.
+
+The paper focuses on Llama 2 7B / 13B, Llama 3 8B, and Qwen 2.5 / 3 (7B/8B/14B) for the analysis, plus a from-scratch 7B Llama-style model trained for 100B tokens for the ablations.
+
+### Concept Diagram
+
+<svg viewBox="0 0 600 460" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="prelim-diag-title">
+  <title id="prelim-diag-title">Pre-norm Transformer block: normalization happens before, residual adds the un-normalized input</title>
+  <defs>
+    <marker id="prearr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="300" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    A single pre-norm block
+  </text>
+  <!-- Input H_i -->
+  <rect x="220" y="50" width="160" height="40" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="300" y="76" text-anchor="middle" font-weight="600" fill="#92400e">H_i (un-normalized)</text>
+  <line x1="300" y1="90" x2="300" y2="115" stroke="#64748b" stroke-width="1.5"/>
+  <!-- Branch: residual passes through -->
+  <line x1="300" y1="115" x2="500" y2="115" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="500" y1="115" x2="500" y2="370" stroke="#64748b" stroke-width="1.5"/>
+  <text x="510" y="240" font-size="11" fill="#64748b" font-style="italic">residual</text>
+  <text x="510" y="256" font-size="11" fill="#64748b" font-style="italic">(carries spikes)</text>
+  <!-- Norm -->
+  <rect x="220" y="120" width="160" height="40" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="300" y="146" text-anchor="middle" font-weight="600" fill="#6b21a8">RMSNorm</text>
+  <line x1="300" y1="160" x2="300" y2="195" stroke="#64748b" stroke-width="1.5" marker-end="url(#prearr)"/>
+  <!-- Block -->
+  <rect x="180" y="200" width="240" height="120" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="300" y="226" text-anchor="middle" font-weight="700" fill="#1e40af">F_i: Attention OR SwiGLU FFN</text>
+  <text x="300" y="252" text-anchor="middle" font-size="11" fill="#64748b">attention: softmax(QK&#8868;/√d_head)V</text>
+  <text x="300" y="270" text-anchor="middle" font-size="11" fill="#64748b">FFN: W_down(SiLU(W_gate h)&#8857;(W_up h))</text>
+  <text x="300" y="298" text-anchor="middle" font-size="11" fill="#64748b" font-style="italic">2L of these in total</text>
+  <line x1="300" y1="320" x2="300" y2="350" stroke="#64748b" stroke-width="1.5"/>
+  <!-- Sum -->
+  <circle cx="300" cy="370" r="14" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="300" y="375" text-anchor="middle" font-weight="700" fill="#166534" font-size="14">+</text>
+  <line x1="300" y1="384" x2="300" y2="410" stroke="#64748b" stroke-width="1.5" marker-end="url(#prearr)"/>
+  <!-- Output -->
+  <rect x="220" y="410" width="160" height="40" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="300" y="436" text-anchor="middle" font-weight="600" fill="#166534">H_{i+1}</text>
+  <text x="500" y="386" text-anchor="end" font-size="11" fill="#64748b">H_i comes here un-normalized</text>
+</svg>
+
+### Key Takeaways
+
+- **The residual stream is un-normalized between blocks**: nothing rescales the running sum until the final layer. That is what lets a few channels grow huge.
+- **Pre-norm is universal but not free**: the price of training stability is the quiet accumulation that makes massive activations possible.
+- **SwiGLU is a multiplication of two projections**: the gate `(W_gate h) ⊙ (W_up h)` is the structural reason an FFN can act as a *quadratic* amplifier, not just a linear one.
+
+---
+
+## The Emergence of Massive Activations
+
+### Overview
+
+Here is the load-bearing observation. If you instrument a trained Llama 2 7B and watch the magnitudes of the hidden state across its 64 layers, almost every channel is small — a few units, maybe a few tens. But two or three specific channels, on a small set of specific tokens (overwhelmingly the very first token), reach magnitudes in the **thousands** for a long stretch of intermediate layers. The trajectory is consistent: a sharp jump up around block 4, a plateau through the middle, a sharp drop back to normal at block 62 (out of 64). The authors call this the "rise – plateau – fall" lifecycle, and they identify three classes of blocks that produce it: **step-up blocks** that inject the spike, intermediate blocks that propagate it via residual addition, and **step-down blocks** at the end that cancel it by injecting equal-and-opposite values.
+
+The mechanism behind step-up is the most surprising part. The SwiGLU feed-forward block, which usually looks like a humdrum nonlinearity, behaves as a **directional quadratic amplifier** for these tokens. Here is the chain of approximations the paper lays out: when SiLU happens to operate in its near-identity regime (the specific spike tokens land in a part of input space where `SiLU(x) ≈ x`), the SwiGLU FFN simplifies from `W_down (SiLU(W_gate h) ⊙ (W_up h))` to roughly `W_down ((W_gate h) ⊙ (W_up h))`. That elementwise product of two linear projections is *quadratic in `h`*. Each output coordinate `k` then has the form `h^T S_k h` for some matrix `S_k`. For most output coordinates, `S_k` is unremarkable. But for a few "spike channels", `S_k` is dominated by a single eigenvalue `λ*` orders of magnitude larger than the rest of the spectrum. When the input `h` aligns with the leading eigenvector `s*`, the FFN multiplies it by `λ*` — that is the moment a hidden value goes from order-10 to order-1000.
+
+Why does the alignment with `s*` happen for the first token specifically? Because the first token is in a structurally privileged position. With causal masking, the first token can only attend to itself, so the attention block at position 0 collapses to a fixed linear map `W_VO`. That map is *the same for every prompt*. The model has therefore learned a `W_VO` that consistently steers position-0 representations toward `s*`. Delimiter tokens (periods, newlines) follow a related but slightly different path: their embeddings are highly aligned with the RMSNorm scale parameters, so RMSNorm gives them an outsized magnitude post-norm, which makes them self-attend disproportionately, which lands them in a near-first-token regime, which triggers the same quadratic amplifier. The pattern holds remarkably broadly: across Llama 2 / 3 and Qwen 2.5 / 3, **over 98% of all vocabulary items become spike tokens when placed at position 0** (Table 2 in the paper). The exceptions are rare characters from low-resource scripts whose embeddings stayed close to initialization.
+
+Five concrete properties characterize massive activations, and they all fall out of this mechanism: (i) they appear only in intermediate layers (because of the step-up / step-down injection pattern), (ii) only in a small number of channels (the few `S_k` matrices with high-gain quadratic forms), (iii) the affected channels spike *together* (they share the same trigger direction `s*`), (iv) inter-channel ratios stay nearly fixed (governed by the leading eigenvalues of the shared `S_k`s), and (v) only a small number of tokens spike (the few that align with `s*`).
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="spike-diag-title">
+  <title id="spike-diag-title">Rise-plateau-fall lifecycle of a spike channel across Transformer blocks</title>
+  <defs>
+    <marker id="sp-arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    Rise – plateau – fall: a spike channel across 64 blocks
+  </text>
+  <!-- Axes -->
+  <line x1="80" y1="280" x2="660" y2="280" stroke="#94a3b8" stroke-width="1.5"/>
+  <line x1="80" y1="60" x2="80" y2="280" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="80" y="300" text-anchor="middle" font-size="11" fill="#64748b">block 1</text>
+  <text x="160" y="300" text-anchor="middle" font-size="11" fill="#64748b">4</text>
+  <text x="370" y="300" text-anchor="middle" font-size="11" fill="#64748b">32</text>
+  <text x="600" y="300" text-anchor="middle" font-size="11" fill="#64748b">62</text>
+  <text x="660" y="300" text-anchor="middle" font-size="11" fill="#64748b">64</text>
+  <text x="370" y="320" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">block index</text>
+  <text x="55" y="170" text-anchor="end" font-size="11" fill="#475569" font-style="italic" transform="rotate(-90 55 170)">|hidden|</text>
+  <!-- Typical channel: flat low -->
+  <path d="M 80 270 L 660 270" stroke="#94a3b8" stroke-width="2" stroke-dasharray="5,4"/>
+  <text x="660" y="265" text-anchor="end" font-size="10" fill="#94a3b8">typical channel ~ 10</text>
+  <!-- Spike channel trajectory -->
+  <path d="M 80 270 L 140 268 L 160 100 L 200 80 L 600 80 L 620 270 L 660 270"
+        stroke="#dc2626" stroke-width="3" fill="none"/>
+  <circle cx="160" cy="100" r="5" fill="#dc2626"/>
+  <circle cx="600" cy="270" r="5" fill="#dc2626"/>
+  <!-- Annotations -->
+  <rect x="120" y="120" width="120" height="50" rx="6" fill="#fef2f2" stroke="#ef4444" stroke-width="1"/>
+  <text x="180" y="140" text-anchor="middle" font-size="12" font-weight="700" fill="#991b1b">step-up block</text>
+  <text x="180" y="158" text-anchor="middle" font-size="11" fill="#991b1b">SwiGLU amplifier</text>
+  <line x1="180" y1="120" x2="170" y2="100" stroke="#ef4444" stroke-width="1"/>
+  <rect x="310" y="100" width="160" height="50" rx="6" fill="#fef3c7" stroke="#f59e0b" stroke-width="1"/>
+  <text x="390" y="120" text-anchor="middle" font-size="12" font-weight="700" fill="#92400e">plateau (residual carry)</text>
+  <text x="390" y="138" text-anchor="middle" font-size="11" fill="#92400e">later blocks contribute &lt;&lt; spike</text>
+  <rect x="540" y="180" width="120" height="50" rx="6" fill="#fef2f2" stroke="#ef4444" stroke-width="1"/>
+  <text x="600" y="200" text-anchor="middle" font-size="12" font-weight="700" fill="#991b1b">step-down block</text>
+  <text x="600" y="218" text-anchor="middle" font-size="11" fill="#991b1b">opposite-sign cancel</text>
+  <line x1="600" y1="230" x2="610" y2="265" stroke="#ef4444" stroke-width="1"/>
+  <text x="370" y="345" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">
+    Llama 2 7B: spike at block 4, cancel at block 62, of 64 total
+  </text>
+</svg>
+
+### Try It Yourself
+
+The model spends most of its life in the plateau. The exact step-up and step-down indices vary across families, but the shape stays the same. Click through the model presets to see the architecture summary and where the spike rises and falls.
+
+<style>
+  .ptb-step-mds { border: 1px solid #e2e8f0; border-radius: 10px; padding: 16px 20px; margin: 16px 0; }
+  .ptb-step-mds .ptb-label { display: block; font-size: 13px; color: #475569; margin-bottom: 8px; font-weight: 600; }
+  .ptb-step-mds .ptb-buttons { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+  .ptb-step-mds input[type="radio"] { display: none; }
+  .ptb-step-mds .ptb-btn { padding: 6px 14px; border: 1px solid #cbd5e1; border-radius: 6px; cursor: pointer; font-size: 13px; font-weight: 600; color: #475569; background: #f8fafc; user-select: none; }
+  .ptb-step-mds .ptb-btn:hover { border-color: #3b82f6; color: #1e40af; }
+  .ptb-step-mds .ptb-state { display: none; }
+  .ptb-step-mds input#mds-l27:checked ~ .ptb-buttons label[for="mds-l27"],
+  .ptb-step-mds input#mds-l213:checked ~ .ptb-buttons label[for="mds-l213"],
+  .ptb-step-mds input#mds-q3:checked ~ .ptb-buttons label[for="mds-q3"],
+  .ptb-step-mds input#mds-q3l:checked ~ .ptb-buttons label[for="mds-q3l"] {
+    background: #eff6ff; border-color: #3b82f6; color: #1e40af;
+  }
+  .ptb-step-mds input#mds-l27:checked ~ #mds-s-l27,
+  .ptb-step-mds input#mds-l213:checked ~ #mds-s-l213,
+  .ptb-step-mds input#mds-q3:checked ~ #mds-s-q3,
+  .ptb-step-mds input#mds-q3l:checked ~ #mds-s-q3l { display: block; }
+</style>
+
+<div class="ptb-step-mds">
+  <span class="ptb-label">Pick a model — see where the spike turns on and off:</span>
+
+  <input type="radio" name="mds" id="mds-l27" checked>
+  <input type="radio" name="mds" id="mds-l213">
+  <input type="radio" name="mds" id="mds-q3">
+  <input type="radio" name="mds" id="mds-q3l">
+
+  <div class="ptb-buttons">
+    <label for="mds-l27" class="ptb-btn">Llama 2 7B</label>
+    <label for="mds-l213" class="ptb-btn">Llama 2 13B</label>
+    <label for="mds-q3" class="ptb-btn">Qwen3 8B</label>
+    <label for="mds-q3l" class="ptb-btn">Qwen3 14B</label>
+  </div>
+
+  <div class="ptb-state" id="mds-s-l27">
+    <svg viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="mds-l27-t">
+      <title id="mds-l27-t">Llama 2 7B: 64 blocks, step-up at 4, step-down at 62</title>
+      <line x1="40" y1="160" x2="600" y2="160" stroke="#94a3b8"/>
+      <text x="40" y="180" font-size="11" fill="#64748b">block 1</text>
+      <text x="600" y="180" font-size="11" fill="#64748b" text-anchor="end">block 64</text>
+      <path d="M 40 155 L 75 153 L 90 50 L 120 40 L 555 40 L 575 155 L 600 155" stroke="#dc2626" stroke-width="3" fill="none"/>
+      <circle cx="90" cy="50" r="5" fill="#dc2626"/>
+      <circle cx="575" cy="155" r="5" fill="#dc2626"/>
+      <text x="90" y="32" text-anchor="middle" font-size="11" fill="#dc2626" font-weight="600">block 4</text>
+      <text x="575" y="32" text-anchor="middle" font-size="11" fill="#dc2626" font-weight="600">block 62</text>
+      <text x="320" y="35" text-anchor="middle" font-size="12" fill="#92400e" font-weight="700">peak ~ 3000</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state" id="mds-s-l213">
+    <svg viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="mds-l213-t">
+      <title id="mds-l213-t">Llama 2 13B: 80 blocks, step-up at 8, step-down at 78-79</title>
+      <line x1="40" y1="160" x2="600" y2="160" stroke="#94a3b8"/>
+      <text x="40" y="180" font-size="11" fill="#64748b">block 1</text>
+      <text x="600" y="180" font-size="11" fill="#64748b" text-anchor="end">block 80</text>
+      <path d="M 40 155 L 105 153 L 120 50 L 150 40 L 540 40 L 560 155 L 600 155" stroke="#dc2626" stroke-width="3" fill="none"/>
+      <circle cx="120" cy="50" r="5" fill="#dc2626"/>
+      <circle cx="560" cy="155" r="5" fill="#dc2626"/>
+      <text x="120" y="32" text-anchor="middle" font-size="11" fill="#dc2626" font-weight="600">block 8</text>
+      <text x="560" y="32" text-anchor="middle" font-size="11" fill="#dc2626" font-weight="600">blocks 78–79</text>
+      <text x="320" y="35" text-anchor="middle" font-size="12" fill="#92400e" font-weight="700">step-down spread over two blocks</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state" id="mds-s-q3">
+    <svg viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="mds-q3-t">
+      <title id="mds-q3-t">Qwen3 8B: 72 blocks, step-up at 14, step-down at 70 / 72</title>
+      <line x1="40" y1="160" x2="600" y2="160" stroke="#94a3b8"/>
+      <text x="40" y="180" font-size="11" fill="#64748b">block 1</text>
+      <text x="600" y="180" font-size="11" fill="#64748b" text-anchor="end">block 72</text>
+      <path d="M 40 155 L 140 153 L 160 50 L 200 40 L 530 40 L 555 155 L 600 155" stroke="#dc2626" stroke-width="3" fill="none"/>
+      <circle cx="160" cy="50" r="5" fill="#dc2626"/>
+      <circle cx="555" cy="155" r="5" fill="#dc2626"/>
+      <text x="160" y="32" text-anchor="middle" font-size="11" fill="#dc2626" font-weight="600">block 14</text>
+      <text x="555" y="32" text-anchor="middle" font-size="11" fill="#dc2626" font-weight="600">blocks 70, 72</text>
+      <text x="320" y="35" text-anchor="middle" font-size="12" fill="#92400e" font-weight="700">peak ~ 8000 (higher than Llama)</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state" id="mds-s-q3l">
+    <svg viewBox="0 0 640 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="mds-q3l-t">
+      <title id="mds-q3l-t">Qwen3 14B: 80 blocks, step-up at 14, step-down at 79</title>
+      <line x1="40" y1="160" x2="600" y2="160" stroke="#94a3b8"/>
+      <text x="40" y="180" font-size="11" fill="#64748b">block 1</text>
+      <text x="600" y="180" font-size="11" fill="#64748b" text-anchor="end">block 80</text>
+      <path d="M 40 155 L 130 153 L 150 50 L 195 40 L 555 40 L 575 155 L 600 155" stroke="#dc2626" stroke-width="3" fill="none"/>
+      <circle cx="150" cy="50" r="5" fill="#dc2626"/>
+      <circle cx="575" cy="155" r="5" fill="#dc2626"/>
+      <text x="150" y="32" text-anchor="middle" font-size="11" fill="#dc2626" font-weight="600">block 14</text>
+      <text x="575" y="32" text-anchor="middle" font-size="11" fill="#dc2626" font-weight="600">block 79</text>
+      <text x="320" y="35" text-anchor="middle" font-size="12" fill="#92400e" font-weight="700">single step-down at the end</text>
+    </svg>
+  </div>
+</div>
+
+### Implementation
+
+A minimal sketch of the directional quadratic amplifier — the part of SwiGLU that becomes a quadratic form when SiLU is in its near-identity regime.
+
+```python
+import torch
+import torch.nn as nn
+
+class DirectionalQuadraticAmplifier(nn.Module):
+    """SwiGLU FFN, simplified to the regime that produces massive activations.
+
+    When SiLU(x) is approximately x for the spike token's input, the SwiGLU
+    block reduces to W_down ((W_gate h) elementwise* (W_up h)). Each output
+    coordinate k is then h^T S_k h, and a few output channels have an S_k
+    that is rank-one dominated by a leading eigenvector s*. When h aligns
+    with s*, those channels are amplified by the leading eigenvalue lambda*.
+    """
+
+    def __init__(self, d_model: int, d_ffn: int):
+        super().__init__()
+        self.W_gate = nn.Linear(d_model, d_ffn, bias=False)
+        self.W_up   = nn.Linear(d_model, d_ffn, bias=False)
+        self.W_down = nn.Linear(d_ffn, d_model, bias=False)
+
+    def forward(self, h: torch.Tensor) -> torch.Tensor:
+        # h shape: (batch, seq, d_model). Each output channel k will end up
+        # behaving like a quadratic form h^T S_k h.
+        gate = self.W_gate(h)
+        up   = self.W_up(h)
+
+        # SwiGLU normally applies SiLU here; for spike tokens it is
+        # near-identity, so the multiplicative gate is the dominant nonlinearity.
+        # The element-wise product is what makes the whole block quadratic in h.
+        product = gate * up
+
+        # W_down picks linear combinations; spike channels are rows whose
+        # corresponding S_k matrix has a single dominant eigenvalue.
+        return self.W_down(product)
+```
+
+### Key Takeaways
+
+- **Step-up + step-down is structural**: spikes are injected by one or two early blocks and cancelled by a symmetric block at the end. They live in the residual stream, not the activations of any one block.
+- **SwiGLU is a quadratic amplifier when SiLU is near-identity**: the gating structure makes the FFN behave like `h^T S_k h`, and a handful of `S_k` matrices have rank-one structure that explodes a single direction.
+- **First tokens are structurally privileged**: with causal masking the first token sees only itself, so the attention block applies a fixed linear map that the model can train to point at the spike direction. Delimiters reach the same regime through a related route.
+- **The 5 properties of massive activations are corollaries of one mechanism**: layer confinement, channel scarcity, joint activation, fixed ratios, and token scarcity all fall out of the rank-one-dominated quadratic forms.
+
+---
+
+## The Emergence of Attention Sinks
+
+### Overview
+
+So we have a few tokens carrying values in the thousands across most of the network. Why does *that* turn into an attention sink? The answer hinges on what RMSNorm does to those tokens. Three properties matter, and they all follow from the spike structure described above.
+
+First, RMSNorm **bounds the magnitudes**. A spike token entering a block has L2 norm dominated by the few spike channels. After RMSNorm, every coordinate is bounded by `sqrt(d_model)`. So the spike disappears from the *normalized* input, even though it is still huge in the residual stream.
+
+Second, RMSNorm **sparsifies** the spike token. Because the L2 norm is dominated by a few channels, division-by-norm crushes the non-spike channels relative to the spike channels. The post-norm vector is approximately a sparse multi-hot indicator over the spike channel set — the rest is noise.
+
+Third, and most importantly, RMSNorm makes the spike token **near-constant across prompts**. Spike channels maintain (almost) fixed inter-channel ratios across different spike tokens, so when you normalize, you get nearly the same vector regardless of which specific spike token you started from. The paper visualizes this with cosine similarity: pre-step-up, spike-token representations vary widely; post-step-up, they collapse to cosine similarity ≈ 1.0.
+
+Now feed those near-constant vectors into the key projection `W_K`. Spike-token keys collapse to the span of just one or two rows of `W_K` (the rows corresponding to the spike channels). That is a *radical* dimensionality reduction relative to `d_head` — sink keys live in 1-2 dimensions, not 64 or 128. Non-spike-token keys, in contrast, span a much higher-dimensional manifold.
+
+Whether a head becomes a sink head is then a matter of geometry. Each head has a query subspace and a key subspace. If the query subspace happens to align more closely with the (1-2 dim, near-constant) sink-key subspace than with the non-sink-key subspace, the dot products `q^T k_sink` are systematically larger than `q^T k_non-sink`, and the softmax dumps mass on the sink. If the alignment is the other way, the head attends semantically. The model has many heads, and the geometry of their query subspaces relative to `W_K` determines who becomes a sink head.
+
+This is the key mechanistic insight: sinks emerge because (i) sparsification from normalization confines sink keys to a low-dimensional subspace, and (ii) near-constancy keeps that subspace stable across prompts, which gives the learned `W_K` something predictable to *route around*. The result is that `W_K` partitions the key space cleanly into "sink" and "non-sink" regions, and each query head picks a side.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="sink-diag-title">
+  <title id="sink-diag-title">RMSNorm collapses spike tokens to a near-constant sparse vector, which gives sink keys a stable 1-2 dim subspace</title>
+  <defs>
+    <marker id="sk-arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    From spike token to sink key, in three steps
+  </text>
+  <!-- Stage 1: Spike vector (variable across prompts) -->
+  <rect x="30" y="60" width="180" height="220" rx="10" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="120" y="84" text-anchor="middle" font-weight="700" fill="#92400e">Pre-norm spike token</text>
+  <!-- 5 stylized "channels" with spikes -->
+  <rect x="50" y="100" width="20" height="120" fill="#dc2626"/>
+  <rect x="80" y="190" width="20" height="30" fill="#94a3b8"/>
+  <rect x="110" y="195" width="20" height="25" fill="#94a3b8"/>
+  <rect x="140" y="110" width="20" height="110" fill="#dc2626" opacity="0.85"/>
+  <rect x="170" y="200" width="20" height="20" fill="#94a3b8"/>
+  <text x="120" y="248" text-anchor="middle" font-size="11" fill="#92400e">few channels &gt;&gt; rest</text>
+  <text x="120" y="264" text-anchor="middle" font-size="11" fill="#92400e">|h| &gt; 1000</text>
+  <line x1="210" y1="170" x2="245" y2="170" stroke="#a855f7" stroke-width="1.5" marker-end="url(#sk-arr)"/>
+  <!-- Stage 2: post-RMSNorm: sparse + near-constant -->
+  <rect x="250" y="60" width="180" height="220" rx="10" fill="#faf5ff" stroke="#a855f7" stroke-width="2"/>
+  <text x="340" y="84" text-anchor="middle" font-weight="700" fill="#6b21a8">Post-RMSNorm</text>
+  <text x="340" y="100" text-anchor="middle" font-size="11" fill="#6b21a8">bounded by √d_model</text>
+  <!-- Sparse with two dominant channels (same ratio) -->
+  <rect x="270" y="120" width="20" height="100" fill="#a855f7"/>
+  <rect x="300" y="210" width="20" height="6" fill="#94a3b8"/>
+  <rect x="330" y="210" width="20" height="6" fill="#94a3b8"/>
+  <rect x="360" y="130" width="20" height="90" fill="#a855f7" opacity="0.85"/>
+  <rect x="390" y="210" width="20" height="6" fill="#94a3b8"/>
+  <text x="340" y="248" text-anchor="middle" font-size="11" fill="#6b21a8">sparse multi-hot</text>
+  <text x="340" y="264" text-anchor="middle" font-size="11" fill="#6b21a8" font-style="italic">same vector for all spike tokens</text>
+  <line x1="430" y1="170" x2="465" y2="170" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#sk-arr)"/>
+  <!-- Stage 3: sink key in 1-2 dim subspace of W_K -->
+  <rect x="470" y="60" width="220" height="220" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <text x="580" y="84" text-anchor="middle" font-weight="700" fill="#1e40af">Sink key k^(s)</text>
+  <text x="580" y="100" text-anchor="middle" font-size="11" fill="#1e40af">= W_K^T · (post-norm)</text>
+  <!-- Schematic: a small star vs a wide cloud -->
+  <circle cx="540" cy="180" r="4" fill="#1e40af"/>
+  <circle cx="544" cy="178" r="4" fill="#1e40af"/>
+  <circle cx="538" cy="184" r="4" fill="#1e40af"/>
+  <ellipse cx="630" cy="180" rx="40" ry="28" fill="none" stroke="#94a3b8" stroke-dasharray="3,3"/>
+  <text x="540" y="220" text-anchor="middle" font-size="11" fill="#1e40af" font-weight="600">sink keys</text>
+  <text x="540" y="234" text-anchor="middle" font-size="10" fill="#1e40af">1-2 dim, stable</text>
+  <text x="630" y="220" text-anchor="middle" font-size="11" fill="#64748b" font-weight="600">non-sink keys</text>
+  <text x="630" y="234" text-anchor="middle" font-size="10" fill="#64748b">spread, varied</text>
+  <text x="580" y="264" text-anchor="middle" font-size="11" fill="#1e40af" font-style="italic">W_K cleanly separates them</text>
+  <text x="360" y="320" text-anchor="middle" font-size="12" fill="#475569">
+    Sink heads' query subspace aligns with the small sink-key subspace; non-sink heads' query subspace aligns with the cloud.
+  </text>
+  <text x="360" y="340" text-anchor="middle" font-size="11" fill="#64748b" font-style="italic">
+    The geometry, not the semantics, decides who sinks.
+  </text>
+</svg>
+
+### Key Takeaways
+
+- **RMSNorm produces three magic properties for spike tokens**: bounded magnitudes, sparsity, and near-constancy across prompts. All three matter for sink formation.
+- **Sink keys live in a 1-2 dim subspace**: a dramatic dimensional collapse from the full `d_head` (typically 64 or 128). That is what the learned `W_K` exploits.
+- **Sink-vs-non-sink heads are a matter of geometry**: which side of `W_K`'s partition the head's query subspace falls on, not anything semantic.
+
+---
+
+## Anatomy by Ablation
+
+The previous two sections build a *mechanism*. The next sections turn that mechanism into a *causal* claim by intervening — one architectural component at a time — and watching what happens to the spike magnitude, the sink ratio (the fraction of attention mass routed to the sink token), and language-modeling perplexity. The setup: a Llama-style 7B model trained from scratch on the DCLM dataset for 100B tokens, which is enough to reproduce both phenomena. Each ablation modifies a specific architectural choice while keeping the rest fixed.
+
+The picture that emerges across the ablations is the headline of the paper: **the two phenomena respond differently to the same interventions**. That is the empirical fingerprint of two mechanisms, not one.
+
+---
+
+### Feed-Forward Block Design
+
+#### Overview
+
+If SwiGLU is the "directional quadratic amplifier" responsible for spikes, what happens when you take it away? The authors compare four feed-forward designs at fixed capacity: SwiGLU (baseline), GeLU (the older standard), a single linear layer, and an attention-only design (no FFN, just more attention layers).
+
+A quick orientation on what those mean for a non-specialist. SwiGLU and GeLU are both "gated MLP" variants — they apply a nonlinearity (SiLU or GeLU) and, in SwiGLU's case, a multiplicative gate. A single linear layer is just `W h`, the simplest possible block. Attention-only replaces every FFN with another attention layer; the model becomes "all attention all the time".
+
+The result: **massive activations and attention sinks emerge in all four configurations**. The block design is *not* a prerequisite. But the *magnitude* of the spikes varies wildly. SwiGLU and GeLU yield spike magnitudes around 3000-4000. Linear and attention-only yield spike magnitudes around 600-700 — the spikes still exist, but they are much smaller because they have to be built up *gradually* across many layers instead of in a single block. The gating (SwiGLU) and saturating-nonlinearity (GeLU) designs concentrate amplification within one block; the others spread it.
+
+That is a useful refinement of the earlier story. SwiGLU is not *necessary* for spikes — any pre-norm architecture will accumulate them — but it is the most *efficient* amplifier, which is why the spike magnitudes are largest there. The implication for quantization is direct: if your model uses SwiGLU, expect bigger spikes and budget more dynamic range for them.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="ffn-diag-title">
+  <title id="ffn-diag-title">Feed-forward block design vs spike magnitude and sink ratio</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    FFN design changes spike size, not sink emergence
+  </text>
+  <text x="360" y="42" text-anchor="middle" font-size="11" fill="#64748b">All configurations produce sinks. SwiGLU/GeLU are the best amplifiers.</text>
+  <text x="220" y="74" text-anchor="end" font-size="11" fill="#64748b" font-weight="600">FFN design</text>
+  <text x="660" y="74" text-anchor="end" font-size="11" fill="#64748b" font-weight="600">Spike magnitude</text>
+  <!-- SwiGLU (baseline) -->
+  <text x="220" y="104" text-anchor="end" fill="#334155" font-size="12">SwiGLU (baseline)</text>
+  <rect x="230" y="92" width="380" height="20" rx="4" fill="#dc2626" opacity="0.85"/>
+  <text x="618" y="107" font-size="11" fill="#991b1b" font-weight="700">3818  · sink 46%</text>
+  <!-- GeLU -->
+  <text x="220" y="134" text-anchor="end" fill="#334155" font-size="12">GeLU</text>
+  <rect x="230" y="122" width="335" height="20" rx="4" fill="#ef4444" opacity="0.7"/>
+  <text x="573" y="137" font-size="11" fill="#991b1b" font-weight="700">3369  · sink 69%</text>
+  <!-- Linear -->
+  <text x="220" y="164" text-anchor="end" fill="#334155" font-size="12">Single linear</text>
+  <rect x="230" y="152" width="68" height="20" rx="4" fill="#94a3b8" opacity="0.55"/>
+  <text x="306" y="167" font-size="11" fill="#475569" font-weight="700">688  · sink 59%</text>
+  <!-- Attention-only -->
+  <text x="220" y="194" text-anchor="end" fill="#334155" font-size="12">Attention-only</text>
+  <rect x="230" y="182" width="63" height="20" rx="4" fill="#94a3b8" opacity="0.55"/>
+  <text x="301" y="197" font-size="11" fill="#475569" font-weight="700">637  · sink 74%</text>
+  <line x1="230" y1="84" x2="230" y2="208" stroke="#cbd5e1" stroke-dasharray="3,3"/>
+  <rect x="60" y="246" width="600" height="50" rx="6" fill="#f8fafc" stroke="#e2e8f0"/>
+  <text x="360" y="266" text-anchor="middle" font-size="12" fill="#475569">
+    Lesson: SwiGLU/GeLU concentrate amplification in one block (big spikes);
+  </text>
+  <text x="360" y="284" text-anchor="middle" font-size="12" fill="#475569" font-style="italic">
+    linear/attention-only spread it across many (small spikes). Sinks always show up.
+  </text>
+</svg>
+
+#### Key Takeaways
+
+- **FFN design is a knob, not a switch**: every architecture produces spikes and sinks, but SwiGLU and GeLU produce far larger spikes (~3000-4000) than linear or attention-only (~600-700).
+- **Concentration vs accumulation**: gated nonlinearities concentrate the amplification into a single block; flatter designs accumulate the same effect over many blocks.
+- **Quantization implication**: SwiGLU models will always have the biggest dynamic range pressure. If you can swap to a less concentrated design, you buy precision headroom.
+
+---
+
+### Normalization Configuration
+
+#### Overview
+
+Now the most consequential ablation. If normalization is the bridge between spikes and sinks, swapping it should disconnect them. The authors test three alternatives.
+
+- **Sandwich normalization** (Ding et al., 2021): an extra RMSNorm at the *output* of each block, after the residual addition. This bounds the residual-stream magnitudes between blocks, which should prevent the unbounded accumulation that makes spikes possible.
+- **Sandwich-QK normalization**: a related variant where input normalization is applied only to queries and keys. This decouples the path that produces sinks (Q/K projections) from the rest of the residual stream.
+- **DynamicTanh** (Zhu et al., 2025): replace RMSNorm with an *element-wise* `tanh`-like saturating function. This caps each coordinate independently, which means it cannot produce the sparse multi-hot vector that arises from L2 normalization of a peaky distribution.
+
+The headline result, summarized in the comparison below: each alternative successfully reduces spike magnitude relative to the baseline, but **the sink ratio mostly survives**. Sandwich norm: spike falls from 3818 to 520 while sinks stay at 44.7%. Sandwich-QK: spikes almost gone (92), sinks 42.0%. DynamicTanh: spikes vanish (153) and sinks *increase* to 61.0% — the model finds an alternative pathway to designate the first token as a stable reference, without needing huge magnitudes.
+
+That is a striking decoupling. The standard story — "spikes cause sinks" — is too strong. What is true is: pre-norm RMSNorm + unbounded residual + SwiGLU is *one* path to sinks, but it is not the only path. When you take the magnitudes away, the model finds another way.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="norm-diag-title">
+  <title id="norm-diag-title">Normalization variants vs spike magnitude and sink ratio</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    Normalization is the lever to decouple spikes from sinks
+  </text>
+  <text x="360" y="42" text-anchor="middle" font-size="11" fill="#64748b">
+    Same model, four normalization variants. Spike falls; sinks mostly survive.
+  </text>
+  <text x="220" y="76" text-anchor="end" font-size="11" font-weight="600" fill="#64748b">Variant</text>
+  <text x="465" y="76" text-anchor="middle" font-size="11" font-weight="600" fill="#64748b">Spike magnitude</text>
+  <text x="650" y="76" text-anchor="end" font-size="11" font-weight="600" fill="#64748b">Sink ratio</text>
+  <!-- Pre-norm (baseline) -->
+  <text x="220" y="104" text-anchor="end" fill="#334155" font-size="12">Pre-norm RMSNorm (baseline)</text>
+  <rect x="230" y="92" width="380" height="20" rx="4" fill="#dc2626" opacity="0.85"/>
+  <text x="618" y="107" font-size="11" fill="#991b1b" font-weight="700">3818</text>
+  <text x="650" y="107" text-anchor="end" font-size="11" fill="#1e40af" font-weight="700">46.0%</text>
+  <!-- Sandwich -->
+  <text x="220" y="144" text-anchor="end" fill="#334155" font-size="12">Sandwich norm</text>
+  <rect x="230" y="132" width="55" height="20" rx="4" fill="#22c55e" opacity="0.75"/>
+  <text x="293" y="147" font-size="11" fill="#166534" font-weight="700">520</text>
+  <text x="650" y="147" text-anchor="end" font-size="11" fill="#1e40af" font-weight="700">44.7%</text>
+  <!-- Sandwich-QK -->
+  <text x="220" y="184" text-anchor="end" fill="#334155" font-size="12">Sandwich-QK norm</text>
+  <rect x="230" y="172" width="12" height="20" rx="4" fill="#22c55e" opacity="0.85"/>
+  <text x="250" y="187" font-size="11" fill="#166534" font-weight="700">92</text>
+  <text x="650" y="187" text-anchor="end" font-size="11" fill="#1e40af" font-weight="700">42.0%</text>
+  <!-- DynamicTanh -->
+  <text x="220" y="224" text-anchor="end" fill="#334155" font-size="12">DynamicTanh</text>
+  <rect x="230" y="212" width="18" height="20" rx="4" fill="#22c55e" opacity="0.85"/>
+  <text x="256" y="227" font-size="11" fill="#166534" font-weight="700">153</text>
+  <text x="650" y="227" text-anchor="end" font-size="11" fill="#a855f7" font-weight="700">61.0%</text>
+  <line x1="230" y1="84" x2="230" y2="244" stroke="#cbd5e1" stroke-dasharray="3,3"/>
+  <rect x="60" y="280" width="600" height="80" rx="6" fill="#f8fafc" stroke="#e2e8f0"/>
+  <text x="360" y="302" text-anchor="middle" font-size="12" fill="#475569">
+    Sandwich norm and QKNorm bound the residual; spikes collapse, sinks are barely touched.
+  </text>
+  <text x="360" y="320" text-anchor="middle" font-size="12" fill="#475569">
+    DynamicTanh is even more emphatic: spikes go away and the sink ratio *rises* —
+  </text>
+  <text x="360" y="338" text-anchor="middle" font-size="12" fill="#475569" font-style="italic">
+    the model finds a different way to designate the first token as a sink.
+  </text>
+</svg>
+
+#### Key Takeaways
+
+- **Pre-norm + unbounded residual is one path to sinks, not the only one**: Sandwich, QKNorm, and DynamicTanh all kill spike magnitudes while preserving (or even increasing) sinks.
+- **DynamicTanh is the cleanest decoupling**: element-wise saturation is mathematically incapable of producing the sparse multi-hot post-norm vector, yet sinks not only survive but strengthen.
+- **The implication for low-precision serving**: you can keep sinks (good for streaming inference) and drop spikes (good for INT4 / FP4 quantization) by changing the normalizer at training time. This is the most actionable result in the paper.
+
+---
+
+### Attention Head Settings
+
+#### Overview
+
+If the geometric story is right — sinks emerge when the per-head subspace is large enough to cleanly separate sink keys from non-sink keys — then the attention head dimension `d_head` should be a major lever. The authors run a clean sweep.
+
+A quick orientation. In multi-head attention, the total attention capacity is split into `N_head` heads of dimension `d_head`. The per-head Q/K/V projections are `d_model -> d_head` matrices. Larger `d_head` gives each head more "room" geometrically. Modern Llama-style models use `d_head = 128` and `N_head = 32` for a 4096-dim model.
+
+The ablation: hold `N_head = 32` fixed, vary `d_head` from 8 to 128. Result: a monotonic rise in sink ratio (4.1% at `d_head=8` to 46.0% at `d_head=128`) and spike magnitude (291 to 3818). Tiny heads cannot form sinks at all, because the sink-key subspace and non-sink-key subspace cannot be cleanly separated in low dimensions.
+
+A second sweep is more illuminating: hold the *total* attention capacity `d_head x N_head = 4096` fixed, and re-allocate it. With `8/512` (tiny heads, lots of them) the sink ratio is 11%; with `128/32` (Llama-style) it is 46%; with `256/16` (giant heads, fewer of them) it is 52%. **Concentrating capacity into fewer, larger heads strengthens sink behavior**, even at fixed total capacity.
+
+This is a strong piece of evidence for the geometric mechanism. Sink formation is fundamentally about whether the head has enough dimensions to *partition*, not about how much total capacity the model has.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="head-diag-title">
+  <title id="head-diag-title">Sink ratio rises with d_head, even at fixed total capacity</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    Sinks need head-dimension room to form
+  </text>
+  <text x="360" y="42" text-anchor="middle" font-size="11" fill="#64748b">
+    Total attention capacity (d_head x N_head) held at 4096 across all rows
+  </text>
+  <!-- Axes -->
+  <line x1="100" y1="260" x2="660" y2="260" stroke="#94a3b8"/>
+  <line x1="100" y1="80" x2="100" y2="260" stroke="#94a3b8"/>
+  <text x="100" y="280" text-anchor="middle" font-size="11" fill="#64748b">d=8</text>
+  <text x="200" y="280" text-anchor="middle" font-size="11" fill="#64748b">d=16</text>
+  <text x="320" y="280" text-anchor="middle" font-size="11" fill="#64748b">d=32</text>
+  <text x="440" y="280" text-anchor="middle" font-size="11" fill="#64748b">d=64</text>
+  <text x="560" y="280" text-anchor="middle" font-size="11" fill="#64748b">d=128</text>
+  <text x="660" y="280" text-anchor="middle" font-size="11" fill="#64748b">d=256</text>
+  <text x="380" y="305" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">d_head (with N_head adjusted to keep capacity fixed)</text>
+  <text x="78" y="170" text-anchor="end" font-size="11" fill="#475569">sink ratio</text>
+  <!-- Y-axis ticks -->
+  <text x="92" y="265" text-anchor="end" font-size="10" fill="#64748b">0%</text>
+  <text x="92" y="220" text-anchor="end" font-size="10" fill="#64748b">25%</text>
+  <text x="92" y="170" text-anchor="end" font-size="10" fill="#64748b">50%</text>
+  <!-- Curve -->
+  <path d="M 100 240 L 200 196 L 320 178 L 440 175 L 560 158 L 660 145" stroke="#3b82f6" stroke-width="3" fill="none"/>
+  <circle cx="100" cy="240" r="5" fill="#3b82f6"/>
+  <circle cx="200" cy="196" r="5" fill="#3b82f6"/>
+  <circle cx="320" cy="178" r="5" fill="#3b82f6"/>
+  <circle cx="440" cy="175" r="5" fill="#3b82f6"/>
+  <circle cx="560" cy="158" r="5" fill="#3b82f6"/>
+  <circle cx="660" cy="145" r="5" fill="#3b82f6"/>
+  <!-- Annotations -->
+  <text x="100" y="234" text-anchor="middle" font-size="10" fill="#1e40af" font-weight="600">11%</text>
+  <text x="320" y="172" text-anchor="middle" font-size="10" fill="#1e40af" font-weight="600">41%</text>
+  <text x="560" y="152" text-anchor="middle" font-size="10" fill="#1e40af" font-weight="600">46%</text>
+  <text x="660" y="139" text-anchor="middle" font-size="10" fill="#1e40af" font-weight="600">52%</text>
+  <text x="180" y="100" font-size="11" fill="#475569" font-style="italic">tiny heads cannot</text>
+  <text x="180" y="116" font-size="11" fill="#475569" font-style="italic">separate sink keys</text>
+  <text x="540" y="100" font-size="11" fill="#475569" font-style="italic">fewer-larger heads</text>
+  <text x="540" y="116" font-size="11" fill="#475569" font-style="italic">give cleaner partition</text>
+</svg>
+
+### Try It Yourself
+
+How much does the per-head dimension change sink behavior at a fixed total capacity? Pick a configuration to see the layout and the resulting sink ratio.
+
+<style>
+  .ptb-step-hd { border: 1px solid #e2e8f0; border-radius: 10px; padding: 16px 20px; margin: 16px 0; }
+  .ptb-step-hd .ptb-label { display: block; font-size: 13px; color: #475569; margin-bottom: 8px; font-weight: 600; }
+  .ptb-step-hd .ptb-buttons { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+  .ptb-step-hd input[type="radio"] { display: none; }
+  .ptb-step-hd .ptb-btn { padding: 6px 14px; border: 1px solid #cbd5e1; border-radius: 6px; cursor: pointer; font-size: 13px; font-weight: 600; color: #475569; background: #f8fafc; user-select: none; }
+  .ptb-step-hd .ptb-btn:hover { border-color: #3b82f6; color: #1e40af; }
+  .ptb-step-hd .ptb-state { display: none; }
+  .ptb-step-hd input#hd-8:checked ~ .ptb-buttons label[for="hd-8"],
+  .ptb-step-hd input#hd-32:checked ~ .ptb-buttons label[for="hd-32"],
+  .ptb-step-hd input#hd-128:checked ~ .ptb-buttons label[for="hd-128"],
+  .ptb-step-hd input#hd-256:checked ~ .ptb-buttons label[for="hd-256"] {
+    background: #eff6ff; border-color: #3b82f6; color: #1e40af;
+  }
+  .ptb-step-hd input#hd-8:checked ~ #hd-s-8,
+  .ptb-step-hd input#hd-32:checked ~ #hd-s-32,
+  .ptb-step-hd input#hd-128:checked ~ #hd-s-128,
+  .ptb-step-hd input#hd-256:checked ~ #hd-s-256 { display: block; }
+</style>
+
+<div class="ptb-step-hd">
+  <span class="ptb-label">Pick a (d_head / N_head) split — total capacity = 4096:</span>
+
+  <input type="radio" name="hd" id="hd-8">
+  <input type="radio" name="hd" id="hd-32">
+  <input type="radio" name="hd" id="hd-128" checked>
+  <input type="radio" name="hd" id="hd-256">
+
+  <div class="ptb-buttons">
+    <label for="hd-8" class="ptb-btn">8 / 512</label>
+    <label for="hd-32" class="ptb-btn">32 / 128</label>
+    <label for="hd-128" class="ptb-btn">128 / 32 (Llama)</label>
+    <label for="hd-256" class="ptb-btn">256 / 16</label>
+  </div>
+
+  <div class="ptb-state" id="hd-s-8">
+    <svg viewBox="0 0 600 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="hd-s-8-t">
+      <title id="hd-s-8-t">d_head = 8, N_head = 512: tiny heads, sink ratio 11%</title>
+      <text x="300" y="30" text-anchor="middle" font-weight="700" fill="#1e293b" font-size="14">d_head = 8, N_head = 512</text>
+      <!-- A long row of tiny heads -->
+      <g fill="#bfdbfe" stroke="#3b82f6">
+        <rect x="50"  y="80" width="20" height="40"/>
+        <rect x="74"  y="80" width="20" height="40"/>
+        <rect x="98"  y="80" width="20" height="40"/>
+        <rect x="122" y="80" width="20" height="40"/>
+        <rect x="146" y="80" width="20" height="40"/>
+        <rect x="170" y="80" width="20" height="40"/>
+        <rect x="194" y="80" width="20" height="40"/>
+        <rect x="218" y="80" width="20" height="40"/>
+      </g>
+      <text x="380" y="105" font-size="12" fill="#64748b">… (504 more tiny heads)</text>
+      <text x="300" y="170" text-anchor="middle" font-size="13" fill="#475569" font-style="italic">
+        too few dimensions per head to separate sink/non-sink keys
+      </text>
+      <text x="300" y="195" text-anchor="middle" font-size="14" fill="#1e40af" font-weight="700">sink ratio: 11.0%</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state" id="hd-s-32">
+    <svg viewBox="0 0 600 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="hd-s-32-t">
+      <title id="hd-s-32-t">d_head = 32, N_head = 128: small heads, sink ratio 41%</title>
+      <text x="300" y="30" text-anchor="middle" font-weight="700" fill="#1e293b" font-size="14">d_head = 32, N_head = 128</text>
+      <g fill="#bfdbfe" stroke="#3b82f6">
+        <rect x="60" y="70" width="40" height="60"/>
+        <rect x="104" y="70" width="40" height="60"/>
+        <rect x="148" y="70" width="40" height="60"/>
+        <rect x="192" y="70" width="40" height="60"/>
+        <rect x="236" y="70" width="40" height="60"/>
+      </g>
+      <text x="380" y="105" font-size="12" fill="#64748b">… (123 more)</text>
+      <text x="300" y="170" text-anchor="middle" font-size="13" fill="#475569" font-style="italic">
+        partial separation; sink behavior emerges in some heads
+      </text>
+      <text x="300" y="195" text-anchor="middle" font-size="14" fill="#1e40af" font-weight="700">sink ratio: 41.1%</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state" id="hd-s-128">
+    <svg viewBox="0 0 600 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="hd-s-128-t">
+      <title id="hd-s-128-t">d_head = 128, N_head = 32: Llama config, sink ratio 46%</title>
+      <text x="300" y="30" text-anchor="middle" font-weight="700" fill="#1e293b" font-size="14">d_head = 128, N_head = 32 (Llama-style)</text>
+      <g fill="#bfdbfe" stroke="#3b82f6">
+        <rect x="80" y="60" width="80" height="80"/>
+        <rect x="170" y="60" width="80" height="80"/>
+        <rect x="260" y="60" width="80" height="80"/>
+        <rect x="350" y="60" width="80" height="80"/>
+      </g>
+      <text x="500" y="105" font-size="12" fill="#64748b">… (28 more)</text>
+      <text x="300" y="170" text-anchor="middle" font-size="13" fill="#475569" font-style="italic">
+        clean partition between sink and non-sink keys
+      </text>
+      <text x="300" y="195" text-anchor="middle" font-size="14" fill="#1e40af" font-weight="700">sink ratio: 46.0%</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state" id="hd-s-256">
+    <svg viewBox="0 0 600 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="hd-s-256-t">
+      <title id="hd-s-256-t">d_head = 256, N_head = 16: giant heads, sink ratio 52%</title>
+      <text x="300" y="30" text-anchor="middle" font-weight="700" fill="#1e293b" font-size="14">d_head = 256, N_head = 16</text>
+      <g fill="#bfdbfe" stroke="#3b82f6">
+        <rect x="80" y="50" width="160" height="100"/>
+        <rect x="250" y="50" width="160" height="100"/>
+      </g>
+      <text x="450" y="105" font-size="12" fill="#64748b">… (14 more)</text>
+      <text x="300" y="170" text-anchor="middle" font-size="13" fill="#475569" font-style="italic">
+        ample geometry to separate keys; sinks strengthen further
+      </text>
+      <text x="300" y="195" text-anchor="middle" font-size="14" fill="#a855f7" font-weight="700">sink ratio: 52.1%</text>
+    </svg>
+  </div>
+</div>
+
+#### Key Takeaways
+
+- **`d_head` is the dominant architectural lever for sinks**: monotonic rise from 4.1% at `d_head=8` to 46% at `d_head=128`.
+- **Concentration beats distribution at fixed capacity**: moving from many-tiny to few-large heads strengthens sinks even when total capacity is held constant.
+- **The geometric mechanism is the right model**: sinks need *room* in the per-head subspace to separate sink-keys from non-sink-keys. Total capacity is not the binding constraint; per-head capacity is.
+
+---
+
+### Gated Attention
+
+#### Overview
+
+A second-order question: if sinks are useful for routing, what happens when we give the model an *explicit* routing mechanism instead? The answer is striking. Following Qiu et al. (2025), the authors test gated attention variants — the head output gets multiplied by a learned gate.
+
+The taxonomy that matters is whether the gate is **conditional** (a function of the current hidden representation, so it changes prompt-by-prompt) or **unconditional / static** (fixed at the per-head, per-channel, or per-position level). Within conditional, you can have per-channel gates (one gate per output channel), per-head gates, or single-token gates.
+
+Result: **conditional gating eliminates sinks**. Per-channel conditional gate yields a 4.5% sink ratio (down from 46%) with spike magnitude 202. Per-head: 6.4% sink, spike 186. Single-token: 31% — partial. Static gates (positional or token-embedding based) preserve sink behavior almost fully (~31-44%).
+
+The interpretation: attention sinks are a **learned input-conditioned gating mechanism**. When the model lacks a built-in dynamic gate, it improvises one by routing excess attention into the spike token, effectively zeroing out unwanted heads. When you give it a real gate, the improvisation becomes redundant and disappears.
+
+This connects sinks to a larger architectural conversation. Multiple recent designs — gated linear units, gated state-space models, mixture-of-experts routers — build dynamic input-conditioned routing as an explicit primitive. The sink phenomenon is a hint that vanilla self-attention has been silently doing a version of this, with the first token playing the role of a "this head is off" signal.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="gate-diag-title">
+  <title id="gate-diag-title">Gating type vs sink ratio: conditional gating eliminates sinks; static gating does not</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    Sinks act as an implicit, input-conditioned gate
+  </text>
+  <text x="360" y="42" text-anchor="middle" font-size="11" fill="#64748b">
+    Replace the implicit gate with an explicit one and sinks vanish — only when the gate is conditional.
+  </text>
+  <!-- Conditional gating panel -->
+  <rect x="40" y="70" width="320" height="260" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="200" y="94" text-anchor="middle" font-weight="700" fill="#166534">Conditional gating (gate = f(h))</text>
+  <text x="60" y="124" font-size="12" fill="#334155">per-channel gate</text>
+  <rect x="180" y="114" width="14" height="14" rx="3" fill="#22c55e"/>
+  <text x="220" y="125" font-size="12" fill="#166534" font-weight="700">sink 4.5%</text>
+  <text x="60" y="154" font-size="12" fill="#334155">per-head gate</text>
+  <rect x="180" y="144" width="20" height="14" rx="3" fill="#22c55e"/>
+  <text x="220" y="155" font-size="12" fill="#166534" font-weight="700">sink 6.4%</text>
+  <text x="60" y="184" font-size="12" fill="#334155">single-token gate</text>
+  <rect x="180" y="174" width="100" height="14" rx="3" fill="#94a3b8" opacity="0.7"/>
+  <text x="290" y="185" font-size="12" fill="#475569" font-weight="700">sink 31.2%</text>
+  <text x="200" y="240" text-anchor="middle" font-size="11" fill="#166534" font-style="italic">
+    finer-grained conditional gates kill sinks
+  </text>
+  <text x="200" y="258" text-anchor="middle" font-size="11" fill="#166534">
+    (per-channel and per-head gates do best)
+  </text>
+  <text x="200" y="294" text-anchor="middle" font-size="11" fill="#475569">
+    perplexity barely changes vs baseline 10.1
+  </text>
+  <!-- Unconditional / static gating panel -->
+  <rect x="380" y="70" width="320" height="260" rx="10" fill="#fef3c7" stroke="#f59e0b" stroke-width="2"/>
+  <text x="540" y="94" text-anchor="middle" font-weight="700" fill="#92400e">Unconditional / static gating</text>
+  <text x="400" y="124" font-size="12" fill="#334155">unconditional channel</text>
+  <rect x="540" y="114" width="135" height="14" rx="3" fill="#f59e0b" opacity="0.8"/>
+  <text x="685" y="125" text-anchor="end" font-size="12" fill="#92400e" font-weight="700">42.2%</text>
+  <text x="400" y="154" font-size="12" fill="#334155">unconditional head</text>
+  <rect x="540" y="144" width="132" height="14" rx="3" fill="#f59e0b" opacity="0.8"/>
+  <text x="685" y="155" text-anchor="end" font-size="12" fill="#92400e" font-weight="700">41.3%</text>
+  <text x="400" y="184" font-size="12" fill="#334155">positional</text>
+  <rect x="540" y="174" width="131" height="14" rx="3" fill="#f59e0b" opacity="0.8"/>
+  <text x="685" y="185" text-anchor="end" font-size="12" fill="#92400e" font-weight="700">41.1%</text>
+  <text x="400" y="214" font-size="12" fill="#334155">token-embedding</text>
+  <rect x="540" y="204" width="100" height="14" rx="3" fill="#f59e0b" opacity="0.8"/>
+  <text x="685" y="215" text-anchor="end" font-size="12" fill="#92400e" font-weight="700">31.1%</text>
+  <text x="540" y="270" text-anchor="middle" font-size="11" fill="#92400e" font-style="italic">
+    gates that do not depend on the current state
+  </text>
+  <text x="540" y="288" text-anchor="middle" font-size="11" fill="#92400e">
+    cannot replace the role of sinks
+  </text>
+  <text x="540" y="312" text-anchor="middle" font-size="11" fill="#475569">
+    sinks survive at near-baseline levels
+  </text>
+</svg>
+
+#### Key Takeaways
+
+- **Sinks are implicit gates**: when an explicit input-conditioned gate is added, sink behavior disappears with no perplexity cost.
+- **Conditional vs static is the dividing line**: unconditional or static-signal gates do not replace sinks. The model needs a *dynamic* gating signal to free up the first token.
+- **A unifying view of recent architectures**: gated attention, gated SSMs, and similar explicit-gating designs are doing what attention sinks have been silently doing. Once explicit, the implicit version is vestigial.
+
+---
+
+### Training Context Length
+
+#### Overview
+
+The last ablation tests the hypothesis that sinks are not just architectural — they are *useful* for short-range prediction. Xiao et al. (2024a) noted that sink heads tend to attend to nearby tokens of the query; the authors of this paper test that systematically by varying the *training* context-length distribution. Concretely, they change the range of sequence positions over which the loss is computed during training. Configurations are reported as `min/max` — e.g. `1/4096` means losses are computed at positions 1 to 4096.
+
+Result: when training includes short sequences (`1/256`, `1/1024`, `1/4096`), the sink ratio is stable at ~42-46%. When short contexts are *removed* and only long-range positions are optimized (`1024/4096`, `2048/4096`, `2048/6144`), the sink ratio collapses dramatically — 13%, 1.2%, 5.8% respectively. Spike magnitudes go *up* in some of these long-only configs (38000+ at `1024/4096`), but the sinks have already disengaged.
+
+The interpretation: sinks exist to support short-range prediction. In a mixed-length training regime, the first token serves as a cheap, universal "ignore the far context" reference for short-context examples. When the model never has to do short-context prediction, it never learns to use that reference, and sinks do not form. This is a counterintuitive but empirically robust result — a phenomenon we usually frame as architectural turns out to be partly *training-data-distribution-driven*.
+
+#### Concept Diagram
+
+<svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="ctx-diag-title">
+  <title id="ctx-diag-title">Sinks collapse when training distribution excludes short contexts</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    Sinks are a byproduct of short-context training
+  </text>
+  <text x="360" y="42" text-anchor="middle" font-size="11" fill="#64748b">
+    Train on positions in (min/max). Remove short positions, sinks collapse.
+  </text>
+  <text x="220" y="74" text-anchor="end" font-size="11" font-weight="600" fill="#64748b">Train positions</text>
+  <text x="660" y="74" text-anchor="end" font-size="11" font-weight="600" fill="#64748b">Sink ratio</text>
+  <!-- 1/256 -->
+  <text x="220" y="104" text-anchor="end" fill="#334155" font-size="12">1 / 256 (short only)</text>
+  <rect x="230" y="92" width="335" height="20" rx="4" fill="#3b82f6" opacity="0.7"/>
+  <text x="660" y="107" text-anchor="end" font-size="11" fill="#1e40af" font-weight="700">42.1%</text>
+  <!-- 1/4096 baseline -->
+  <text x="220" y="134" text-anchor="end" fill="#334155" font-size="12">1 / 4096 (mixed, baseline)</text>
+  <rect x="230" y="122" width="370" height="20" rx="4" fill="#3b82f6" opacity="0.85"/>
+  <text x="660" y="137" text-anchor="end" font-size="11" fill="#1e40af" font-weight="700">46.0%</text>
+  <!-- 1024/4096 -->
+  <text x="220" y="164" text-anchor="end" fill="#334155" font-size="12">1024 / 4096 (no short)</text>
+  <rect x="230" y="152" width="105" height="20" rx="4" fill="#ef4444" opacity="0.6"/>
+  <text x="660" y="167" text-anchor="end" font-size="11" fill="#dc2626" font-weight="700">13.0%</text>
+  <!-- 1024/5120 -->
+  <text x="220" y="194" text-anchor="end" fill="#334155" font-size="12">1024 / 5120 (no short)</text>
+  <rect x="230" y="182" width="65" height="20" rx="4" fill="#ef4444" opacity="0.6"/>
+  <text x="660" y="197" text-anchor="end" font-size="11" fill="#dc2626" font-weight="700">8.0%</text>
+  <!-- 2048/4096 -->
+  <text x="220" y="224" text-anchor="end" fill="#334155" font-size="12">2048 / 4096 (long only)</text>
+  <rect x="230" y="212" width="10" height="20" rx="4" fill="#ef4444" opacity="0.85"/>
+  <text x="660" y="227" text-anchor="end" font-size="11" fill="#dc2626" font-weight="700">1.2%</text>
+  <line x1="230" y1="84" x2="230" y2="244" stroke="#cbd5e1" stroke-dasharray="3,3"/>
+  <rect x="60" y="262" width="600" height="40" rx="6" fill="#f8fafc" stroke="#e2e8f0"/>
+  <text x="360" y="285" text-anchor="middle" font-size="12" fill="#475569" font-style="italic">
+    Short-context training is what makes the first-token sink useful. Remove it, and the model never learns to dump.
+  </text>
+</svg>
+
+#### Key Takeaways
+
+- **Sinks are partly a data-distribution phenomenon**: training only on long-context positions collapses sinks to ~1-13%.
+- **The first token is a cheap universal "ignore far context" reference**: in mixed-length training, it lets the model ignore distant tokens for short-range prediction.
+- **Architectural and data-side mitigations are both available**: if you want to avoid sinks, you can change the architecture (gated attention, alternative norm) *or* change the training context distribution.
+
+---
+
+## Discussion
+
+### Overview
+
+Pulled together, the picture is coherent. Pre-norm Transformers, as currently trained, have a quirky internal logic. The first token, which can only attend to itself, sits in a structurally privileged position; the model learns to push its representation in a direction `s*` that the SwiGLU FFN can amplify quadratically; that amplification dumps massive values into a few specific channels, which persist through the residual stream as approximately constant signals (implicit parameters, not data); RMSNorm then transforms those large values into a sparse, near-constant input vector; the learned key projection `W_K` notices that the first-token keys cluster in a tiny subspace, and partitions the key space accordingly; some heads orient their queries toward the sink subspace and become sink heads, which is useful because dumping attention into the first token is a cheap way to bias toward short-range prediction in mixed-length training.
+
+So the spike-and-sink couple is not one phenomenon; it is two phenomena tied together by an architectural choice (pre-norm + RMSNorm) and a training distribution choice (mixed-length context). Each can be undone:
+
+- **Suppress spikes, keep sinks**: sandwich norm, QKNorm, DynamicTanh.
+- **Suppress sinks, keep spikes**: per-channel or per-head conditional gating; long-only training distribution.
+- **Suppress both**: combining the above.
+- **In every case, language-modeling perplexity is preserved**.
+
+That last point is the load-bearing engineering claim. If the spike-and-sink coupling were doing something *necessary*, suppressing it would damage the model. It does not. Their overlap in standard pretrained LLMs is best understood as a byproduct of the default normalization-and-training recipe, not a reflection of any underlying functional necessity.
+
+For practitioners, the main implications:
+
+- **Quantization gets easier with the right normalizer.** A model trained with sandwich norm or QKNorm has 6-40x smaller spike magnitudes, which directly translates to lower precision-loss in INT4 / FP4 quantization without specialized outlier handling.
+- **KV-cache strategies that rely on sinks need not break under spike suppression.** Sinks survive most spike-killing interventions, including DynamicTanh (where they actually strengthen).
+- **Long-context-only training is a different regime.** If you fine-tune a base model exclusively on very long sequences, expect attention sinks to fade — which may or may not be what you want depending on your inference pipeline.
+
+The bigger picture: this paper continues a useful trend of treating "weird LLM behaviors" as *architectural artifacts to be designed around*, rather than mysterious emergent properties. Spikes and sinks are not magic; they are the predictable output of pre-norm + RMSNorm + SwiGLU + mixed-length training, and we now have a menu of replacements for each ingredient.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="disc-diag-title">
+  <title id="disc-diag-title">Levers for suppressing spikes and sinks independently</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">
+    A 2x2 of architectural levers
+  </text>
+  <text x="360" y="42" text-anchor="middle" font-size="11" fill="#64748b">
+    Each axis: which phenomenon does the intervention suppress?
+  </text>
+  <!-- Quadrants -->
+  <line x1="80" y1="80" x2="80" y2="320" stroke="#94a3b8"/>
+  <line x1="640" y1="80" x2="640" y2="320" stroke="#94a3b8"/>
+  <line x1="80" y1="200" x2="640" y2="200" stroke="#94a3b8"/>
+  <line x1="80" y1="80" x2="640" y2="80" stroke="#94a3b8"/>
+  <line x1="80" y1="320" x2="640" y2="320" stroke="#94a3b8"/>
+  <line x1="360" y1="80" x2="360" y2="320" stroke="#94a3b8"/>
+  <!-- Axis labels -->
+  <text x="360" y="74" text-anchor="middle" font-size="12" font-weight="600" fill="#475569">Affects spikes?</text>
+  <text x="60" y="200" text-anchor="end" font-size="12" font-weight="600" fill="#475569" transform="rotate(-90 60 200)">Affects sinks?</text>
+  <text x="220" y="98" text-anchor="middle" font-size="11" fill="#64748b">no</text>
+  <text x="500" y="98" text-anchor="middle" font-size="11" fill="#64748b">yes</text>
+  <text x="74" y="140" text-anchor="end" font-size="11" fill="#64748b">yes</text>
+  <text x="74" y="260" text-anchor="end" font-size="11" fill="#64748b">no</text>
+  <!-- Quadrant 1: top-left, kills sinks but not spikes -->
+  <text x="220" y="130" text-anchor="middle" font-weight="700" fill="#1e40af" font-size="12">Conditional gating</text>
+  <text x="220" y="148" text-anchor="middle" font-size="11" fill="#1e40af">per-channel / per-head</text>
+  <text x="220" y="166" text-anchor="middle" font-size="11" fill="#1e40af">long-only training</text>
+  <text x="220" y="184" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">sinks ↓, spikes ~ same</text>
+  <!-- Quadrant 2: top-right, kills both -->
+  <text x="500" y="130" text-anchor="middle" font-weight="700" fill="#a855f7" font-size="12">Combined</text>
+  <text x="500" y="148" text-anchor="middle" font-size="11" fill="#6b21a8">DynamicTanh + gated attn</text>
+  <text x="500" y="166" text-anchor="middle" font-size="11" fill="#6b21a8">QKNorm + gated attn</text>
+  <text x="500" y="184" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">both phenomena suppressed</text>
+  <!-- Quadrant 3: bottom-left, baseline (no intervention) -->
+  <text x="220" y="240" text-anchor="middle" font-weight="700" fill="#94a3b8" font-size="12">Baseline (do nothing)</text>
+  <text x="220" y="258" text-anchor="middle" font-size="11" fill="#64748b">pre-norm + SwiGLU</text>
+  <text x="220" y="276" text-anchor="middle" font-size="11" fill="#64748b">mixed-length training</text>
+  <text x="220" y="294" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">spikes + sinks (the puzzle)</text>
+  <!-- Quadrant 4: bottom-right, kills spikes but not sinks -->
+  <text x="500" y="240" text-anchor="middle" font-weight="700" fill="#16a34a" font-size="12">Sandwich / QKNorm / DyT</text>
+  <text x="500" y="258" text-anchor="middle" font-size="11" fill="#166534">linear / attention-only FFN</text>
+  <text x="500" y="276" text-anchor="middle" font-size="11" fill="#166534">(quantization-friendly)</text>
+  <text x="500" y="294" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">spikes ↓, sinks ~ same</text>
+</svg>
+
+### Key Takeaways
+
+- **Two phenomena, two levers**: normalization controls spikes; gated attention and short-context training control sinks. They are not knobs on the same machine.
+- **No language-modeling cost**: every intervention examined preserves perplexity. The spike-and-sink coupling is not load-bearing for next-token prediction.
+- **Engineering frontier widens**: low-precision serving (which wants no spikes) and streaming inference (which wants sinks) are no longer in tension once you pick the right combination of normalizer and gating.
+
+---
+
+## Key Takeaways (Summary)
+
+- **Massive activations and attention sinks share tokens but not mechanisms**: they co-occur because pre-norm + RMSNorm bridges them, not because one causes the other.
+- **Spikes are a directional quadratic amplifier story**: SwiGLU's gated structure makes the FFN behave like `h^T S_k h`; a few rank-one-dominated `S_k` blow up a single direction `s*`, which the first token consistently aligns with.
+- **Sinks are a geometric story**: RMSNorm collapses spike tokens to a sparse near-constant vector, so sink keys live in a 1-2 dim subspace. `W_K` partitions, heads pick a side based on query alignment.
+- **The engineering payoff is real**: swap the normalizer to suppress spikes (good for INT4/FP4 quantization) while keeping sinks (good for streaming inference / KV-cache).
+- **Sinks are also a training-distribution phenomenon**: in long-only training, they collapse to ~1-13%. Mixed-length training is what makes the first-token sink *useful* in the first place.
+- **The bigger picture**: these are designable artifacts, not emergent magic. The recipe `pre-norm + RMSNorm + SwiGLU + mixed-length training` is one path; the menu of alternatives is now mapped.

--- a/docs/superpowers/plans/2026-04-30-blog-html-pipeline.md
+++ b/docs/superpowers/plans/2026-04-30-blog-html-pipeline.md
@@ -1,0 +1,2251 @@
+# Blog HTML Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the blog markdown→HTML render from view time to submit time. Lint mistletoe foot-guns at submit, store rendered HTML as `body_html` in BigQuery, backfill all 22 existing posts, drop the legacy `body` column after a 1-week soak.
+
+**Architecture:** Two new pure-Python modules (`blog_lint.py`, `blog_render.py`) implement auto-fix + render + validate. The CLI's `_payload_from_blog` invokes them in sequence and writes both `body` and `body_html` to BigQuery during the migration window. After backfill + soak, the `body` column and transitional code are removed.
+
+**Tech Stack:** Python 3.13, Pydantic v2, mistletoe (via monsterui.render_md), google-cloud-bigquery, pytest. The `.md` files in `assets/blogs/` remain the source of truth.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/services/blog_lint.py` — `LintFix`, `LintError`, `lint_body(body) -> (str, list[LintFix])`. Pure regex transforms; no I/O.
+- `src/services/blog_render.py` — `RenderError`, `ValidationIssue`, `render_to_html(body) -> str`, `validate_html(html) -> list[ValidationIssue]`.
+- `scripts/__init__.py` — empty.
+- `scripts/backfill_blog_html.py` — CLI runner that iterates `assets/blogs/*.md`, runs the new pipeline against each, and updates BigQuery. Has `--dry-run` and a 35-minute streaming-buffer retry.
+- `tests/test_blog_lint.py` — bug-class unit tests, idempotency, stash-and-restore, skip-indented-widgets.
+- `tests/test_blog_render.py` — render unwrap, validation rule unit tests.
+- `tests/test_blog_pipeline_e2e.py` — integration on real posts 0020 (control) + 0022 (canary).
+- `tests/test_backfill_blog_html.py` — dry-run mode unit tests; the script's logic in isolation.
+
+**Modified files:**
+- `src/services/blog_frontmatter.py` — add `BlogRow` Pydantic model. `BlogFrontmatter` unchanged.
+- `src/cli/blog.py` — rewire `_payload_from_blog` (lint→render→validate→BlogRow); upgrade `_cmd_validate` (read-only lint+render+validate).
+- `src/models/project.py` — `Project` dataclass adds `body_html: str = ""`. `from_dict` reads it. `body` stays for the transitional period.
+- `src/features/projects/projects_page.py:54` — change `render_md(project.body)` to `NotStr(project.body_html)`.
+
+**Final cleanup (after soak):**
+- `src/services/blog_frontmatter.py` — drop `body: str` from `BlogRow`.
+- `src/cli/blog.py` — adjust `_payload_from_blog` to `exclude={"body"}`.
+- `src/models/project.py` — drop `body` field (or keep as optional/deprecated).
+
+**Why this layout:**
+- `blog_lint.py` and `blog_render.py` are separate because they have distinct responsibilities (auto-fix source vs render+validate output) and can be tested in isolation. Splitting also keeps each file under 200 lines, which matches the rest of `src/services/`.
+- The backfill script lives in `scripts/` (a new sibling of `src/`) because it's a one-shot operational tool, not application code.
+- Tests follow the existing one-file-per-module convention in `tests/`.
+
+---
+
+## Phase 1: Foundation — Pure Python (no BigQuery)
+
+### Task 1: Bootstrap `blog_lint.py` module skeleton
+
+**Files:**
+- Create: `src/services/blog_lint.py`
+- Create: `tests/test_blog_lint.py`
+
+- [ ] **Step 1.1: Write the failing import test**
+
+`tests/test_blog_lint.py`:
+```python
+"""Tests for src.services.blog_lint."""
+from src.services.blog_lint import LintError, LintFix, lint_body
+
+
+def test_lint_body_returns_tuple_of_text_and_fixes():
+    text = "no svg here, just prose"
+    fixed, fixes = lint_body(text)
+    assert fixed == text
+    assert fixes == []
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `pytest tests/test_blog_lint.py::test_lint_body_returns_tuple_of_text_and_fixes -v`
+Expected: `ImportError` (module doesn't exist yet) or `ModuleNotFoundError`.
+
+- [ ] **Step 1.3: Create the skeleton module**
+
+`src/services/blog_lint.py`:
+```python
+"""Auto-fix mistletoe foot-guns in blog markdown source.
+
+The portfolio's markdown renderer (mistletoe via monsterui.render_md) has
+three known failure modes when blog bodies contain inline SVG:
+
+1. HTML named entities inside SVG break XML parsing.
+2. Multi-line `<svg ...>` opening tags break mistletoe's HTML-block detection.
+3. Blank lines inside SVG followed by single-line elements break mistletoe's
+   HTML-block continuation.
+
+This module fixes all three at submit time, idempotently. See
+`docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md` for the
+full reasoning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+class LintError(Exception):
+    """Raised when the linter encounters a problem it cannot auto-fix
+    (e.g. an HTML named entity with no Unicode mapping).
+    """
+
+
+@dataclass
+class LintFix:
+    """A single class of fix the linter applied to a body of text."""
+
+    kind: Literal["named-entity", "multi-line-svg-open", "blank-line-in-svg"]
+    count: int
+    detail: str
+
+
+def lint_body(body: str) -> tuple[str, list[LintFix]]:
+    """Apply all three lint rules to `body`, returning the fixed text + list of fixes.
+
+    The transforms are idempotent: running `lint_body` twice on the same input
+    produces the same output as running it once.
+    """
+    return body, []
+```
+
+- [ ] **Step 1.4: Run test to verify it passes**
+
+Run: `pytest tests/test_blog_lint.py::test_lint_body_returns_tuple_of_text_and_fixes -v`
+Expected: PASS.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/services/blog_lint.py tests/test_blog_lint.py
+git commit -m "feat(blog-lint): add module skeleton with LintFix and LintError"
+```
+
+---
+
+### Task 2: Implement entity replacement
+
+**Files:**
+- Modify: `src/services/blog_lint.py`
+- Modify: `tests/test_blog_lint.py`
+
+- [ ] **Step 2.1: Write failing tests**
+
+Append to `tests/test_blog_lint.py`:
+```python
+import pytest
+
+
+def test_lint_replaces_mdash_with_unicode():
+    src = "<svg><text>A &mdash; B</text></svg>"
+    fixed, fixes = lint_body(src)
+    assert "&mdash;" not in fixed
+    assert "—" in fixed
+    assert any(f.kind == "named-entity" and f.count == 1 for f in fixes)
+
+
+def test_lint_replaces_multiple_named_entities():
+    src = "<svg><text>x &times; y &rarr; z</text></svg>"
+    fixed, _ = lint_body(src)
+    assert "&times;" not in fixed
+    assert "&rarr;" not in fixed
+    assert "×" in fixed and "→" in fixed
+
+
+def test_lint_preserves_xml_safe_entities():
+    src = "<svg><text>x &lt; y &amp; z &gt; w</text></svg>"
+    fixed, fixes = lint_body(src)
+    assert fixed == src
+    assert fixes == []
+
+
+def test_lint_raises_on_unmapped_entity():
+    src = "<svg><text>nonsense &zzznotreal;</text></svg>"
+    with pytest.raises(LintError, match="zzznotreal"):
+        lint_body(src)
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_blog_lint.py -v`
+Expected: 3 of the 4 new tests fail (the preserves-xml-safe one passes by accident since the skeleton returns input unchanged).
+
+- [ ] **Step 2.3: Implement `_replace_named_entities`**
+
+In `src/services/blog_lint.py`, add at module level:
+
+```python
+import re
+
+# Map of HTML named entities to their Unicode literals. The five XML-predefined
+# entities (amp/lt/gt/apos/quot) are intentionally absent — they're valid in
+# both XML and HTML and do not need substitution.
+ENTITY_MAP: dict[str, str] = {
+    "mdash": "—", "ndash": "–",
+    "middot": "·", "bull": "•",
+    "times": "×", "divide": "÷",
+    "plusmn": "±", "minus": "−",
+    "rarr": "→", "larr": "←",
+    "uarr": "↑", "darr": "↓", "harr": "↔",
+    "hellip": "…",
+    "asymp": "≈", "ne": "≠",
+    "ge": "≥", "le": "≤",
+    "deg": "°",
+    "radic": "√", "infin": "∞",
+    "alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ",
+    "epsilon": "ε", "theta": "θ", "lambda": "λ", "mu": "μ",
+    "pi": "π", "sigma": "σ", "phi": "φ", "omega": "ω",
+    "Sigma": "Σ", "Delta": "Δ", "Omega": "Ω",
+    "sum": "∑", "prod": "∏",
+    "nbsp": " ",
+    "copy": "©", "reg": "®", "trade": "™",
+}
+
+_XML_SAFE_ENTITIES = frozenset({"amp", "lt", "gt", "apos", "quot"})
+_ENTITY_PATTERN = re.compile(r"&([a-zA-Z][a-zA-Z0-9]*);")
+
+
+def _replace_named_entities(body: str) -> tuple[str, int]:
+    """Replace every HTML named entity with its Unicode literal.
+
+    Returns (transformed_body, count_of_replacements). Raises LintError if
+    an entity is encountered that has no mapping in ENTITY_MAP and is not
+    one of the five XML-safe entities.
+    """
+    count = 0
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal count
+        name = match.group(1)
+        if name in _XML_SAFE_ENTITIES:
+            return match.group(0)
+        if name in ENTITY_MAP:
+            count += 1
+            return ENTITY_MAP[name]
+        raise LintError(
+            f"Unmapped named entity '&{name};'. "
+            f"Add a mapping to ENTITY_MAP in src/services/blog_lint.py and re-run."
+        )
+
+    return _ENTITY_PATTERN.sub(_sub, body), count
+```
+
+Then update `lint_body` to call it:
+
+```python
+def lint_body(body: str) -> tuple[str, list[LintFix]]:
+    fixes: list[LintFix] = []
+    body, n = _replace_named_entities(body)
+    if n:
+        fixes.append(LintFix(
+            kind="named-entity",
+            count=n,
+            detail=f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals",
+        ))
+    return body, fixes
+```
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+Run: `pytest tests/test_blog_lint.py -v`
+Expected: all 5 tests PASS.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/services/blog_lint.py tests/test_blog_lint.py
+git commit -m "feat(blog-lint): replace HTML named entities with Unicode literals"
+```
+
+---
+
+### Task 3: Collapse multi-line `<svg>` opening tags
+
+**Files:**
+- Modify: `src/services/blog_lint.py`
+- Modify: `tests/test_blog_lint.py`
+
+- [ ] **Step 3.1: Write failing tests**
+
+Append to `tests/test_blog_lint.py`:
+```python
+def test_lint_collapses_multi_line_svg_open():
+    src = (
+        '<svg viewBox="0 0 100 100"\n'
+        '     xmlns="http://www.w3.org/2000/svg"\n'
+        '     role="img">\n'
+        '  <title>x</title>\n'
+        '</svg>'
+    )
+    fixed, fixes = lint_body(src)
+    first_line = fixed.split("\n", 1)[0]
+    assert first_line == '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img">'
+    assert any(f.kind == "multi-line-svg-open" and f.count == 1 for f in fixes)
+
+
+def test_lint_leaves_single_line_svg_open_alone():
+    src = '<svg viewBox="0 0 100 100" xmlns="..." role="img"><title>x</title></svg>'
+    fixed, fixes = lint_body(src)
+    assert fixed == src
+    assert all(f.kind != "multi-line-svg-open" for f in fixes)
+
+
+def test_lint_collapses_only_svg_tag_not_other_multi_line_tags():
+    # <text> spanning lines is FINE — common in SVG body. We only care about <svg> opens.
+    src = (
+        '<svg viewBox="0 0 100 100" xmlns="..." role="img">\n'
+        '  <text x="10" y="20"\n'
+        '        font-size="13">hello</text>\n'
+        '</svg>'
+    )
+    fixed, _ = lint_body(src)
+    # The multi-line <text> should be unchanged; the <svg> open is already on one line.
+    assert "<text x=\"10\" y=\"20\"\n        font-size=\"13\">" in fixed
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_blog_lint.py -v -k "svg_open or multi_line"`
+Expected: 2 of 3 fail (the leaves-single-line one passes vacuously).
+
+- [ ] **Step 3.3: Implement `_collapse_svg_open_tags`**
+
+Add to `src/services/blog_lint.py`:
+
+```python
+_SVG_OPEN_PATTERN = re.compile(r"<svg\b([^>]*)>", re.DOTALL)
+
+
+def _collapse_svg_open_tags(body: str) -> tuple[str, int]:
+    """Collapse multi-line `<svg ...>` opening tags onto a single line.
+
+    Returns (transformed_body, count_collapsed). A "collapse" means the
+    opening tag spanned multiple lines in the source; if it was already on
+    one line, no change is recorded for that tag.
+    """
+    count = 0
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal count
+        inner = match.group(1)
+        if "\n" not in inner:
+            return match.group(0)
+        count += 1
+        collapsed = re.sub(r"\s+", " ", inner).strip()
+        return f"<svg {collapsed}>" if collapsed else "<svg>"
+
+    return _SVG_OPEN_PATTERN.sub(_sub, body), count
+```
+
+Update `lint_body`:
+
+```python
+def lint_body(body: str) -> tuple[str, list[LintFix]]:
+    fixes: list[LintFix] = []
+    body, n = _replace_named_entities(body)
+    if n:
+        fixes.append(LintFix("named-entity", n, f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals"))
+    body, n = _collapse_svg_open_tags(body)
+    if n:
+        fixes.append(LintFix("multi-line-svg-open", n, f"collapsed {n} multi-line <svg ...> opening tag(s) to single line"))
+    return body, fixes
+```
+
+- [ ] **Step 3.4: Run tests**
+
+Run: `pytest tests/test_blog_lint.py -v`
+Expected: all PASS.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/services/blog_lint.py tests/test_blog_lint.py
+git commit -m "feat(blog-lint): collapse multi-line <svg> opening tags to single line"
+```
+
+---
+
+### Task 4: Strip blank lines inside SVG blocks
+
+**Files:**
+- Modify: `src/services/blog_lint.py`
+- Modify: `tests/test_blog_lint.py`
+
+- [ ] **Step 4.1: Write failing tests**
+
+Append to `tests/test_blog_lint.py`:
+```python
+def test_lint_strips_blank_lines_inside_svg():
+    src = (
+        '<svg>\n'
+        '  <title>t</title>\n'
+        '\n'
+        '  <text>line a</text>\n'
+        '\n'
+        '  <text>line b</text>\n'
+        '</svg>'
+    )
+    fixed, fixes = lint_body(src)
+    inside = fixed[fixed.index("<svg>"):fixed.index("</svg>")]
+    assert "\n\n" not in inside
+    assert "<text>line a</text>" in fixed and "<text>line b</text>" in fixed
+    assert any(f.kind == "blank-line-in-svg" for f in fixes)
+
+
+def test_lint_preserves_blank_lines_outside_svg():
+    src = (
+        "Paragraph one.\n"
+        "\n"
+        "Paragraph two.\n"
+        "\n"
+        '<svg>\n'
+        '  <title>t</title>\n'
+        '\n'
+        '  <text>x</text>\n'
+        '</svg>\n'
+        "\n"
+        "Paragraph three.\n"
+    )
+    fixed, _ = lint_body(src)
+    assert "Paragraph one.\n\nParagraph two." in fixed
+    assert "</svg>\n\nParagraph three." in fixed
+
+
+def test_lint_preserves_indentation_in_svg():
+    src = (
+        '<svg>\n'
+        '  <title>t</title>\n'
+        '\n'
+        '  <text>indented body</text>\n'
+        '</svg>'
+    )
+    fixed, _ = lint_body(src)
+    assert "  <text>indented body</text>" in fixed
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_blog_lint.py -v -k "blank_line or outside_svg or indentation"`
+Expected: at least 2 fail.
+
+- [ ] **Step 4.3: Implement `_strip_blank_lines_in_svg`**
+
+Add to `src/services/blog_lint.py`:
+
+```python
+_SVG_BLOCK_PATTERN = re.compile(r"<svg\b[^>]*>.*?</svg>", re.DOTALL)
+
+
+def _strip_blank_lines_in_svg(body: str) -> tuple[str, int]:
+    """Strip blank lines inside `<svg>...</svg>` blocks.
+
+    Mistletoe terminates HTML blocks at blank lines, which fragments inline
+    SVG content. This strips internal blank lines (lines whose only content
+    is whitespace) without touching prose blank lines outside SVGs.
+
+    Returns (transformed_body, count_of_blank_lines_stripped).
+    """
+    total_stripped = 0
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal total_stripped
+        block = match.group(0)
+        kept = []
+        for line in block.split("\n"):
+            if line.strip() == "":
+                total_stripped += 1
+                continue
+            kept.append(line)
+        return "\n".join(kept)
+
+    return _SVG_BLOCK_PATTERN.sub(_sub, body), total_stripped
+```
+
+Update `lint_body`:
+
+```python
+def lint_body(body: str) -> tuple[str, list[LintFix]]:
+    fixes: list[LintFix] = []
+    body, n = _replace_named_entities(body)
+    if n:
+        fixes.append(LintFix("named-entity", n, f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals"))
+    body, n = _collapse_svg_open_tags(body)
+    if n:
+        fixes.append(LintFix("multi-line-svg-open", n, f"collapsed {n} multi-line <svg ...> opening tag(s) to single line"))
+    body, n = _strip_blank_lines_in_svg(body)
+    if n:
+        fixes.append(LintFix("blank-line-in-svg", n, f"stripped {n} blank line(s) inside <svg>...</svg> blocks"))
+    return body, fixes
+```
+
+- [ ] **Step 4.4: Run tests**
+
+Run: `pytest tests/test_blog_lint.py -v`
+Expected: all PASS.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/services/blog_lint.py tests/test_blog_lint.py
+git commit -m "feat(blog-lint): strip blank lines inside <svg> blocks"
+```
+
+---
+
+### Task 5: Stash and restore fenced code blocks
+
+**Files:**
+- Modify: `src/services/blog_lint.py`
+- Modify: `tests/test_blog_lint.py`
+
+**Why:** The skill's `references/svg_diagrams.md` (and any tutorial post about SVG) contains fenced code blocks like ` ```svg\n<svg ...>\n``` ` that demonstrate SVG syntax. The lint rules above would mangle the example — collapsing multi-line opens, stripping internal blanks. We need to preserve fenced code verbatim. The cleanest pattern is **stash** all fenced code blocks before lint, run the rules on the rest, **restore** the stashed blocks.
+
+- [ ] **Step 5.1: Write failing test**
+
+Append to `tests/test_blog_lint.py`:
+```python
+def test_lint_does_not_mangle_fenced_code_blocks():
+    src = (
+        "Here's the template:\n"
+        "\n"
+        "```svg\n"
+        '<svg viewBox="0 0 100 100"\n'
+        '     xmlns="..."\n'
+        '     role="img">\n'
+        "\n"
+        "  <text>example</text>\n"
+        "</svg>\n"
+        "```\n"
+        "\n"
+        "And here's a real one:\n"
+        "\n"
+        '<svg viewBox="0 0 200 200" xmlns="..." role="img">\n'
+        '  <title>real</title>\n'
+        "\n"
+        "  <text>real text</text>\n"
+        "</svg>\n"
+    )
+    fixed, fixes = lint_body(src)
+    # The CODE BLOCK content must be preserved verbatim — multi-line open and blanks stay.
+    assert (
+        '```svg\n'
+        '<svg viewBox="0 0 100 100"\n'
+        '     xmlns="..."\n'
+        '     role="img">\n'
+        "\n"
+        "  <text>example</text>\n"
+        "</svg>\n"
+        "```"
+    ) in fixed
+    # The REAL <svg> outside the code block IS linted (no internal blank line).
+    real_block_start = fixed.index('<svg viewBox="0 0 200 200"')
+    real_block_end = fixed.index("</svg>", real_block_start)
+    real_block = fixed[real_block_start:real_block_end]
+    assert "\n\n" not in real_block
+```
+
+- [ ] **Step 5.2: Run test to verify it fails**
+
+Run: `pytest tests/test_blog_lint.py::test_lint_does_not_mangle_fenced_code_blocks -v`
+Expected: FAIL (the lint mangles the code block).
+
+- [ ] **Step 5.3: Implement stash/restore around lint_body**
+
+Add at the top of the lint pipeline (above `_replace_named_entities` etc., or refactor `lint_body`):
+
+```python
+_FENCED_CODE_PATTERN = re.compile(r"(^|\n)(```[^\n]*\n.*?\n```)(?=\n|$)", re.DOTALL)
+
+
+def _stash_fenced_code(body: str) -> tuple[str, list[str]]:
+    """Replace each fenced code block with a unique placeholder; return placeholder list.
+
+    The placeholder is a sentinel that won't match any lint regex, so the rest
+    of the pipeline ignores code-block content. Caller restores via _restore_fenced_code.
+    """
+    stash: list[str] = []
+
+    def _sub(match: re.Match[str]) -> str:
+        prefix, block = match.group(1), match.group(2)
+        idx = len(stash)
+        stash.append(block)
+        return f"{prefix}__BLOG_LINT_STASH_{idx}__"
+
+    return _FENCED_CODE_PATTERN.sub(_sub, body), stash
+
+
+def _restore_fenced_code(body: str, stash: list[str]) -> str:
+    for idx, block in enumerate(stash):
+        body = body.replace(f"__BLOG_LINT_STASH_{idx}__", block)
+    return body
+```
+
+Update `lint_body`:
+
+```python
+def lint_body(body: str) -> tuple[str, list[LintFix]]:
+    body, stash = _stash_fenced_code(body)
+    fixes: list[LintFix] = []
+    body, n = _replace_named_entities(body)
+    if n:
+        fixes.append(LintFix("named-entity", n, f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals"))
+    body, n = _collapse_svg_open_tags(body)
+    if n:
+        fixes.append(LintFix("multi-line-svg-open", n, f"collapsed {n} multi-line <svg ...> opening tag(s) to single line"))
+    body, n = _strip_blank_lines_in_svg(body)
+    if n:
+        fixes.append(LintFix("blank-line-in-svg", n, f"stripped {n} blank line(s) inside <svg>...</svg> blocks"))
+    body = _restore_fenced_code(body, stash)
+    return body, fixes
+```
+
+- [ ] **Step 5.4: Run all blog_lint tests**
+
+Run: `pytest tests/test_blog_lint.py -v`
+Expected: all PASS, including the new code-block test.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add src/services/blog_lint.py tests/test_blog_lint.py
+git commit -m "feat(blog-lint): stash fenced code blocks before lint to preserve examples"
+```
+
+---
+
+### Task 6: Idempotency, indented widget SVGs, regression on real fixture
+
+**Files:**
+- Modify: `tests/test_blog_lint.py`
+
+- [ ] **Step 6.1: Write three more tests**
+
+Append to `tests/test_blog_lint.py`:
+```python
+def test_lint_is_idempotent():
+    """Running lint twice on the same input produces the same output as once."""
+    src = (
+        '<svg viewBox="0 0 100 100"\n'
+        '     xmlns="..."\n'
+        '     role="img">\n'
+        '  <title>t &mdash; subtitle</title>\n'
+        '\n'
+        '  <text>x &times; y</text>\n'
+        '</svg>'
+    )
+    once, _ = lint_body(src)
+    twice, fixes_second = lint_body(once)
+    assert once == twice
+    assert fixes_second == []  # second pass is a no-op
+
+
+def test_lint_does_not_mangle_indented_widget_svg():
+    """SVG indented as a child of <div class="ptb-state"> is left alone by the
+    blank-line rule; the surrounding <div> already prevents mistletoe from
+    breaking the SVG, so the lint shouldn't touch the indentation.
+
+    The strip_blank_lines_in_svg rule operates inside <svg>...</svg> regardless
+    of indentation, which is fine because indented SVGs typically don't have
+    blank lines inside in the first place. This test guards against any future
+    rule that might be too aggressive about indentation.
+    """
+    src = (
+        '<div class="ptb-state" id="s1">\n'
+        '    <svg viewBox="0 0 100 100" xmlns="..." role="img">\n'
+        '      <title>indented</title>\n'
+        '      <text>x</text>\n'
+        '    </svg>\n'
+        '</div>'
+    )
+    fixed, fixes = lint_body(src)
+    # No changes expected — this SVG is already lint-clean.
+    assert fixed == src
+    assert fixes == []
+
+
+def test_lint_canary_against_real_post_0022():
+    """Regression guard: lint reduces 0022 to a state with no internal SVG blanks.
+
+    This is the post that originally exhibited all three bug classes. We don't
+    assert byte-equality (that would be brittle if the post is edited); we
+    assert that after lint, the body has no <svg> block with a blank line in it.
+    """
+    from pathlib import Path
+    src = Path("assets/blogs/0022-spike-sparse-sink-anatomy-massive.md").read_text(encoding="utf-8")
+    fixed, _ = lint_body(src)
+    # Find every <svg>...</svg> and check no blank line inside.
+    import re
+    for m in re.finditer(r"<svg\b[^>]*>.*?</svg>", fixed, re.DOTALL):
+        block = m.group(0)
+        for line in block.split("\n"):
+            assert line.strip() != "", f"Blank line found inside SVG block: {block[:120]!r}..."
+```
+
+- [ ] **Step 6.2: Run tests**
+
+Run: `pytest tests/test_blog_lint.py -v`
+Expected: all PASS. (The canary test will pass because the user already pushed the lint fix for 0022 in an earlier session — but it serves as a regression guard against future drift.)
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add tests/test_blog_lint.py
+git commit -m "test(blog-lint): idempotency, indented widget skip, real-post canary"
+```
+
+---
+
+### Task 7: `blog_render.py` — render_to_html
+
+**Files:**
+- Create: `src/services/blog_render.py`
+- Create: `tests/test_blog_render.py`
+
+- [ ] **Step 7.1: Write failing test**
+
+`tests/test_blog_render.py`:
+```python
+"""Tests for src.services.blog_render."""
+import pytest
+from src.services.blog_render import RenderError, render_to_html
+
+
+def test_render_passes_simple_markdown_to_html():
+    md = "# Hello\n\nWorld."
+    html = render_to_html(md)
+    assert "<h1" in html  # monsterui adds classes; just check the tag opened
+    assert "Hello" in html
+    assert "<p" in html
+    assert "World." in html
+
+
+def test_render_returns_plain_string_not_notstr():
+    """The function must return `str`, not a FastHTML NotStr/FT object."""
+    html = render_to_html("plain")
+    assert isinstance(html, str)
+
+
+def test_render_preserves_inline_svg_when_clean():
+    md = (
+        '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img">\n'
+        '  <title>t</title>\n'
+        '  <text>x</text>\n'
+        '</svg>'
+    )
+    html = render_to_html(md)
+    assert "<svg" in html
+    assert "<title" in html  # monsterui may rewrite case but tag stays
+    assert "<text" in html
+    # The diagnostic for the bug we're fixing — must NOT appear:
+    assert "<p><svg" not in html
+    assert "<p><text" not in html
+```
+
+- [ ] **Step 7.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_blog_render.py -v`
+Expected: ImportError.
+
+- [ ] **Step 7.3: Implement `render_to_html`**
+
+`src/services/blog_render.py`:
+```python
+"""Render linted blog markdown to HTML and validate the output.
+
+This module exists so the blog rendering pipeline runs once at submit time
+(rather than once per page view), surfaces parser foot-guns when they're
+cheap to fix, and stores the final HTML in BigQuery as `body_html`.
+
+See `docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from monsterui.all import render_md
+
+
+class RenderError(Exception):
+    """Raised when mistletoe (via monsterui) fails to render a body."""
+
+
+def render_to_html(body: str) -> str:
+    """Render markdown `body` to an HTML string via monsterui.render_md.
+
+    `monsterui.render_md` returns a `NotStr` wrapping HTML; this function
+    unwraps it to a plain `str` so callers can store it as a BigQuery
+    column or scan it with regex validators.
+    """
+    try:
+        rendered = render_md(body)
+    except Exception as exc:  # noqa: BLE001 - we want to wrap any failure
+        raise RenderError(f"render_md failed: {exc}") from exc
+
+    # monsterui returns a NotStr (subclass of str). __str__ is the HTML.
+    return str(rendered)
+```
+
+- [ ] **Step 7.4: Run tests**
+
+Run: `pytest tests/test_blog_render.py -v`
+Expected: all PASS.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add src/services/blog_render.py tests/test_blog_render.py
+git commit -m "feat(blog-render): render markdown to HTML via monsterui.render_md"
+```
+
+---
+
+### Task 8: `blog_render.py` — validate_html with four rules
+
+**Files:**
+- Modify: `src/services/blog_render.py`
+- Modify: `tests/test_blog_render.py`
+
+- [ ] **Step 8.1: Write failing tests**
+
+Append to `tests/test_blog_render.py`:
+```python
+from src.services.blog_render import ValidationIssue, validate_html
+
+
+def test_validate_returns_empty_for_clean_html():
+    html = '<svg viewBox="0 0 1 1" role="img"><title>t</title></svg>'
+    assert validate_html(html) == []
+
+
+def test_validate_catches_p_wrapping_svg():
+    bad = '<p><svg></svg></p>'
+    issues = validate_html(bad)
+    assert any(i.kind == "p-wraps-svg" for i in issues)
+
+
+def test_validate_catches_p_wrapping_text():
+    bad = '<svg role="img"><title>t</title></svg>\n<p><text x="0">stray</text></p>'
+    issues = validate_html(bad)
+    assert any(i.kind == "p-wraps-svg" for i in issues)
+
+
+def test_validate_catches_svg_tag_mismatch():
+    bad = '<svg role="img"><title>t</title>'  # missing </svg>
+    issues = validate_html(bad)
+    assert any(i.kind == "svg-tag-mismatch" for i in issues)
+
+
+def test_validate_catches_svg_missing_title():
+    bad = '<svg viewBox="0 0 1 1" role="img"><text>x</text></svg>'  # no <title>
+    issues = validate_html(bad)
+    assert any(i.kind == "svg-missing-title" for i in issues)
+
+
+def test_validate_catches_svg_missing_role_img():
+    bad = '<svg viewBox="0 0 1 1"><title>t</title></svg>'  # no role="img"
+    issues = validate_html(bad)
+    assert any(i.kind == "svg-missing-role" for i in issues)
+
+
+def test_validate_returns_multiple_issues_at_once():
+    bad = '<p><svg></svg></p><p><text>x</text></p>'  # two <p> wraps + tag mismatch + missing title
+    issues = validate_html(bad)
+    kinds = [i.kind for i in issues]
+    assert kinds.count("p-wraps-svg") >= 2
+
+
+def test_validate_issue_includes_snippet():
+    bad = '<p><svg></svg></p>'
+    issues = validate_html(bad)
+    p_issues = [i for i in issues if i.kind == "p-wraps-svg"]
+    assert len(p_issues) >= 1
+    assert "<svg" in p_issues[0].snippet
+```
+
+- [ ] **Step 8.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_blog_render.py -v`
+Expected: ImportError on `ValidationIssue` and `validate_html`.
+
+- [ ] **Step 8.3: Implement `validate_html`**
+
+Append to `src/services/blog_render.py`:
+
+```python
+@dataclass
+class ValidationIssue:
+    """A single issue found by `validate_html`."""
+
+    kind: Literal["p-wraps-svg", "svg-tag-mismatch", "svg-missing-title", "svg-missing-role"]
+    line: int | None
+    snippet: str
+
+
+# Tags whose presence inside a <p> wrap is the diagnostic of the class-3 bug.
+_SVG_INTERNAL_TAGS = (
+    "svg", "text", "rect", "line", "circle", "path",
+    "g", "defs", "marker",
+)
+_P_WRAPS_SVG = re.compile(
+    r"<p\b[^>]*>\s*<(?:" + "|".join(_SVG_INTERNAL_TAGS) + r"|!--)\b",
+    re.IGNORECASE,
+)
+_SVG_OPEN = re.compile(r"<svg\b[^>]*>", re.IGNORECASE)
+_SVG_CLOSE = re.compile(r"</svg\s*>", re.IGNORECASE)
+_SVG_BLOCK = re.compile(r"<svg\b[^>]*>.*?</svg\s*>", re.DOTALL | re.IGNORECASE)
+_HAS_ROLE_IMG = re.compile(r'role\s*=\s*"img"', re.IGNORECASE)
+_HAS_TITLE_CHILD = re.compile(r"<title\b[^>]*>", re.IGNORECASE)
+
+
+def _line_of(html: str, offset: int) -> int:
+    return html.count("\n", 0, offset) + 1
+
+
+def validate_html(html: str) -> list[ValidationIssue]:
+    """Scan rendered HTML for the four known bad patterns. Returns [] on clean output."""
+    issues: list[ValidationIssue] = []
+
+    # Rule 1: <p>-wraps-SVG-internal-tag
+    for match in _P_WRAPS_SVG.finditer(html):
+        issues.append(ValidationIssue(
+            kind="p-wraps-svg",
+            line=_line_of(html, match.start()),
+            snippet=html[match.start(): match.start() + 120],
+        ))
+
+    # Rule 2: <svg> open count == </svg> close count
+    n_open = len(_SVG_OPEN.findall(html))
+    n_close = len(_SVG_CLOSE.findall(html))
+    if n_open != n_close:
+        issues.append(ValidationIssue(
+            kind="svg-tag-mismatch",
+            line=None,
+            snippet=f"<svg> opens={n_open}, </svg> closes={n_close}",
+        ))
+
+    # Rules 3+4 operate per top-level SVG block.
+    # We don't try to detect nesting here — top-level SVGs are the only ones
+    # users author; nested SVGs are not used in this project.
+    for match in _SVG_BLOCK.finditer(html):
+        block = match.group(0)
+        line = _line_of(html, match.start())
+        if not _HAS_TITLE_CHILD.search(block):
+            issues.append(ValidationIssue(
+                kind="svg-missing-title",
+                line=line,
+                snippet=block[:120],
+            ))
+        # Inspect the opening tag specifically (first match within the block).
+        open_match = _SVG_OPEN.match(block)
+        if open_match and not _HAS_ROLE_IMG.search(open_match.group(0)):
+            issues.append(ValidationIssue(
+                kind="svg-missing-role",
+                line=line,
+                snippet=open_match.group(0),
+            ))
+
+    return issues
+```
+
+- [ ] **Step 8.4: Run tests**
+
+Run: `pytest tests/test_blog_render.py -v`
+Expected: all PASS.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add src/services/blog_render.py tests/test_blog_render.py
+git commit -m "feat(blog-render): validate_html with four bad-pattern rules"
+```
+
+---
+
+## Phase 2: Pydantic + CLI wiring
+
+### Task 9: Add `BlogRow` Pydantic model
+
+**Files:**
+- Modify: `src/services/blog_frontmatter.py`
+- Modify: `tests/test_blog_frontmatter.py`
+
+- [ ] **Step 9.1: Write failing tests**
+
+Append to `tests/test_blog_frontmatter.py`:
+```python
+def test_blog_row_validates_minimal_payload():
+    """BlogRow accepts a complete payload (markdown + html) with no errors."""
+    from datetime import datetime, timezone
+    from src.services.blog_frontmatter import BlogRow
+    row = BlogRow(
+        id="00000000-0000-0000-0000-000000000000",
+        title="Test",
+        date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        tags=["test"],
+        description="d",
+        image="https://example.com/img.svg",
+        type="note",
+        disabled=False,
+        views=0,
+        likes=0,
+        body="# md",
+        body_html="<h1>md</h1>",
+    )
+    assert row.body_html == "<h1>md</h1>"
+
+
+def test_blog_row_rejects_empty_body_html():
+    from datetime import datetime, timezone
+    from pydantic import ValidationError
+    from src.services.blog_frontmatter import BlogRow
+    with pytest.raises(ValidationError, match="body_html"):
+        BlogRow(
+            id="x",
+            title="t",
+            date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            tags=[],
+            description="d",
+            image="https://e.com/i.svg",
+            type="note",
+            disabled=False,
+            views=0,
+            likes=0,
+            body="md",
+            body_html="   ",  # whitespace only — invalid
+        )
+
+
+def test_blog_row_extra_fields_forbidden():
+    from datetime import datetime, timezone
+    from pydantic import ValidationError
+    from src.services.blog_frontmatter import BlogRow
+    with pytest.raises(ValidationError):
+        BlogRow(
+            id="x", title="t",
+            date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            tags=[], description="d",
+            image="https://e.com/i.svg",
+            type="note", disabled=False, views=0, likes=0,
+            body="md", body_html="<h1/>",
+            unexpected="boom",
+        )
+```
+
+- [ ] **Step 9.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_blog_frontmatter.py -v -k blog_row`
+Expected: ImportError on `BlogRow`.
+
+- [ ] **Step 9.3: Add `BlogRow` to `src/services/blog_frontmatter.py`**
+
+Append to `src/services/blog_frontmatter.py`:
+
+```python
+class BlogRow(BaseModel):
+    """The shape of a row in the BigQuery `gn-blog` table.
+
+    During the migration window this carries both `body` (legacy markdown)
+    and `body_html` (rendered HTML). After the legacy `body` column is
+    dropped from the BigQuery table, `body` will be removed from this model
+    and `_payload_from_blog` in src.cli.blog will stop populating it.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    title: str
+    date: datetime
+    tags: list[str]
+    description: str
+    image: HttpUrl
+    type: Literal["note", "article"]
+    disabled: bool
+    views: int
+    likes: int
+    body: str
+    body_html: str
+
+    @field_validator("body_html")
+    @classmethod
+    def _body_html_not_empty(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("body_html must be non-empty")
+        return value
+```
+
+- [ ] **Step 9.4: Run tests**
+
+Run: `pytest tests/test_blog_frontmatter.py -v`
+Expected: all PASS, including the new BlogRow tests AND every pre-existing test (the existing `BlogFrontmatter` is untouched).
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add src/services/blog_frontmatter.py tests/test_blog_frontmatter.py
+git commit -m "feat(blog-frontmatter): add BlogRow Pydantic model for BigQuery payload"
+```
+
+---
+
+### Task 10: Wire `_payload_from_blog` to lint+render+validate
+
+**Files:**
+- Modify: `src/cli/blog.py`
+- Modify: `tests/test_cli_blog.py`
+
+- [ ] **Step 10.1: Write failing tests**
+
+Append to `tests/test_cli_blog.py`:
+```python
+def test_payload_from_blog_includes_body_html(tmp_path):
+    """_payload_from_blog returns a dict with both `body` (markdown) and
+    `body_html` (rendered)."""
+    from src.cli.blog import _payload_from_blog
+    md = tmp_path / "post.md"
+    md.write_text(
+        "@{title = \"T\"\n"
+        "  date = \"2026-01-01T00:00:00Z\"\n"
+        "  tags = [\"x\"]\n"
+        "  views = 0\n"
+        "  likes = 0\n"
+        "  image = \"https://e.com/i.svg\"\n"
+        "  description = \"d\"\n"
+        "  type = \"note\"\n"
+        "  disabled = false\n"
+        "}\n"
+        "# Body\n",
+        encoding="utf-8",
+    )
+    payload = _payload_from_blog(md)
+    assert "body" in payload
+    assert "body_html" in payload
+    assert "<h1" in payload["body_html"]
+
+
+def test_payload_from_blog_persists_lint_fixes_to_disk(tmp_path, capsys):
+    """If lint changes the body, the .md file is overwritten with the linted text."""
+    from src.cli.blog import _payload_from_blog
+    md = tmp_path / "post.md"
+    raw = (
+        "@{title = \"T\"\n"
+        "  date = \"2026-01-01T00:00:00Z\"\n"
+        "  tags = [\"x\"]\n"
+        "  views = 0\n"
+        "  likes = 0\n"
+        "  image = \"https://e.com/i.svg\"\n"
+        "  description = \"d\"\n"
+        "  type = \"note\"\n"
+        "  disabled = false\n"
+        "}\n"
+        "# Body\n"
+        '<svg viewBox="0 0 100 100" xmlns="..." role="img">\n'
+        "  <title>x &mdash; y</title>\n"
+        "  <text>z</text>\n"
+        "</svg>\n"
+    )
+    md.write_text(raw, encoding="utf-8")
+    _payload_from_blog(md)
+    after = md.read_text(encoding="utf-8")
+    assert "&mdash;" not in after
+    assert "—" in after
+    captured = capsys.readouterr()
+    assert "[lint]" in captured.out
+
+
+def test_payload_from_blog_raises_on_validation_failure(tmp_path):
+    """If validate_html finds an issue, _payload_from_blog raises."""
+    from src.cli.blog import _payload_from_blog
+    md = tmp_path / "post.md"
+    # Body contains an SVG with no <title> and no role="img" — both will fail validation.
+    md.write_text(
+        "@{title = \"T\"\n"
+        "  date = \"2026-01-01T00:00:00Z\"\n"
+        "  tags = [\"x\"]\n"
+        "  views = 0\n"
+        "  likes = 0\n"
+        "  image = \"https://e.com/i.svg\"\n"
+        "  description = \"d\"\n"
+        "  type = \"note\"\n"
+        "  disabled = false\n"
+        "}\n"
+        "# Body\n"
+        "<svg viewBox=\"0 0 100 100\"><text>x</text></svg>\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="validate_html"):
+        _payload_from_blog(md)
+```
+
+(Add `import pytest` at the top of the file if it's not already there.)
+
+- [ ] **Step 10.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_cli_blog.py -v -k payload_from_blog`
+Expected: 3 fails (current `_payload_from_blog` doesn't lint, render, or write back).
+
+- [ ] **Step 10.3: Rewire `_payload_from_blog`**
+
+In `src/cli/blog.py`:
+
+1. Update imports:
+```python
+from src.services.blog_frontmatter import BlogRow, ensure_id, parse_blog
+from src.services.blog_lint import LintError, lint_body
+from src.services.blog_render import RenderError, render_to_html, validate_html
+```
+
+2. Replace the body of `_payload_from_blog` with:
+```python
+def _payload_from_blog(path: Path) -> dict[str, Any]:
+    """Parse `path`, lint the body, render to HTML, validate, and return a BlogRow dict.
+
+    Side effects:
+      * Backfills a UUID into the file (via ensure_id) if missing.
+      * Writes lint fixes back to the file if any rule applied.
+    """
+    ensure_id(path)
+    blog = parse_blog(path)
+
+    try:
+        fixed_body, fixes = lint_body(blog.body)
+    except LintError as exc:
+        raise ValueError(f"lint_body failed: {exc}") from exc
+
+    if fixes and fixed_body != blog.body:
+        _persist_body_to_file(path, blog.body, fixed_body)
+        for f in fixes:
+            print(f"[lint] {f.kind}: {f.detail}")
+        # Re-parse so the in-memory model reflects the on-disk file.
+        blog = parse_blog(path)
+
+    try:
+        html = render_to_html(blog.body)
+    except RenderError as exc:
+        raise ValueError(f"render_to_html failed: {exc}") from exc
+
+    issues = validate_html(html)
+    if issues:
+        for i in issues:
+            print(
+                f"[error] {i.kind} (line {i.line}): {i.snippet[:120]}",
+                file=sys.stderr,
+            )
+        raise ValueError(
+            f"validate_html found {len(issues)} issue(s); fix the source and re-run"
+        )
+
+    row = BlogRow(**{**blog.model_dump(), "body_html": html})
+    return row.model_dump(mode="json")
+
+
+def _persist_body_to_file(path: Path, old_body: str, new_body: str) -> None:
+    """Replace the body of `path` with `new_body`, preserving the frontmatter block.
+
+    Writes byte-for-byte except for the body section after the closing
+    frontmatter delimiter.
+    """
+    text = path.read_text(encoding="utf-8")
+    if not text.endswith(old_body):
+        # Defensive: the body should always be the trailing portion of the file.
+        # If it's not, refuse to mangle the file.
+        raise ValueError(
+            f"refusing to persist lint fixes: body of {path} does not appear at end of file"
+        )
+    new_text = text[: -len(old_body)] + new_body
+    path.write_text(new_text, encoding="utf-8")
+```
+
+- [ ] **Step 10.4: Run all CLI tests**
+
+Run: `pytest tests/test_cli_blog.py -v`
+Expected: all PASS, including new tests AND existing validate-only ones.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add src/cli/blog.py tests/test_cli_blog.py
+git commit -m "feat(cli-blog): wire _payload_from_blog to lint+render+validate"
+```
+
+---
+
+### Task 11: Upgrade `_cmd_validate` to read-only lint+render+validate
+
+**Files:**
+- Modify: `src/cli/blog.py`
+- Modify: `tests/test_cli_blog.py`
+
+- [ ] **Step 11.1: Write failing tests**
+
+Append to `tests/test_cli_blog.py`:
+```python
+def test_validate_reports_lint_issues_without_writing(tmp_path, capsys):
+    """`blog validate` reports lint issues but does NOT write the file."""
+    from src.cli.__main__ import main
+    md = tmp_path / "post.md"
+    raw = (
+        "@{id = \"00000000-0000-0000-0000-000000000000\"\n"
+        "  title = \"T\"\n"
+        "  date = \"2026-01-01T00:00:00Z\"\n"
+        "  tags = [\"x\"]\n"
+        "  views = 0\n"
+        "  likes = 0\n"
+        "  image = \"https://e.com/i.svg\"\n"
+        "  description = \"d\"\n"
+        "  type = \"note\"\n"
+        "  disabled = false\n"
+        "}\n"
+        "# B\n<svg viewBox=\"0 0 1 1\" xmlns=\"...\" role=\"img\"><title>x &mdash; y</title></svg>\n"
+    )
+    md.write_text(raw, encoding="utf-8")
+    rc = main(["blog", "validate", str(md)])
+    assert rc == 0
+    after = md.read_text(encoding="utf-8")
+    # File must be unchanged.
+    assert after == raw
+    captured = capsys.readouterr()
+    # Validate should report what lint WOULD do.
+    assert "lint" in captured.out.lower() or "would" in captured.out.lower()
+
+
+def test_validate_exits_nonzero_on_validation_issue(tmp_path):
+    """`blog validate` exits nonzero when validate_html finds an issue."""
+    from src.cli.__main__ import main
+    md = tmp_path / "post.md"
+    md.write_text(
+        "@{id = \"00000000-0000-0000-0000-000000000000\"\n"
+        "  title = \"T\"\n"
+        "  date = \"2026-01-01T00:00:00Z\"\n"
+        "  tags = [\"x\"]\n"
+        "  views = 0\n"
+        "  likes = 0\n"
+        "  image = \"https://e.com/i.svg\"\n"
+        "  description = \"d\"\n"
+        "  type = \"note\"\n"
+        "  disabled = false\n"
+        "}\n"
+        "# B\n<svg viewBox=\"0 0 1 1\"><text>missing title and role</text></svg>\n",
+        encoding="utf-8",
+    )
+    rc = main(["blog", "validate", str(md)])
+    assert rc == 1
+```
+
+- [ ] **Step 11.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_cli_blog.py -v -k "lint_issues_without_writing or validation_issue"`
+Expected: 2 fails.
+
+- [ ] **Step 11.3: Implement read-only `_cmd_validate`**
+
+Replace `_cmd_validate` in `src/cli/blog.py`:
+
+```python
+def _cmd_validate(args: argparse.Namespace) -> int:
+    """Read-only check: parse, run lint preview, render, validate.
+
+    Does NOT write to disk and does NOT submit to BigQuery. Use this from
+    pre-commit or CI to catch issues before `submit`.
+    """
+    try:
+        blog = parse_blog(args.path)
+    except Exception as exc:  # noqa: BLE001
+        print(f"INVALID: {exc}", file=sys.stderr)
+        return 1
+
+    # Lint preview — report what `submit` would auto-fix, but don't write.
+    try:
+        _, fixes = lint_body(blog.body)
+    except LintError as exc:
+        print(f"INVALID (lint): {exc}", file=sys.stderr)
+        return 1
+    for f in fixes:
+        print(f"[lint preview] would {f.kind}: {f.detail}")
+
+    # Render + validate against the LINTED body, since that's what submit would push.
+    fixed_body, _ = lint_body(blog.body)
+    try:
+        html = render_to_html(fixed_body)
+    except RenderError as exc:
+        print(f"INVALID (render): {exc}", file=sys.stderr)
+        return 1
+
+    issues = validate_html(html)
+    if issues:
+        for i in issues:
+            print(f"[error] {i.kind} (line {i.line}): {i.snippet[:120]}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {blog.title}")
+    return 0
+```
+
+- [ ] **Step 11.4: Run all CLI tests**
+
+Run: `pytest tests/test_cli_blog.py -v`
+Expected: all PASS, including pre-existing tests like `test_blog_validate_exits_zero_on_valid_file`.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add src/cli/blog.py tests/test_cli_blog.py
+git commit -m "feat(cli-blog): upgrade validate command to read-only lint+render+validate"
+```
+
+---
+
+## Phase 3: End-to-end pipeline tests
+
+### Task 12: E2E tests against real posts 0020 and 0022
+
+**Files:**
+- Create: `tests/test_blog_pipeline_e2e.py`
+
+- [ ] **Step 12.1: Write the E2E suite**
+
+`tests/test_blog_pipeline_e2e.py`:
+```python
+"""End-to-end tests: real posts through the full pipeline (lint → render → validate).
+
+Uses real files in assets/blogs/ as fixtures. These tests run BEFORE BigQuery
+is touched — they exercise pure-Python pipeline only.
+"""
+from pathlib import Path
+
+from src.services.blog_lint import lint_body
+from src.services.blog_render import render_to_html, validate_html
+
+
+def _full_pipeline(md_path: Path) -> tuple[str, list]:
+    """Run a markdown file through lint → render → validate.
+
+    Returns (rendered_html, validation_issues). Does not write to disk.
+    """
+    src = md_path.read_text(encoding="utf-8")
+    fixed, _ = lint_body(src)
+    html = render_to_html(fixed)
+    return html, validate_html(html)
+
+
+def test_e2e_post_0020_renders_clean():
+    """Control: a prose-heavy post with a few SVGs renders with no issues."""
+    html, issues = _full_pipeline(Path("assets/blogs/0020-fm-purturb.md"))
+    assert issues == [], f"Issues found: {[i.kind for i in issues]}"
+    assert len(html) > 1000  # sanity: didn't render to nothing
+
+
+def test_e2e_post_0022_renders_clean():
+    """Canary: post 0022 originally had 33 mistletoe foot-gun sites; must be clean now."""
+    html, issues = _full_pipeline(Path("assets/blogs/0022-spike-sparse-sink-anatomy-massive.md"))
+    assert issues == [], f"Issues found: {[i.kind for i in issues]}"
+    # Spot-check that the SVGs survived.
+    assert html.count("<svg") >= 10
+
+
+def test_e2e_post_0001_renders_clean():
+    """Old prose-only post (no SVG) should still pass through cleanly."""
+    html, issues = _full_pipeline(Path("assets/blogs/0001-fastp.md"))
+    assert issues == [], f"Issues found: {[i.kind for i in issues]}"
+
+
+def test_e2e_lint_is_idempotent_against_real_posts():
+    """Running lint twice on every real post produces identical output."""
+    for md_path in sorted(Path("assets/blogs").glob("*.md")):
+        src = md_path.read_text(encoding="utf-8")
+        once, _ = lint_body(src)
+        twice, _ = lint_body(once)
+        assert once == twice, f"lint is not idempotent on {md_path.name}"
+```
+
+- [ ] **Step 12.2: Run the suite**
+
+Run: `pytest tests/test_blog_pipeline_e2e.py -v`
+Expected: all PASS. If a real post fails, that's signal — investigate, do not silence.
+
+- [ ] **Step 12.3: Commit**
+
+```bash
+git add tests/test_blog_pipeline_e2e.py
+git commit -m "test(blog-pipeline): e2e on real posts 0001/0020/0022 + idempotency sweep"
+```
+
+---
+
+## Phase 4: BigQuery schema + backfill
+
+### Task 13: Add `body_html` column
+
+**Files:** none (BigQuery DDL)
+
+- [ ] **Step 13.1: Run the DDL**
+
+```bash
+bq query --nouse_legacy_sql \
+  'ALTER TABLE `noble-office-299208.portfolio.gn-blog` ADD COLUMN body_html STRING;'
+```
+
+- [ ] **Step 13.2: Verify the column exists**
+
+```bash
+bq show --schema --format=prettyjson noble-office-299208:portfolio.gn-blog | grep -c '"name": "body_html"'
+```
+Expected: `1`.
+
+- [ ] **Step 13.3: Smoke-test a single submit**
+
+Pick one post (e.g. 0021-portello.md) and run:
+```bash
+python -m src.cli blog submit assets/blogs/0021-portello.md --dry-run
+```
+Expected: prints `[dry-run] would insert into noble-office-299208.portfolio.gn-blog:` followed by JSON containing both `"body": "..."` and `"body_html": "<...>"`.
+
+If submit works against a freshly added column without errors, the schema migration is healthy.
+
+- [ ] **Step 13.4: Document the DDL ran**
+
+Append to `docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md` under "Schema migration":
+
+```markdown
+**Migration log:**
+- YYYY-MM-DD HH:MM UTC — `ALTER TABLE ... ADD COLUMN body_html STRING;` executed; verified via `bq show`.
+```
+
+```bash
+git add docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
+git commit -m "chore(bq): add body_html column to gn-blog table"
+```
+
+---
+
+### Task 14: `scripts/backfill_blog_html.py` — dry-run mode
+
+**Files:**
+- Create: `scripts/__init__.py` (empty)
+- Create: `scripts/backfill_blog_html.py`
+- Create: `tests/test_backfill_blog_html.py`
+
+- [ ] **Step 14.1: Write failing tests for the dry-run logic**
+
+`tests/test_backfill_blog_html.py`:
+```python
+"""Tests for scripts.backfill_blog_html."""
+from pathlib import Path
+
+import pytest
+
+
+def test_iter_blog_paths_returns_sorted_md_files(tmp_path):
+    from scripts.backfill_blog_html import iter_blog_paths
+    (tmp_path / "0003-c.md").write_text("@{}\n", encoding="utf-8")
+    (tmp_path / "0001-a.md").write_text("@{}\n", encoding="utf-8")
+    (tmp_path / "0002-b.md").write_text("@{}\n", encoding="utf-8")
+    (tmp_path / "skip.txt").write_text("not md", encoding="utf-8")
+
+    paths = iter_blog_paths(tmp_path)
+    names = [p.name for p in paths]
+    assert names == ["0001-a.md", "0002-b.md", "0003-c.md"]
+
+
+def test_dry_run_does_not_call_submit(tmp_path, monkeypatch, capsys):
+    """In --dry-run mode, the script previews each file without invoking BigQuery."""
+    from scripts.backfill_blog_html import run_backfill
+    from src.cli import blog as blog_module
+
+    submit_calls: list[str] = []
+    monkeypatch.setattr(
+        blog_module, "_cmd_submit", lambda args: submit_calls.append(str(args.path)) or 0
+    )
+
+    # Stub out _payload_from_blog so we don't need real Pydantic frontmatter.
+    def fake_payload(path):
+        return {"id": "x", "body": path.read_text(), "body_html": "<p>html</p>"}
+    monkeypatch.setattr(blog_module, "_payload_from_blog", fake_payload)
+
+    blogs = tmp_path / "blogs"
+    blogs.mkdir()
+    (blogs / "0001-a.md").write_text("@{}\nbody", encoding="utf-8")
+
+    rc = run_backfill(blogs, dry_run=True)
+    assert rc == 0
+    assert submit_calls == []  # nothing pushed
+    captured = capsys.readouterr()
+    assert "0001-a.md" in captured.out
+
+
+def test_classify_streaming_buffer_error_recognizes_known_message():
+    from scripts.backfill_blog_html import is_streaming_buffer_error
+
+    class MockExc(Exception):
+        pass
+
+    err = MockExc("UPDATE or DELETE statement over table ... would affect rows in the streaming buffer, which is not supported")
+    assert is_streaming_buffer_error(err)
+    assert not is_streaming_buffer_error(MockExc("permission denied"))
+```
+
+- [ ] **Step 14.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_backfill_blog_html.py -v`
+Expected: ImportError on `scripts.backfill_blog_html`.
+
+- [ ] **Step 14.3: Create the script**
+
+`scripts/__init__.py`:
+```python
+"""Operational scripts (one-shots / migrations)."""
+```
+
+`scripts/backfill_blog_html.py`:
+```python
+"""Backfill body_html for every blog post in /app/assets/blogs.
+
+Usage:
+    python scripts/backfill_blog_html.py --dry-run   # preview only
+    python scripts/backfill_blog_html.py             # execute (one update per post)
+
+In execute mode, each post is processed:
+  1. Run _payload_from_blog (lint → render → validate) and persist any lint fixes
+     to the .md file.
+  2. If --dry-run, print a one-line summary and continue.
+  3. Otherwise call `python -m src.cli blog update <path>` (DELETE + INSERT).
+
+BigQuery's streaming buffer rejects DML on rows inserted within the last
+~30 minutes. The script collects streaming-buffer failures, sleeps 35 min,
+and retries them once. Anything that still fails after retry is reported
+and the script exits non-zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BLOGS_DIR = REPO_ROOT / "assets" / "blogs"
+STREAMING_BUFFER_MARKER = "streaming buffer"
+
+
+def iter_blog_paths(blogs_dir: Path) -> list[Path]:
+    """Return all `*.md` files in `blogs_dir`, sorted by filename."""
+    return sorted(p for p in blogs_dir.iterdir() if p.suffix == ".md" and p.is_file())
+
+
+def is_streaming_buffer_error(exc: BaseException) -> bool:
+    """Heuristic: BigQuery surfaces this exact phrase in the error message."""
+    return STREAMING_BUFFER_MARKER in str(exc).lower()
+
+
+def run_backfill(blogs_dir: Path, dry_run: bool) -> int:
+    """Iterate blogs and submit updates. Return 0 on success, 1 on failures."""
+    from argparse import Namespace
+    from src.cli import blog as blog_module
+
+    paths = iter_blog_paths(blogs_dir)
+    print(f"Found {len(paths)} blog post(s) in {blogs_dir}.")
+
+    successes: list[Path] = []
+    streaming_failures: list[Path] = []
+    hard_failures: list[tuple[Path, str]] = []
+
+    for path in paths:
+        print(f"\n--- {path.name} ---")
+        try:
+            payload = blog_module._payload_from_blog(path)
+        except Exception as exc:  # noqa: BLE001
+            hard_failures.append((path, f"payload error: {exc}"))
+            continue
+
+        if dry_run:
+            print(f"[dry-run] would update id={payload.get('id', '?')} (body_html: {len(payload.get('body_html', ''))} chars)")
+            successes.append(path)
+            continue
+
+        ns = Namespace(path=path, dry_run=False, table=None)
+        try:
+            rc = blog_module._cmd_update(ns)
+        except Exception as exc:
+            if is_streaming_buffer_error(exc):
+                print(f"[stream-buffer] {path.name} hit streaming-buffer; will retry")
+                streaming_failures.append(path)
+                continue
+            hard_failures.append((path, f"update raised: {exc}"))
+            continue
+        if rc != 0:
+            hard_failures.append((path, f"update returned {rc}"))
+        else:
+            successes.append(path)
+
+    if streaming_failures and not dry_run:
+        print(f"\n=== Sleeping 35 minutes before retrying {len(streaming_failures)} streaming-buffer post(s) ===")
+        time.sleep(35 * 60)
+        for path in streaming_failures:
+            print(f"\n--- retry: {path.name} ---")
+            ns = Namespace(path=path, dry_run=False, table=None)
+            try:
+                rc = blog_module._cmd_update(ns)
+            except Exception as exc:
+                hard_failures.append((path, f"retry raised: {exc}"))
+                continue
+            if rc != 0:
+                hard_failures.append((path, f"retry returned {rc}"))
+            else:
+                successes.append(path)
+
+    print("\n=== Summary ===")
+    print(f"  succeeded: {len(successes)}")
+    print(f"  hard-failed: {len(hard_failures)}")
+    for p, reason in hard_failures:
+        print(f"    - {p.name}: {reason}")
+    return 0 if not hard_failures else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Preview only; do not push to BigQuery.")
+    parser.add_argument("--blogs-dir", default=str(DEFAULT_BLOGS_DIR), help="Directory containing the blog .md files.")
+    args = parser.parse_args(argv)
+    return run_backfill(Path(args.blogs_dir), dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 14.4: Run tests**
+
+Run: `pytest tests/test_backfill_blog_html.py -v`
+Expected: all PASS.
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add scripts/__init__.py scripts/backfill_blog_html.py tests/test_backfill_blog_html.py
+git commit -m "feat(scripts): add backfill_blog_html with dry-run + streaming-buffer retry"
+```
+
+---
+
+### Task 15: Backfill — dry-run review, then real
+
+**Files:** posts in `assets/blogs/` (lint may rewrite some)
+
+- [ ] **Step 15.1: Run dry-run**
+
+```bash
+python scripts/backfill_blog_html.py --dry-run 2>&1 | tee /tmp/backfill-dryrun.log
+```
+Expected: 22 posts processed, summary shows 22 succeeded / 0 hard-failed.
+
+- [ ] **Step 15.2: Inspect lint diffs**
+
+The dry-run runs `_payload_from_blog`, which writes lint fixes back to the `.md` file. After dry-run, review what changed:
+
+```bash
+git status assets/blogs/
+git diff assets/blogs/ | less
+```
+
+Spot-check a few diffs:
+- Entity replacements (e.g. `&mdash;` → `—`) should be the bulk on legacy posts (0001-0020).
+- No prose changes — lint only touches SVG content and named entities.
+
+If diffs look surprising, investigate before continuing. Restore the file with `git checkout assets/blogs/<file>` and dig in.
+
+- [ ] **Step 15.3: Commit lint-cleaned posts**
+
+```bash
+git add assets/blogs/
+git commit -m "chore(blogs): apply lint fixes from backfill dry-run"
+```
+
+- [ ] **Step 15.4: Run real backfill**
+
+```bash
+python scripts/backfill_blog_html.py 2>&1 | tee /tmp/backfill-run.log
+```
+
+Expected: each post is updated. Posts inserted within the last ~30 min hit the streaming-buffer path; the script sleeps 35 min and retries. End-state: `succeeded: 22, hard-failed: 0`.
+
+If the run hits hard failures, review the log, fix the underlying issue, and re-run for just the failed posts (e.g. `python -m src.cli blog update assets/blogs/<name>.md`).
+
+- [ ] **Step 15.5: Verify in BigQuery**
+
+```bash
+bq query --nouse_legacy_sql \
+  'SELECT COUNT(*) AS n_total, COUNTIF(body_html IS NOT NULL AND LENGTH(body_html) > 0) AS n_with_html FROM `noble-office-299208.portfolio.gn-blog`'
+```
+Expected: `n_total == n_with_html` and equal to the number of posts.
+
+---
+
+## Phase 5: Reader cutover
+
+### Task 16: Add `body_html` to `Project` model
+
+**Files:**
+- Modify: `src/models/project.py`
+- Add: `tests/test_project_model.py` (if it doesn't already exist; otherwise extend the existing tests file)
+
+- [ ] **Step 16.1: Write failing test**
+
+`tests/test_project_model.py` (or extend existing):
+```python
+"""Tests for src.models.project."""
+from src.models.project import Project
+
+
+def test_project_from_dict_reads_body_html():
+    data = {
+        "id": "x",
+        "title": "T",
+        "description": "d",
+        "image": "https://e.com/i.svg",
+        "tags": ["t"],
+        "disabled": False,
+        "views": 0,
+        "likes": 0,
+        "date": "2026-01-01T00:00:00Z",
+        "body": "# md",
+        "body_html": "<h1>md</h1>",
+    }
+    p = Project.from_dict(data)
+    assert p.body_html == "<h1>md</h1>"
+    assert p.body == "# md"  # transitional: both fields populated
+
+
+def test_project_from_dict_defaults_body_html_to_empty_string():
+    """A row that doesn't have body_html (legacy/transitional) yields an empty string."""
+    data = {"id": "x", "title": "T", "description": "d", "image": "i", "body": "md"}
+    p = Project.from_dict(data)
+    assert p.body_html == ""
+```
+
+- [ ] **Step 16.2: Run tests**
+
+Run: `pytest tests/test_project_model.py -v`
+Expected: 1+ fail (no `body_html` field).
+
+- [ ] **Step 16.3: Add `body_html` to the dataclass**
+
+In `src/models/project.py`:
+
+```python
+@dataclass
+class Project:
+    id: str
+    blog_id: str
+    title: str
+    description: str
+    image: str
+    tags: List[str] = field(default_factory=list)
+    disabled: bool = False
+    views: int = 0
+    likes: int = 0
+    date: str = ""
+    body: str = ""           # legacy markdown source; dropped after the body column is dropped
+    body_html: str = ""      # rendered HTML; the new source for the renderer
+    slug: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Project":
+        # ...existing tag and slug logic...
+        return cls(
+            id=data.get("id", ""),
+            blog_id=data.get("blog_id", ""),
+            title=title,
+            description=data.get("description", ""),
+            image=data.get("image", ""),
+            tags=tags,
+            disabled=data.get("disabled", False),
+            views=data.get("views", 0),
+            likes=data.get("likes", 0),
+            date=data.get("date", ""),
+            body=data.get("body", ""),
+            body_html=data.get("body_html", ""),
+            slug=slug,
+        )
+```
+
+- [ ] **Step 16.4: Run tests**
+
+Run: `pytest tests/test_project_model.py tests/ -v`
+Expected: all PASS.
+
+- [ ] **Step 16.5: Commit**
+
+```bash
+git add src/models/project.py tests/test_project_model.py
+git commit -m "feat(models): Project gains body_html field for rendered HTML"
+```
+
+---
+
+### Task 17: Switch `projects_page.py` renderer to use `body_html`
+
+**Files:**
+- Modify: `src/features/projects/projects_page.py:54`
+
+- [ ] **Step 17.1: Make the change**
+
+In `src/features/projects/projects_page.py`, line 54:
+```python
+# before
+render_md(project.body),
+# after
+NotStr(project.body_html) if project.body_html else render_md(project.body),
+```
+
+Why the conditional: it's a defensive fallback so a row missing `body_html` (e.g. if someone manually inserts a row in the BQ console without going through the CLI) doesn't render as a blank page. Once we DROP the `body` column at task 20, the fallback is removed.
+
+- [ ] **Step 17.2: Add an integration test**
+
+In `tests/test_blog_detail_view.py` (new file):
+```python
+"""Tests that the blog detail page reads body_html in preference to body."""
+from src.models.project import Project
+
+
+def test_blog_detail_uses_body_html_when_present(monkeypatch):
+    """Renderer prefers body_html when populated."""
+    from src.features.projects import projects_page
+
+    project = Project(
+        id="x", blog_id="x", title="T", description="d", image="i",
+        body="# markdown", body_html="<h1>html-rendered</h1>",
+    )
+    out = projects_page._render_blog_detail(project)
+    rendered = str(out)
+    assert "html-rendered" in rendered
+    assert "# markdown" not in rendered  # markdown text not exposed raw
+
+
+def test_blog_detail_falls_back_to_body_when_html_missing():
+    """Renderer falls back to render_md(body) when body_html is empty."""
+    from src.features.projects import projects_page
+
+    project = Project(
+        id="x", blog_id="x", title="T", description="d", image="i",
+        body="# markdown", body_html="",
+    )
+    out = projects_page._render_blog_detail(project)
+    rendered = str(out)
+    # render_md should have produced an <h1> from the markdown.
+    assert "<h1" in rendered
+```
+
+- [ ] **Step 17.3: Run tests**
+
+Run: `pytest tests/test_blog_detail_view.py tests/ -v`
+Expected: all PASS.
+
+- [ ] **Step 17.4: Verify against the live site**
+
+```bash
+# Restart the dev server (or wait for cloud-run redeploy) and curl one post:
+curl -s 'https://gabriel.navarro.bio/blogs/slug/portello-making-global-assembly-more-effective-for-rare-disease-whole-genome-sequencing' \
+  | grep -c '<svg ' \
+  # Expect ≥ 5 — the SVGs are now baked from body_html.
+```
+
+If you have Playwright access, run a quick check that no `<p><svg` appears in the rendered DOM.
+
+- [ ] **Step 17.5: Commit**
+
+```bash
+git add src/features/projects/projects_page.py tests/test_blog_detail_view.py
+git commit -m "feat(blog-detail): render body_html in preference to body"
+```
+
+---
+
+### Task 18: Soak — 1 week of monitoring
+
+**Files:** none
+
+- [ ] **Step 18.1: Wait at least 7 days**
+
+During the soak window:
+- Watch the live site for any reports of broken posts.
+- Spot-check a handful of posts manually each day.
+- If a regression is found, the rollback is one revert: `git revert <task-17-commit>`.
+
+- [ ] **Step 18.2: After 7 days, run a final sanity scan**
+
+```bash
+# Pull every blog row's body_html and assert validate_html returns clean.
+python - <<'PY'
+from src.services.projects import ProjectService
+from src.services.blog_render import validate_html
+
+projects = ProjectService().get_all_projects(include_disabled=True)
+bad = [(p.id, p.title, validate_html(p.body_html)) for p in projects if validate_html(p.body_html)]
+if bad:
+    for pid, title, issues in bad:
+        print(f"{pid} | {title}")
+        for i in issues:
+            print(f"  {i.kind}: {i.snippet[:100]}")
+    raise SystemExit(1)
+print(f"All {len(projects)} posts pass validate_html.")
+PY
+```
+Expected: no output of bad rows; final line confirms all posts clean.
+
+- [ ] **Step 18.3: Document the soak**
+
+Append to the spec:
+
+```markdown
+**Soak log:**
+- YYYY-MM-DD — soak began (commit <hash>).
+- YYYY-MM-DD — soak ended; all 22 posts pass validate_html; no incidents reported.
+```
+
+```bash
+git add docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
+git commit -m "docs(spec): record successful 1-week soak of body_html cutover"
+```
+
+---
+
+## Phase 6: Drop legacy `body` column
+
+### Task 19: DROP `body` column
+
+**Files:** none (BigQuery DDL)
+
+- [ ] **Step 19.1: Run the DDL**
+
+```bash
+bq query --nouse_legacy_sql \
+  'ALTER TABLE `noble-office-299208.portfolio.gn-blog` DROP COLUMN body;'
+```
+
+- [ ] **Step 19.2: Verify**
+
+```bash
+bq show --schema --format=prettyjson noble-office-299208:portfolio.gn-blog | grep -c '"name": "body"'
+```
+Expected: `0` (only `body_html` remains; `body` is gone).
+
+- [ ] **Step 19.3: Smoke-test live page**
+
+Visit one blog post URL in a browser. The page should render exactly as before — `body_html` is the source.
+
+- [ ] **Step 19.4: Document**
+
+Append to spec under "Migration log":
+```markdown
+- YYYY-MM-DD — `ALTER TABLE ... DROP COLUMN body;` executed; verified via `bq show`.
+```
+
+```bash
+git add docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
+git commit -m "chore(bq): drop legacy body column from gn-blog"
+```
+
+---
+
+### Task 20: Remove transitional code
+
+**Files:**
+- Modify: `src/services/blog_frontmatter.py` (remove `body: str` from `BlogRow`)
+- Modify: `src/cli/blog.py` (`_payload_from_blog` excludes `body` from BlogRow construction)
+- Modify: `src/models/project.py` (remove `body` field)
+- Modify: `src/features/projects/projects_page.py` (remove the `if project.body_html else render_md(project.body)` fallback)
+- Modify: tests that asserted both fields (update to body_html only)
+
+- [ ] **Step 20.1: Update tests first (red-green)**
+
+Update `tests/test_blog_frontmatter.py` and `tests/test_project_model.py` so that:
+- `BlogRow` test no longer passes `body=`.
+- `Project` test no longer asserts `p.body`.
+- `Project.from_dict` test passes a row dict with NO `body` key.
+
+Also remove the fallback test in `tests/test_blog_detail_view.py`:
+- Drop `test_blog_detail_falls_back_to_body_when_html_missing`.
+
+- [ ] **Step 20.2: Run tests; expect failures in production code**
+
+Run: `pytest tests/ -v`
+Expected: failures in tests that touched `body`; production code still has the field.
+
+- [ ] **Step 20.3: Remove the `body` field from production code**
+
+In `src/services/blog_frontmatter.py` `BlogRow`:
+```python
+class BlogRow(BaseModel):
+    """The shape of a row in the BigQuery `gn-blog` table.
+
+    The legacy `body` column was dropped on YYYY-MM-DD; only `body_html`
+    is stored.
+    """
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    title: str
+    date: datetime
+    tags: list[str]
+    description: str
+    image: HttpUrl
+    type: Literal["note", "article"]
+    disabled: bool
+    views: int
+    likes: int
+    body_html: str
+    # ...validator unchanged
+```
+
+In `src/cli/blog.py` `_payload_from_blog`:
+```python
+row = BlogRow(**{**blog.model_dump(exclude={"body"}), "body_html": html})
+```
+
+In `src/models/project.py` `Project`:
+```python
+@dataclass
+class Project:
+    # ...
+    body_html: str = ""
+    # body field REMOVED
+    slug: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Project":
+        # ...
+        return cls(
+            # ...
+            body_html=data.get("body_html", ""),
+            # body=...  REMOVED
+            slug=slug,
+        )
+```
+
+In `src/features/projects/projects_page.py`:
+```python
+NotStr(project.body_html),
+```
+(remove the conditional fallback).
+
+- [ ] **Step 20.4: Run all tests**
+
+Run: `pytest tests/ -v`
+Expected: all PASS.
+
+- [ ] **Step 20.5: Smoke test the CLI**
+
+```bash
+python -m src.cli blog validate assets/blogs/0021-portello.md
+python -m src.cli blog submit assets/blogs/0021-portello.md --dry-run
+```
+Expected: both succeed; the dry-run JSON contains `body_html` and NO `body` key.
+
+- [ ] **Step 20.6: Smoke-test live**
+
+Visit any blog post in a browser. Expect identical rendering to before.
+
+- [ ] **Step 20.7: Commit**
+
+```bash
+git add src/services/blog_frontmatter.py src/cli/blog.py src/models/project.py src/features/projects/projects_page.py tests/
+git commit -m "refactor: remove transitional body field after legacy column drop"
+```
+
+---
+
+## Phase 7: Documentation alignment
+
+### Task 21: Update the paper-to-blog skill docs
+
+**Files:**
+- Modify: `.claude/skills/paper-to-blog/SKILL.md`
+- Modify: `.claude/skills/paper-to-blog/references/blog_format.md`
+
+These are informational-only changes — the skill's *workflow* hasn't changed (authors still write `.md` files). What changes is what `submit` does under the hood.
+
+- [ ] **Step 21.1: Add a "Pipeline" subsection to SKILL.md**
+
+After the existing "Stage 4: Fact and logic validation pass" section, add:
+
+```markdown
+## How submit works under the hood
+
+`python -m src.cli blog submit <post.md>` runs an automated pipeline before
+inserting into BigQuery:
+
+1. **Lint** — auto-fixes mistletoe foot-guns: HTML named entities → Unicode,
+   multi-line `<svg>` opens → single-line, blank lines inside SVG → stripped.
+   Lint fixes are written back to the `.md` file. See
+   `src/services/blog_lint.py`.
+2. **Render** — `monsterui.render_md(body)` produces the final HTML.
+3. **Validate** — scans the HTML for known bad patterns (no `<p><svg`, every
+   SVG has `<title>` and `role="img"`, etc.). Submit fails if any issue is
+   found. See `src/services/blog_render.py`.
+4. **Submit** — inserts a row with `body_html` (rendered) into BigQuery. The
+   live page reads `body_html` directly; mistletoe is not run at view time.
+
+If submit reports a `[lint]` line, your `.md` was edited; commit the diff.
+If submit reports a `[error]` line, the lint couldn't auto-fix something
+(e.g. an unmapped HTML entity, or an SVG without a `<title>`); fix the
+source and re-run.
+```
+
+- [ ] **Step 21.2: Note the change in `blog_format.md`**
+
+Add to the top:
+
+```markdown
+## Server-side rendering (since 2026-05)
+
+Blog posts are rendered to HTML at submit time and stored in BigQuery as
+`body_html`. The `.md` file in `assets/blogs/` remains the editable
+source. See `docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md`.
+
+Authors do not need to do anything different: write the `.md`, run
+`python -m src.cli blog submit ...`. The pipeline lints, renders, and
+validates automatically.
+```
+
+- [ ] **Step 21.3: Commit**
+
+```bash
+git add .claude/skills/paper-to-blog/SKILL.md .claude/skills/paper-to-blog/references/blog_format.md
+git commit -m "docs(skill): document body_html pipeline in paper-to-blog skill"
+```
+
+---
+
+## Acceptance Criteria (per spec)
+
+The migration is complete when:
+
+- [ ] `python -m src.cli blog submit <any-post.md>` succeeds with linted source written back to disk and `body_html` populated in BigQuery.
+- [ ] All 22 existing posts have non-null `body_html` in the table.
+- [ ] Every public blog page renders without a `<p><svg` or `<p><text` pattern in the served HTML (verify with curl + grep, or Playwright).
+- [ ] The `body` column has been dropped from `gn-blog` (verify with `bq show --schema`).
+- [ ] `pytest tests/test_blog_lint.py tests/test_blog_render.py tests/test_blog_pipeline_e2e.py tests/test_backfill_blog_html.py tests/test_cli_blog.py tests/test_blog_frontmatter.py tests/test_project_model.py tests/test_blog_detail_view.py` passes (a single full `pytest tests/` run also works).
+- [ ] The paper-to-blog skill's `SKILL.md` and `references/blog_format.md` mention the new pipeline.
+
+---
+
+## Self-review (recorded after first pass)
+
+- **Spec coverage:** Every numbered item in spec's "Implementation order" maps to a task: schema add → 13, lint → 1-6, render → 7-8, BlogRow → 9, payload wiring → 10-11, backfill dry-run + run → 14-15, reader → 16-17, soak → 18, drop → 19, transitional cleanup → 20. Skill docs (acceptance criterion #6) → task 21.
+- **Placeholder scan:** Searched for TBD/TODO; none. Every code step shows full code.
+- **Type consistency:** `LintFix.kind` literal values match between `blog_lint.py` and tests. `ValidationIssue.kind` literal values match between `blog_render.py` and tests. `BlogRow` field names match across the model, `_payload_from_blog`, and tests. `Project` field names match across the dataclass, `from_dict`, the renderer call, and tests.
+- **Scope check:** Single migration. One implementation plan. No further decomposition needed.
+- **Ambiguity check:** "Soak" is explicitly defined as ≥ 7 days plus a final sanity scan. "Streaming buffer retry" is explicitly 35 min, single retry. "Transitional code removal" lists every file.

--- a/docs/superpowers/plans/2026-04-30-blog-html-pipeline.md
+++ b/docs/superpowers/plans/2026-04-30-blog-html-pipeline.md
@@ -55,7 +55,19 @@
 `tests/test_blog_lint.py`:
 ```python
 """Tests for src.services.blog_lint."""
+import pytest
+
 from src.services.blog_lint import LintError, LintFix, lint_body
+
+
+def test_module_exports_public_surface():
+    """The module exports `LintError`, `LintFix`, `lint_body` as the public API."""
+    with pytest.raises(LintError):
+        raise LintError("test")
+    fix = LintFix(kind="named-entity", count=1, detail="example")
+    assert fix.kind == "named-entity"
+    assert fix.count == 1
+    assert fix.detail == "example"
 
 
 def test_lint_body_returns_tuple_of_text_and_fixes():
@@ -64,6 +76,8 @@ def test_lint_body_returns_tuple_of_text_and_fixes():
     assert fixed == text
     assert fixes == []
 ```
+
+(Both tests in the same file — the first exercises `LintError`/`LintFix` directly so the imports aren't unused, the second locks in the no-op return contract.)
 
 - [ ] **Step 1.2: Run test to verify it fails**
 

--- a/docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
@@ -298,6 +298,10 @@ BigQuery doesn't allow column renames, so the migration is `ADD body_html` → b
    ```
    `Project.body` and `BlogRow` no longer reference it. `_payload_from_blog` stops writing it.
 
+### Migration log
+
+- **2026-04-30T21:25Z** — `ALTER TABLE noble-office-299208.portfolio.gn-blog ADD COLUMN body_html STRING;` executed (BigQuery job `afbb8615-44c9-4115-9235-d5dc832ebe4c`). Verified: schema now has 12 fields; `body_html` (STRING) is present and `body` (legacy STRING) is preserved. End-to-end smoke test on `assets/blogs/0021-portello.md --dry-run` confirms the BlogRow payload contains both fields (body=67056 chars, body_html=78579 chars).
+
 ### Migration risks
 
 - **Streaming-buffer constraint on `update`.** Each `update` is DELETE+INSERT, and the streaming buffer holds rows for ~30 min. Backfilling 22 posts naively will trip this. The backfill script handles it with a 35-minute retry loop.

--- a/docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
@@ -1,0 +1,349 @@
+# Blog HTML Pipeline — Design
+
+**Date:** 2026-04-30
+**Status:** Approved (Option B from brainstorming)
+**Owner:** Gabriel Navarro
+**Author of spec:** Claude (paper-to-blog brainstorming session)
+
+## Problem
+
+The portfolio's blog system stores raw markdown in BigQuery and renders it server-side at view time via `monsterui.render_md` (which calls `mistletoe.markdown` under the hood). This works fine for prose-heavy posts but has produced three distinct rendering bugs in posts containing inline SVG diagrams:
+
+1. **HTML named entities in SVG content** (`&mdash;`, `&middot;`, `&times;`, `&rarr;`). SVG is XML and only the five XML-predefined entities (`&amp; &lt; &gt; &apos; &quot;`) parse. Anything else breaks XML parsing. Fix: replace with Unicode literals.
+2. **Multi-line `<svg ...>` opening tags.** Mistletoe's CommonMark Type-7 HTML-block detection requires the entire opening tag to fit on one line; multi-line attributes mean the parser doesn't recognize the SVG as a block, wraps it in a `<p>`, and the browser's HTML5 parser self-closes the empty `<svg>` immediately, leaving every child as orphan DOM. Fix: collapse opening tag to one line.
+3. **Blank lines inside `<svg>` blocks followed by single-line elements.** Mistletoe terminates HTML blocks at blank lines. When the next non-blank line is `<text x="220" y="74">Train positions</text>` (single-line element with content directly after the opening tag's `>`), the parser's "any other tag" rule rejects it (because the opening tag isn't followed by whitespace or end-of-line), falls back to paragraph parsing, and wraps the line in `<p>...</p>`. The matching `</svg>` ends up nested inside another `<p>`. Fix: strip blank lines inside SVG blocks.
+
+All three bugs share a single root cause: **mistletoe parses SVG content as markdown, which it isn't designed for.** Each instance is mechanically fixable, but reactively patching every new mistletoe foot-gun is friction. As of 2026-04-30, post `0022-spike-sparse-sink-anatomy-massive.md` had 33 sites where mistletoe wrapped SVG content in `<p>` tags before the bug class was identified.
+
+## Goals
+
+- Move the markdown→HTML render from view time to submit time.
+- Store the final HTML in BigQuery; the `.md` file remains the editable source.
+- Surface mistletoe foot-guns at submit time (when they're cheap to fix), not at view time (when they're already live).
+- Backfill all 22 existing posts so the cutover is clean.
+- Drop the legacy `body` (markdown) column from BigQuery once verified.
+
+## Non-goals
+
+- Restructuring the body as typed JSON blocks (Option C from brainstorming). Considered, rejected as over-engineering for ≤30 posts.
+- Replacing mistletoe with a different markdown renderer.
+- Changing the markdown frontmatter format (still legacy `@{...}` blocks per `blog_format.md`).
+- Re-authoring existing posts. Lint may rewrite SVG content but will not change prose.
+
+## Architecture
+
+```
+            ┌──────────────────────────────┐
+            │ /app/assets/blogs/NNNN-x.md  │  ← source of truth (markdown)
+            └──────────────┬───────────────┘
+                           │  python -m src.cli blog submit ...
+                           ▼
+   ┌───────────────────────────────────────────────────────┐
+   │ _payload_from_blog()                                  │
+   │  1. ensure_id(path)        — backfill UUID            │
+   │  2. parse_blog(path)        — Pydantic-validate .md   │
+   │  3. lint_body(body)         — auto-fix mistletoe      │
+   │       • entity replacement                            │
+   │       • single-line SVG open                          │
+   │       • strip blank lines in SVG                      │
+   │       • write fixes back to .md                       │
+   │  4. render_to_html(body)    — mistletoe + classes     │
+   │  5. validate_html(html)     — fail-loud on bad shapes │
+   │  6. emit BlogRow {id, ..., body_html}                 │
+   └─────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼
+   ┌───────────────────────────────────────────────────────┐
+   │ BigQuery: noble-office-299208.portfolio.gn-blog       │
+   │   id | title | date | tags | description | image     │
+   │   type | disabled | views | likes | body_html        │
+   └─────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼
+   ┌───────────────────────────────────────────────────────┐
+   │ Page render (FastHTML route /blogs/slug/<slug>)       │
+   │   ProjectService.get_project_by_slug(slug) → Project  │
+   │   _render_blog_detail(project):                       │
+   │     ...                                               │
+   │     NotStr(project.body_html)                         │
+   │     ...                                               │
+   └───────────────────────────────────────────────────────┘
+```
+
+The `.md` file remains the editable source. Mistletoe runs once at submit time. The lint step auto-fixes the three known mistletoe foot-guns and writes the cleaned source back to disk so the `.md` and the BigQuery HTML stay in sync.
+
+## Components
+
+### New module: `src/services/blog_lint.py`
+
+Pure-Python, no I/O coupling. Exposes:
+
+```python
+@dataclass
+class LintFix:
+    kind: Literal["named-entity", "multi-line-svg-open", "blank-line-in-svg"]
+    count: int        # how many sites the rule fixed
+    detail: str       # short human-readable summary
+
+def lint_body(body: str) -> tuple[str, list[LintFix]]: ...
+```
+
+Order of operations within `lint_body`:
+1. Replace named entities (preserving the five XML-safe ones).
+2. Collapse multi-line `<svg ...>` opening tags.
+3. Strip blank lines inside `<svg>...</svg>` blocks.
+
+Each step uses a regex with `re.DOTALL` and is idempotent (safe to run twice). The lint **does not** touch:
+- Fenced code blocks (` ``` ` to ` ``` `): protect with a "stash and restore" pre/post pass.
+- Inline code (single backticks): same.
+- Markdown prose outside `<svg>` blocks: blanks lines in prose are intentional paragraph breaks.
+- HTML-comment-only lines outside SVG.
+
+Unmapped entities raise `LintError` with the unmapped entity name. The CLI catches this and prints a clear "add mapping for `&copy;` and re-run" message.
+
+### New module: `src/services/blog_render.py`
+
+Bridges the linted markdown to validated HTML:
+
+```python
+@dataclass
+class ValidationIssue:
+    kind: Literal["p-wraps-svg", "svg-tag-mismatch", "svg-missing-title", "svg-missing-role"]
+    line: int | None
+    snippet: str
+
+def render_to_html(body: str) -> str: ...
+def validate_html(html: str) -> list[ValidationIssue]: ...
+```
+
+`render_to_html` calls `monsterui.render_md(body, ...)` to keep the existing class-mapping behavior (Tailwind `text-lg leading-relaxed mb-6` on paragraphs, etc.). The function unwraps the `NotStr`/`FT` and returns a plain string.
+
+`validate_html` runs four checks (see "Validation rules" below). Returns `[]` on success.
+
+### Modified module: `src/services/blog_frontmatter.py`
+
+Add a new Pydantic model that represents the BigQuery row payload (distinct from the file-level `BlogFrontmatter`):
+
+```python
+class BlogRow(BaseModel):
+    """The shape of a row in the BigQuery `gn-blog` table.
+
+    During migration (steps 2-9) this model carries both `body` and
+    `body_html`; the CLI populates both on every submit/update. After
+    step 10 drops the `body` column, the field is removed from this
+    model and its callers.
+    """
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    title: str
+    date: datetime
+    tags: list[str]
+    description: str
+    image: HttpUrl
+    type: Literal["note", "article"]
+    disabled: bool
+    views: int
+    likes: int
+    body: str          # legacy markdown source; dropped at step 10
+    body_html: str     # rendered HTML; the new source of truth for the renderer
+
+    @field_validator("body_html")
+    @classmethod
+    def _body_html_not_empty(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("body_html must be non-empty")
+        return value
+```
+
+`BlogFrontmatter` (representing the on-disk `.md` file) keeps its existing `body: str` field — that's the markdown source.
+
+### Modified module: `src/cli/blog.py`
+
+`_payload_from_blog(path)` rewires to:
+
+```python
+def _payload_from_blog(path: Path) -> dict[str, Any]:
+    blog = parse_blog(path)                     # BlogFrontmatter
+    fixed, fixes = lint_body(blog.body)
+    if fixes:
+        _persist_lint_fixes(path, fixed)        # write back to .md
+        for f in fixes:
+            print(f"[lint] {f.kind}: {f.detail} (×{f.count})")
+    html = render_to_html(fixed)
+    issues = validate_html(html)
+    if issues:
+        for i in issues:
+            print(f"[error] {i.kind}: {i.snippet[:120]} (line {i.line})", file=sys.stderr)
+        raise ValueError(f"validate_html found {len(issues)} issue(s)")
+    row = BlogRow(**{**blog.model_dump(), "body_html": html})
+    return row.model_dump(mode="json")
+```
+
+Note that `blog.body` (the linted markdown) and `html` (rendered) are both written during the migration period. After step 10, `BlogRow.body` is removed; `_payload_from_blog` adjusts to `{**blog.model_dump(exclude={"body"}), "body_html": html}`.
+
+`_cmd_validate` is upgraded to also run `lint` + `render_to_html` + `validate_html` and print issues — but it does NOT write back to disk or push anywhere. Pure read-only check. (Useful for `pre-commit`-style local verification.)
+
+`_cmd_submit` and `_cmd_update` are unchanged in flow — they just consume the new `body_html` payload.
+
+### Modified module: `src/services/projects.py`
+
+`Project` model gains `body_html: str` (alongside the existing `body: str` for the legacy column during migration). After the `body` column is dropped, `body` is removed from the model.
+
+### Modified module: `src/features/projects/projects_page.py`
+
+Single line change:
+```python
+# before
+render_md(project.body),
+# after
+NotStr(project.body_html),
+```
+
+### New script: `scripts/backfill_blog_html.py`
+
+One-time backfill runner. Usage:
+
+```bash
+python scripts/backfill_blog_html.py --dry-run     # preview every change
+python scripts/backfill_blog_html.py               # execute
+```
+
+Iterates `assets/blogs/*.md` in numeric order, runs `_payload_from_blog` on each, and calls `python -m src.cli blog update <path>` (or the equivalent in-process). Stops on first failure (non-zero exit) so partial migrations are visible. Reports a summary at the end: posts processed, lint fixes applied per post, validation issues (should be 0).
+
+The script handles the streaming-buffer constraint by:
+1. Submitting all updates in a tight loop first.
+2. Catching streaming-buffer errors per-post.
+3. After the loop, sleeping 35 minutes and retrying any that failed.
+4. Failing hard if a row still can't be updated after the second attempt.
+
+## Validation rules
+
+Implemented in `validate_html`:
+
+1. **`p-wraps-svg`** — no `<p>` element directly precedes any of `<svg`, `<text`, `<rect`, `<line`, `<circle`, `<path`, `<g`, `<defs`, `<marker`, `<!--`. This is the exact diagnostic signature of the class-3 bug.
+2. **`svg-tag-mismatch`** — count of `<svg ` opening tags equals count of `</svg>` closing tags. Drift indicates parser state corruption.
+3. **`svg-missing-title`** — every top-level `<svg>...</svg>` block contains at least one direct-child `<title>` element. "Top-level" means the SVG is at column 0 of the rendered HTML or the immediate child of a structural container (`<div>`, `<details>`); not nested inside another `<svg>`. Some templates put `<defs>` before `<title>`, so we don't require `<title>` to be the *first* child — we require it to be a child.
+4. **`svg-missing-role`** — every top-level `<svg ` opening tag has `role="img"`. Same definition of "top-level" as above.
+
+All four are runnable on the rendered HTML string with regex; no DOM library required.
+
+## Edge cases
+
+- **Indented SVGs inside CSS-widget containers** (`ptb-step-mds`, `ptb-step-hd`). These are inside `<div>...</div>` blocks which mistletoe passes through verbatim. Lint should skip them — the regex for "blank line inside SVG" only matches when the surrounding `<svg>` is at column 0 (top-level), not when indented. (Cleaner: skip any SVG whose preceding non-blank line is `<div ...>` or that's inside a `<div>` block.)
+- **Code blocks containing SVG examples** (e.g. tutorials about SVG). Stash fenced code blocks before lint, restore after. The skill's `references/svg_diagrams.md` itself contains code-block SVG examples; the lint must not mangle those.
+- **Greek letters and trademark symbols** (`&alpha;`, `&copy;`, etc.). The entity map covers these. If a new symbol appears, the lint fails loud with "add mapping for X" rather than silently passing through.
+- **Markdown emphasis inside SVG `<text>`** (`<text>**bold**</text>`). Mistletoe doesn't currently emphasize-parse content inside HTML blocks, so this passes through. Regression test included.
+- **Bare `<` and `>` inside SVG `<text>`** (e.g. `<text>x &lt; 5</text>`). These render fine. Lint leaves them alone.
+
+## Testing
+
+New file: `tests/test_blog_lint.py`. One test per bug class plus idempotency:
+
+```python
+def test_lint_replaces_named_entities()
+def test_lint_collapses_multi_line_svg_open()
+def test_lint_strips_blank_lines_inside_svg()
+def test_lint_is_idempotent()
+def test_lint_skips_fenced_code_blocks()
+def test_lint_skips_indented_widget_svgs()
+def test_lint_fails_on_unmapped_entity()
+```
+
+New file: `tests/test_blog_render.py`:
+
+```python
+def test_render_to_html_passes_clean_input_through()
+def test_validate_html_returns_empty_for_clean_html()
+def test_validate_html_catches_p_wrapping_svg()
+def test_validate_html_catches_missing_title()
+def test_validate_html_catches_missing_role_img()
+def test_validate_html_catches_tag_mismatch()
+```
+
+Integration: `tests/test_blog_pipeline_e2e.py`:
+
+```python
+def test_pipeline_on_real_post_0022()  # canary: post that originally had the bug
+def test_pipeline_on_real_post_0020()  # control: a post without SVGs
+def test_pipeline_writes_lint_fixes_back()
+```
+
+The pytest harness should already exist (per `CLAUDE.md`: "Backend: pytest + httpx"). New tests slot in.
+
+## Schema migration
+
+BigQuery doesn't allow column renames, so the migration is `ADD body_html` → backfill → switch reader → `DROP body`.
+
+### Steps in order
+
+1. **Add `body_html` column.**
+   ```sql
+   ALTER TABLE `noble-office-299208.portfolio.gn-blog`
+   ADD COLUMN body_html STRING;
+   ```
+   The Pydantic model reading rows still uses `body`; the new column is dormant.
+
+2. **Ship the CLI changes.** New posts populate `body_html`. `body` continues to be populated via the existing markdown body field on `BlogFrontmatter` for transitional reads. (Concretely: `_payload_from_blog` writes BOTH `body` (markdown) AND `body_html` (rendered) for the duration of the migration.)
+
+3. **Backfill all 22 posts** via `scripts/backfill_blog_html.py`. After this completes, every row has `body_html`.
+
+4. **Switch the reader.** `_render_blog_detail` changes to `NotStr(project.body_html)`. `Project.body_html` becomes required, `Project.body` becomes optional (transitional).
+
+5. **Soak for 1 week.** Live page now serves `body_html`. If a regression appears, easy rollback: revert step 4.
+
+6. **Drop the `body` column.**
+   ```sql
+   ALTER TABLE `noble-office-299208.portfolio.gn-blog`
+   DROP COLUMN body;
+   ```
+   `Project.body` and `BlogRow` no longer reference it. `_payload_from_blog` stops writing it.
+
+### Migration risks
+
+- **Streaming-buffer constraint on `update`.** Each `update` is DELETE+INSERT, and the streaming buffer holds rows for ~30 min. Backfilling 22 posts naively will trip this. The backfill script handles it with a 35-minute retry loop.
+- **Lint rewrites legacy posts.** Posts 0001–0020 were authored before the lint rules existed. The lint will likely modify some of them (entity replacements, blank-line stripping). The script runs a `--dry-run` mode first; user reviews the diff before pushing.
+- **Step 4 → step 5 cutover.** Once the reader switches, the old `body` column is no longer rendered. If `body_html` is somehow corrupted on a post, the page goes blank. Mitigation: the `validate_html` step at submit guarantees no row gets `body_html=""` or malformed HTML.
+- **Existing CI/deploy pipeline.** No changes needed — `_cmd_submit` is the only entry point and it's still the same command. CI doesn't run `blog submit`.
+
+## Error handling summary
+
+| Stage | Failure | Surface |
+|---|---|---|
+| Lint | unmapped entity | `LintError`; CLI prints "add mapping for X" + offending file:line; non-zero exit |
+| Render | mistletoe raises | wrap in `RenderError` with surrounding 3 lines; non-zero exit |
+| Validate | any issue | print all issues to stderr; non-zero exit; do NOT push |
+| Submit | streaming buffer | print user-friendly "row in streaming buffer; retry in 30 min"; non-zero exit |
+| Backfill | one post fails | log it, continue with the rest; final summary lists failures |
+
+## Out of scope (for follow-ups)
+
+- A `blog rebuild-html` CLI command that re-renders all posts in place (useful if mistletoe or monsterui ever update with new behavior).
+- Caching the rendered HTML at the application layer (already implicit — BigQuery row reads are cheap and cacheable upstream).
+- Linting the `references/svg_diagrams.md` examples themselves to verify the templates produce clean HTML (low priority — those are demonstrative, not user-facing).
+- A `pre-commit` hook that runs `blog validate` on touched `.md` files (nice-to-have).
+
+## Acceptance criteria
+
+The migration is complete when:
+
+1. `python -m src.cli blog submit <any-post.md>` succeeds with linted source written back to disk and `body_html` populated in BigQuery.
+2. All 22 existing posts have non-null `body_html` in the table.
+3. Every public blog page renders without a `<p><svg` or `<p><text` pattern in the served HTML.
+4. The `body` column has been dropped from `gn-blog`.
+5. `pytest tests/test_blog_lint.py tests/test_blog_render.py tests/test_blog_pipeline_e2e.py` passes.
+6. The paper-to-blog skill's `SKILL.md` and references are updated to reference the new pipeline (informational; the skill workflow doesn't change for authors).
+
+## Implementation order (high-level — full plan via writing-plans)
+
+1. Add `body_html` column (BigQuery DDL).
+2. Implement `blog_lint.py` + tests.
+3. Implement `blog_render.py` + tests.
+4. Add `BlogRow` Pydantic model.
+5. Wire `_payload_from_blog` to lint+render+validate; populate both `body` and `body_html`.
+6. Implement and run `backfill_blog_html.py --dry-run`; review diff.
+7. Run `backfill_blog_html.py` for real.
+8. Update `Project` model + `projects_page.py` to read `body_html`.
+9. Soak 1 week.
+10. Drop `body` column; remove transitional code.
+
+The detailed step-by-step plan lives in the implementation plan that `writing-plans` produces from this spec.

--- a/docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
@@ -301,6 +301,7 @@ BigQuery doesn't allow column renames, so the migration is `ADD body_html` → b
 ### Migration log
 
 - **2026-04-30T21:25Z** — `ALTER TABLE noble-office-299208.portfolio.gn-blog ADD COLUMN body_html STRING;` executed (BigQuery job `afbb8615-44c9-4115-9235-d5dc832ebe4c`). Verified: schema now has 12 fields; `body_html` (STRING) is present and `body` (legacy STRING) is preserved. End-to-end smoke test on `assets/blogs/0021-portello.md --dry-run` confirms the BlogRow payload contains both fields (body=67056 chars, body_html=78579 chars).
+- **2026-04-30T22:30Z** — `python scripts/backfill_blog_html.py` completed: 22 succeeded / 0 hard-failed / 0 streaming-buffer retries. All 22 rows now carry both `body` and `body_html` (lengths: min 5,170 / avg 29,201 / max 102,510 chars). Phase A (`--dry-run`) earlier in the run touched only `0022-spike-sparse-sink-anatomy-massive.md` (84 internal-blank-line lint fixes); legacy posts 0001–0020 were already lint-clean.
 
 ### Migration risks
 

--- a/docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
@@ -302,6 +302,14 @@ BigQuery doesn't allow column renames, so the migration is `ADD body_html` → b
 
 - **2026-04-30T21:25Z** — `ALTER TABLE noble-office-299208.portfolio.gn-blog ADD COLUMN body_html STRING;` executed (BigQuery job `afbb8615-44c9-4115-9235-d5dc832ebe4c`). Verified: schema now has 12 fields; `body_html` (STRING) is present and `body` (legacy STRING) is preserved. End-to-end smoke test on `assets/blogs/0021-portello.md --dry-run` confirms the BlogRow payload contains both fields (body=67056 chars, body_html=78579 chars).
 - **2026-04-30T22:30Z** — `python scripts/backfill_blog_html.py` completed: 22 succeeded / 0 hard-failed / 0 streaming-buffer retries. All 22 rows now carry both `body` and `body_html` (lengths: min 5,170 / avg 29,201 / max 102,510 chars). Phase A (`--dry-run`) earlier in the run touched only `0022-spike-sparse-sink-anatomy-massive.md` (84 internal-blank-line lint fixes); legacy posts 0001–0020 were already lint-clean.
+- **2026-05-01** — Pre-merge `validate_html` sweep across all 22 stored `body_html` values: 22/22 clean, 0 issues. Branch `feat/blog-html-pipeline` ready for merge to `main`.
+
+### Soak window
+
+- **Start:** 2026-05-01 (commit `87be52a`, "feat(blog-detail): render body_html in preference to body").
+- **Min duration:** 7 days. The cutover is reversible by reverting `87be52a` until the legacy `body` column is dropped (Task 19).
+- **Earliest DROP COLUMN date:** 2026-05-08.
+- **Final sweep before DROP:** rerun the same `validate_html` query as above.
 
 ### Migration risks
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Operational scripts (one-shots / migrations)."""

--- a/scripts/backfill_blog_html.py
+++ b/scripts/backfill_blog_html.py
@@ -1,0 +1,129 @@
+"""Backfill body_html for every blog post in /app/assets/blogs.
+
+Usage:
+    python scripts/backfill_blog_html.py --dry-run   # preview only
+    python scripts/backfill_blog_html.py             # execute (one update per post)
+
+In execute mode, each post is processed:
+  1. Run _payload_from_blog (lint -> render -> validate) and persist any lint fixes
+     to the .md file.
+  2. If --dry-run, print a one-line summary and continue.
+  3. Otherwise call `python -m src.cli blog update <path>` (DELETE + INSERT).
+
+BigQuery's streaming buffer rejects DML on rows inserted within the last
+~30 minutes. The script collects streaming-buffer failures, sleeps 35 min,
+and retries them once. Anything that still fails after retry is reported
+and the script exits non-zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BLOGS_DIR = REPO_ROOT / "assets" / "blogs"
+STREAMING_BUFFER_MARKER = "streaming buffer"
+
+
+def iter_blog_paths(blogs_dir: Path) -> list[Path]:
+    """Return all `*.md` files in `blogs_dir`, sorted by filename."""
+    return sorted(p for p in blogs_dir.iterdir() if p.suffix == ".md" and p.is_file())
+
+
+def is_streaming_buffer_error(exc: BaseException) -> bool:
+    """Heuristic: BigQuery surfaces this exact phrase in the error message."""
+    return STREAMING_BUFFER_MARKER in str(exc).lower()
+
+
+def run_backfill(blogs_dir: Path, dry_run: bool) -> int:
+    """Iterate blogs and submit updates. Return 0 on success, 1 on failures."""
+    from argparse import Namespace
+
+    from src.cli import blog as blog_module
+
+    paths = iter_blog_paths(blogs_dir)
+    print(f"Found {len(paths)} blog post(s) in {blogs_dir}.")
+
+    successes: list[Path] = []
+    streaming_failures: list[Path] = []
+    hard_failures: list[tuple[Path, str]] = []
+
+    for path in paths:
+        print(f"\n--- {path.name} ---")
+        try:
+            payload = blog_module._payload_from_blog(path)
+        except Exception as exc:  # noqa: BLE001
+            hard_failures.append((path, f"payload error: {exc}"))
+            continue
+
+        if dry_run:
+            print(
+                f"[dry-run] would update id={payload.get('id', '?')} "
+                f"(body_html: {len(payload.get('body_html', ''))} chars)"
+            )
+            successes.append(path)
+            continue
+
+        ns = Namespace(path=path, dry_run=False, table=None)
+        try:
+            rc = blog_module._cmd_update(ns)
+        except Exception as exc:  # noqa: BLE001
+            if is_streaming_buffer_error(exc):
+                print(f"[stream-buffer] {path.name} hit streaming-buffer; will retry")
+                streaming_failures.append(path)
+                continue
+            hard_failures.append((path, f"update raised: {exc}"))
+            continue
+        if rc != 0:
+            hard_failures.append((path, f"update returned {rc}"))
+        else:
+            successes.append(path)
+
+    if streaming_failures and not dry_run:
+        print(
+            f"\n=== Sleeping 35 minutes before retrying "
+            f"{len(streaming_failures)} streaming-buffer post(s) ==="
+        )
+        time.sleep(35 * 60)
+        for path in streaming_failures:
+            print(f"\n--- retry: {path.name} ---")
+            ns = Namespace(path=path, dry_run=False, table=None)
+            try:
+                rc = blog_module._cmd_update(ns)
+            except Exception as exc:  # noqa: BLE001
+                hard_failures.append((path, f"retry raised: {exc}"))
+                continue
+            if rc != 0:
+                hard_failures.append((path, f"retry returned {rc}"))
+            else:
+                successes.append(path)
+
+    print("\n=== Summary ===")
+    print(f"  succeeded: {len(successes)}")
+    print(f"  hard-failed: {len(hard_failures)}")
+    for p, reason in hard_failures:
+        print(f"    - {p.name}: {reason}")
+    return 0 if not hard_failures else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview only; do not push to BigQuery.",
+    )
+    parser.add_argument(
+        "--blogs-dir",
+        default=str(DEFAULT_BLOGS_DIR),
+        help="Directory containing the blog .md files.",
+    )
+    args = parser.parse_args(argv)
+    return run_backfill(Path(args.blogs_dir), dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cli/blog.py
+++ b/src/cli/blog.py
@@ -113,9 +113,7 @@ def _payload_from_blog(path: Path) -> dict[str, Any]:
                 f"[error] {i.kind} (line {i.line}): {i.snippet[:120]}",
                 file=sys.stderr,
             )
-        raise ValueError(
-            f"validate_html found {len(issues)} issue(s); fix the source and re-run"
-        )
+        raise ValueError(f"validate_html found {len(issues)} issue(s); fix the source and re-run")
 
     row = BlogRow(**{**blog.model_dump(), "body_html": html})
     return row.model_dump(mode="json")

--- a/src/cli/blog.py
+++ b/src/cli/blog.py
@@ -18,7 +18,9 @@ from pathlib import Path
 from typing import Any
 
 from src.config.settings import settings
-from src.services.blog_frontmatter import ensure_id, parse_blog
+from src.services.blog_frontmatter import BlogRow, ensure_id, parse_blog
+from src.services.blog_lint import LintError, lint_body
+from src.services.blog_render import RenderError, render_to_html, validate_html
 from src.services.projects import ProjectService
 
 logger = logging.getLogger(__name__)
@@ -78,13 +80,62 @@ def run_blog(args: argparse.Namespace) -> int:
 
 
 def _payload_from_blog(path: Path) -> dict[str, Any]:
-    """Parse ``path`` and produce a BigQuery-ready row dict."""
+    """Parse `path`, lint the body, render to HTML, validate, and return a BlogRow dict.
+
+    Side effects:
+      * Backfills a UUID into the file (via ensure_id) if missing.
+      * Writes lint fixes back to the file if any rule applied.
+    """
+    ensure_id(path)
     blog = parse_blog(path)
-    payload = blog.model_dump(mode="json")
-    # BigQuery's TIMESTAMP type expects an ISO-8601 string; pydantic's
-    # mode="json" already serialises datetimes that way. ``HttpUrl`` is also
-    # rendered as a plain string in mode="json".
-    return payload
+
+    try:
+        fixed_body, fixes = lint_body(blog.body)
+    except LintError as exc:
+        raise ValueError(f"lint_body failed: {exc}") from exc
+
+    if fixes and fixed_body != blog.body:
+        _persist_body_to_file(path, blog.body, fixed_body)
+        for f in fixes:
+            print(f"[lint] {f.kind}: {f.detail}")
+        # Re-parse so the in-memory model reflects the on-disk file.
+        blog = parse_blog(path)
+
+    try:
+        html = render_to_html(blog.body)
+    except RenderError as exc:
+        raise ValueError(f"render_to_html failed: {exc}") from exc
+
+    issues = validate_html(html)
+    if issues:
+        for i in issues:
+            print(
+                f"[error] {i.kind} (line {i.line}): {i.snippet[:120]}",
+                file=sys.stderr,
+            )
+        raise ValueError(
+            f"validate_html found {len(issues)} issue(s); fix the source and re-run"
+        )
+
+    row = BlogRow(**{**blog.model_dump(), "body_html": html})
+    return row.model_dump(mode="json")
+
+
+def _persist_body_to_file(path: Path, old_body: str, new_body: str) -> None:
+    """Replace the body of `path` with `new_body`, preserving the frontmatter block.
+
+    Writes byte-for-byte except for the body section after the closing
+    frontmatter delimiter.
+    """
+    text = path.read_text(encoding="utf-8")
+    if not text.endswith(old_body):
+        # Defensive: the body should always be the trailing portion of the file.
+        # If it's not, refuse to mangle the file.
+        raise ValueError(
+            f"refusing to persist lint fixes: body of {path} does not appear at end of file"
+        )
+    new_text = text[: -len(old_body)] + new_body
+    path.write_text(new_text, encoding="utf-8")
 
 
 def _bq_client():  # pragma: no cover - thin wrapper around external SDK

--- a/src/cli/blog.py
+++ b/src/cli/blog.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from src.config.settings import settings
-from src.services.blog_frontmatter import parse_blog
+from src.services.blog_frontmatter import ensure_id, parse_blog
 from src.services.projects import ProjectService
 
 logger = logging.getLogger(__name__)
@@ -114,6 +114,7 @@ def _cmd_validate(args: argparse.Namespace) -> int:
 
 def _cmd_submit(args: argparse.Namespace) -> int:
     try:
+        ensure_id(args.path)
         payload = _payload_from_blog(args.path)
     except Exception as exc:  # noqa: BLE001
         print(f"INVALID: {exc}", file=sys.stderr)
@@ -137,6 +138,7 @@ def _cmd_submit(args: argparse.Namespace) -> int:
 
 def _cmd_update(args: argparse.Namespace) -> int:
     try:
+        ensure_id(args.path)
         payload = _payload_from_blog(args.path)
     except Exception as exc:  # noqa: BLE001
         print(f"INVALID: {exc}", file=sys.stderr)

--- a/src/cli/blog.py
+++ b/src/cli/blog.py
@@ -154,11 +154,40 @@ def _bq_client():  # pragma: no cover - thin wrapper around external SDK
 
 
 def _cmd_validate(args: argparse.Namespace) -> int:
+    """Read-only check: parse, run lint preview, render, validate.
+
+    Does NOT write to disk and does NOT submit to BigQuery. Use this from
+    pre-commit or CI to catch issues before `submit`.
+    """
     try:
         blog = parse_blog(args.path)
-    except Exception as exc:  # noqa: BLE001 - CLI surface, want any failure to be reported.
+    except Exception as exc:  # noqa: BLE001
         print(f"INVALID: {exc}", file=sys.stderr)
         return 1
+
+    # Lint preview — report what `submit` would auto-fix, but don't write.
+    try:
+        _, fixes = lint_body(blog.body)
+    except LintError as exc:
+        print(f"INVALID (lint): {exc}", file=sys.stderr)
+        return 1
+    for f in fixes:
+        print(f"[lint preview] would {f.kind}: {f.detail}")
+
+    # Render + validate against the LINTED body, since that's what submit would push.
+    fixed_body, _ = lint_body(blog.body)
+    try:
+        html = render_to_html(fixed_body)
+    except RenderError as exc:
+        print(f"INVALID (render): {exc}", file=sys.stderr)
+        return 1
+
+    issues = validate_html(html)
+    if issues:
+        for i in issues:
+            print(f"[error] {i.kind} (line {i.line}): {i.snippet[:120]}", file=sys.stderr)
+        return 1
+
     print(f"OK: {blog.title}")
     return 0
 

--- a/src/features/projects/projects_page.py
+++ b/src/features/projects/projects_page.py
@@ -51,7 +51,7 @@ def _render_blog_detail(project):
             cls="blog-detail-meta",
         ),
         Div(
-            render_md(project.body),
+            NotStr(project.body_html) if project.body_html else render_md(project.body),
             cls="factory-markdown-content blog-detail-body",
         ),
         Div(

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -22,6 +22,7 @@ class Project:
     likes: int = 0
     date: str = ""
     body: str = ""
+    body_html: str = ""
     slug: str = ""
 
     @classmethod
@@ -57,5 +58,6 @@ class Project:
             likes=data.get("likes", 0),
             date=data.get("date", ""),
             body=data.get("body", ""),
+            body_html=data.get("body_html", ""),
             slug=slug,
         )

--- a/src/services/blog_frontmatter.py
+++ b/src/services/blog_frontmatter.py
@@ -189,3 +189,35 @@ def ensure_id(path: Path) -> str:
         p.write_text(f"---\n{dumped}---\n{body}", encoding="utf-8")
 
     return new_id
+
+
+class BlogRow(BaseModel):
+    """The shape of a row in the BigQuery `gn-blog` table.
+
+    During the migration window this carries both `body` (legacy markdown)
+    and `body_html` (rendered HTML). After the legacy `body` column is
+    dropped from the BigQuery table, `body` will be removed from this model
+    and `_payload_from_blog` in src.cli.blog will stop populating it.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    title: str
+    date: datetime
+    tags: list[str]
+    description: str
+    image: HttpUrl
+    type: Literal["note", "article"]
+    disabled: bool
+    views: int
+    likes: int
+    body: str
+    body_html: str
+
+    @field_validator("body_html")
+    @classmethod
+    def _body_html_not_empty(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("body_html must be non-empty")
+        return value

--- a/src/services/blog_lint.py
+++ b/src/services/blog_lint.py
@@ -39,24 +39,48 @@ class LintFix:
 # entities (amp/lt/gt/apos/quot) are intentionally absent — they're valid in
 # both XML and HTML and do not need substitution.
 ENTITY_MAP: dict[str, str] = {
-    "mdash": "—", "ndash": "–",
-    "middot": "·", "bull": "•",
-    "times": "×", "divide": "÷",
-    "plusmn": "±", "minus": "−",
-    "rarr": "→", "larr": "←",
-    "uarr": "↑", "darr": "↓", "harr": "↔",
+    "mdash": "—",
+    "ndash": "–",
+    "middot": "·",
+    "bull": "•",
+    "times": "×",
+    "divide": "÷",
+    "plusmn": "±",
+    "minus": "−",
+    "rarr": "→",
+    "larr": "←",
+    "uarr": "↑",
+    "darr": "↓",
+    "harr": "↔",
     "hellip": "…",
-    "asymp": "≈", "ne": "≠",
-    "ge": "≥", "le": "≤",
+    "asymp": "≈",
+    "ne": "≠",
+    "ge": "≥",
+    "le": "≤",
     "deg": "°",
-    "radic": "√", "infin": "∞",
-    "alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ",
-    "epsilon": "ε", "theta": "θ", "lambda": "λ", "mu": "μ",
-    "pi": "π", "sigma": "σ", "phi": "φ", "omega": "ω",
-    "Sigma": "Σ", "Delta": "Δ", "Omega": "Ω",
-    "sum": "∑", "prod": "∏",
+    "radic": "√",
+    "infin": "∞",
+    "alpha": "α",
+    "beta": "β",
+    "gamma": "γ",
+    "delta": "δ",
+    "epsilon": "ε",
+    "theta": "θ",
+    "lambda": "λ",
+    "mu": "μ",
+    "pi": "π",
+    "sigma": "σ",
+    "phi": "φ",
+    "omega": "ω",
+    "Sigma": "Σ",
+    "Delta": "Δ",
+    "Omega": "Ω",
+    "sum": "∑",
+    "prod": "∏",
     "nbsp": " ",
-    "copy": "©", "reg": "®", "trade": "™",
+    "copy": "©",
+    "reg": "®",
+    "trade": "™",
 }
 
 _XML_SAFE_ENTITIES = frozenset({"amp", "lt", "gt", "apos", "quot"})
@@ -180,24 +204,30 @@ def lint_body(body: str) -> tuple[str, list[LintFix]]:
     fixes: list[LintFix] = []
     body, n = _replace_named_entities(body)
     if n:
-        fixes.append(LintFix(
-            kind="named-entity",
-            count=n,
-            detail=f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals",
-        ))
+        fixes.append(
+            LintFix(
+                kind="named-entity",
+                count=n,
+                detail=f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals",
+            )
+        )
     body, n = _collapse_svg_open_tags(body)
     if n:
-        fixes.append(LintFix(
-            kind="multi-line-svg-open",
-            count=n,
-            detail=f"collapsed {n} multi-line <svg ...> opening tag(s) to single line",
-        ))
+        fixes.append(
+            LintFix(
+                kind="multi-line-svg-open",
+                count=n,
+                detail=f"collapsed {n} multi-line <svg ...> opening tag(s) to single line",
+            )
+        )
     body, n = _strip_blank_lines_in_svg(body)
     if n:
-        fixes.append(LintFix(
-            kind="blank-line-in-svg",
-            count=n,
-            detail=f"stripped {n} blank line(s) inside <svg>...</svg> blocks",
-        ))
+        fixes.append(
+            LintFix(
+                kind="blank-line-in-svg",
+                count=n,
+                detail=f"stripped {n} blank line(s) inside <svg>...</svg> blocks",
+            )
+        )
     body = _restore_fenced_code(body, stash)
     return body, fixes

--- a/src/services/blog_lint.py
+++ b/src/services/blog_lint.py
@@ -1,0 +1,43 @@
+"""Auto-fix mistletoe foot-guns in blog markdown source.
+
+The portfolio's markdown renderer (mistletoe via monsterui.render_md) has
+three known failure modes when blog bodies contain inline SVG:
+
+1. HTML named entities inside SVG break XML parsing.
+2. Multi-line `<svg ...>` opening tags break mistletoe's HTML-block detection.
+3. Blank lines inside SVG followed by single-line elements break mistletoe's
+   HTML-block continuation.
+
+This module fixes all three at submit time, idempotently. See
+`docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md` for the
+full reasoning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+class LintError(Exception):
+    """Raised when the linter encounters a problem it cannot auto-fix
+    (e.g. an HTML named entity with no Unicode mapping).
+    """
+
+
+@dataclass
+class LintFix:
+    """A single class of fix the linter applied to a body of text."""
+
+    kind: Literal["named-entity", "multi-line-svg-open", "blank-line-in-svg"]
+    count: int
+    detail: str
+
+
+def lint_body(body: str) -> tuple[str, list[LintFix]]:
+    """Apply all three lint rules to `body`, returning the fixed text + list of fixes.
+
+    The transforms are idempotent: running `lint_body` twice on the same input
+    produces the same output as running it once.
+    """
+    return body, []

--- a/src/services/blog_lint.py
+++ b/src/services/blog_lint.py
@@ -15,6 +15,7 @@ full reasoning.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Literal
 
@@ -34,10 +35,71 @@ class LintFix:
     detail: str
 
 
+# Map of HTML named entities to their Unicode literals. The five XML-predefined
+# entities (amp/lt/gt/apos/quot) are intentionally absent — they're valid in
+# both XML and HTML and do not need substitution.
+ENTITY_MAP: dict[str, str] = {
+    "mdash": "—", "ndash": "–",
+    "middot": "·", "bull": "•",
+    "times": "×", "divide": "÷",
+    "plusmn": "±", "minus": "−",
+    "rarr": "→", "larr": "←",
+    "uarr": "↑", "darr": "↓", "harr": "↔",
+    "hellip": "…",
+    "asymp": "≈", "ne": "≠",
+    "ge": "≥", "le": "≤",
+    "deg": "°",
+    "radic": "√", "infin": "∞",
+    "alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ",
+    "epsilon": "ε", "theta": "θ", "lambda": "λ", "mu": "μ",
+    "pi": "π", "sigma": "σ", "phi": "φ", "omega": "ω",
+    "Sigma": "Σ", "Delta": "Δ", "Omega": "Ω",
+    "sum": "∑", "prod": "∏",
+    "nbsp": " ",
+    "copy": "©", "reg": "®", "trade": "™",
+}
+
+_XML_SAFE_ENTITIES = frozenset({"amp", "lt", "gt", "apos", "quot"})
+_ENTITY_PATTERN = re.compile(r"&([a-zA-Z][a-zA-Z0-9]*);")
+
+
+def _replace_named_entities(body: str) -> tuple[str, int]:
+    """Replace every HTML named entity with its Unicode literal.
+
+    Returns (transformed_body, count_of_replacements). Raises LintError if
+    an entity is encountered that has no mapping in ENTITY_MAP and is not
+    one of the five XML-safe entities.
+    """
+    count = 0
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal count
+        name = match.group(1)
+        if name in _XML_SAFE_ENTITIES:
+            return match.group(0)
+        if name in ENTITY_MAP:
+            count += 1
+            return ENTITY_MAP[name]
+        raise LintError(
+            f"Unmapped named entity '&{name};'. "
+            f"Add a mapping to ENTITY_MAP in src/services/blog_lint.py and re-run."
+        )
+
+    return _ENTITY_PATTERN.sub(_sub, body), count
+
+
 def lint_body(body: str) -> tuple[str, list[LintFix]]:
     """Apply all three lint rules to `body`, returning the fixed text + list of fixes.
 
     The transforms are idempotent: running `lint_body` twice on the same input
     produces the same output as running it once.
     """
-    return body, []
+    fixes: list[LintFix] = []
+    body, n = _replace_named_entities(body)
+    if n:
+        fixes.append(LintFix(
+            kind="named-entity",
+            count=n,
+            detail=f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals",
+        ))
+    return body, fixes

--- a/src/services/blog_lint.py
+++ b/src/services/blog_lint.py
@@ -88,6 +88,30 @@ def _replace_named_entities(body: str) -> tuple[str, int]:
     return _ENTITY_PATTERN.sub(_sub, body), count
 
 
+_SVG_OPEN_PATTERN = re.compile(r"<svg\b([^>]*)>", re.DOTALL)
+
+
+def _collapse_svg_open_tags(body: str) -> tuple[str, int]:
+    """Collapse multi-line `<svg ...>` opening tags onto a single line.
+
+    Returns (transformed_body, count_collapsed). A "collapse" means the
+    opening tag spanned multiple lines in the source; if it was already on
+    one line, no change is recorded for that tag.
+    """
+    count = 0
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal count
+        inner = match.group(1)
+        if "\n" not in inner:
+            return match.group(0)
+        count += 1
+        collapsed = re.sub(r"\s+", " ", inner).strip()
+        return f"<svg {collapsed}>" if collapsed else "<svg>"
+
+    return _SVG_OPEN_PATTERN.sub(_sub, body), count
+
+
 def lint_body(body: str) -> tuple[str, list[LintFix]]:
     """Apply all three lint rules to `body`, returning the fixed text + list of fixes.
 
@@ -101,5 +125,12 @@ def lint_body(body: str) -> tuple[str, list[LintFix]]:
             kind="named-entity",
             count=n,
             detail=f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals",
+        ))
+    body, n = _collapse_svg_open_tags(body)
+    if n:
+        fixes.append(LintFix(
+            kind="multi-line-svg-open",
+            count=n,
+            detail=f"collapsed {n} multi-line <svg ...> opening tag(s) to single line",
         ))
     return body, fixes

--- a/src/services/blog_lint.py
+++ b/src/services/blog_lint.py
@@ -112,6 +112,34 @@ def _collapse_svg_open_tags(body: str) -> tuple[str, int]:
     return _SVG_OPEN_PATTERN.sub(_sub, body), count
 
 
+_SVG_BLOCK_PATTERN = re.compile(r"<svg\b[^>]*>.*?</svg>", re.DOTALL)
+
+
+def _strip_blank_lines_in_svg(body: str) -> tuple[str, int]:
+    """Strip blank lines inside `<svg>...</svg>` blocks.
+
+    Mistletoe terminates HTML blocks at blank lines, which fragments inline
+    SVG content. This strips internal blank lines (lines whose only content
+    is whitespace) without touching prose blank lines outside SVGs.
+
+    Returns (transformed_body, count_of_blank_lines_stripped).
+    """
+    total_stripped = 0
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal total_stripped
+        block = match.group(0)
+        kept = []
+        for line in block.split("\n"):
+            if line.strip() == "":
+                total_stripped += 1
+                continue
+            kept.append(line)
+        return "\n".join(kept)
+
+    return _SVG_BLOCK_PATTERN.sub(_sub, body), total_stripped
+
+
 def lint_body(body: str) -> tuple[str, list[LintFix]]:
     """Apply all three lint rules to `body`, returning the fixed text + list of fixes.
 
@@ -132,5 +160,12 @@ def lint_body(body: str) -> tuple[str, list[LintFix]]:
             kind="multi-line-svg-open",
             count=n,
             detail=f"collapsed {n} multi-line <svg ...> opening tag(s) to single line",
+        ))
+    body, n = _strip_blank_lines_in_svg(body)
+    if n:
+        fixes.append(LintFix(
+            kind="blank-line-in-svg",
+            count=n,
+            detail=f"stripped {n} blank line(s) inside <svg>...</svg> blocks",
         ))
     return body, fixes

--- a/src/services/blog_lint.py
+++ b/src/services/blog_lint.py
@@ -140,12 +140,43 @@ def _strip_blank_lines_in_svg(body: str) -> tuple[str, int]:
     return _SVG_BLOCK_PATTERN.sub(_sub, body), total_stripped
 
 
+_FENCED_CODE_PATTERN = re.compile(r"(^|\n)(```[^\n]*\n.*?\n```)(?=\n|$)", re.DOTALL)
+
+
+def _stash_fenced_code(body: str) -> tuple[str, list[str]]:
+    """Replace each fenced code block with a unique placeholder; return placeholder list.
+
+    The placeholder is a sentinel that won't match any lint regex, so the rest
+    of the pipeline ignores code-block content. Caller restores via _restore_fenced_code.
+    """
+    stash: list[str] = []
+
+    def _sub(match: re.Match[str]) -> str:
+        prefix, block = match.group(1), match.group(2)
+        idx = len(stash)
+        stash.append(block)
+        return f"{prefix}__BLOG_LINT_STASH_{idx}__"
+
+    return _FENCED_CODE_PATTERN.sub(_sub, body), stash
+
+
+def _restore_fenced_code(body: str, stash: list[str]) -> str:
+    for idx, block in enumerate(stash):
+        body = body.replace(f"__BLOG_LINT_STASH_{idx}__", block)
+    return body
+
+
 def lint_body(body: str) -> tuple[str, list[LintFix]]:
     """Apply all three lint rules to `body`, returning the fixed text + list of fixes.
 
     The transforms are idempotent: running `lint_body` twice on the same input
     produces the same output as running it once.
+
+    Fenced code blocks (``` ... ```) are stashed before the transforms run and
+    restored afterward, so example SVG inside code fences is not mangled by
+    the lint rules.
     """
+    body, stash = _stash_fenced_code(body)
     fixes: list[LintFix] = []
     body, n = _replace_named_entities(body)
     if n:
@@ -168,4 +199,5 @@ def lint_body(body: str) -> tuple[str, list[LintFix]]:
             count=n,
             detail=f"stripped {n} blank line(s) inside <svg>...</svg> blocks",
         ))
+    body = _restore_fenced_code(body, stash)
     return body, fixes

--- a/src/services/blog_render.py
+++ b/src/services/blog_render.py
@@ -47,8 +47,15 @@ class ValidationIssue:
 
 # Tags whose presence inside a <p> wrap is the diagnostic of the class-3 bug.
 _SVG_INTERNAL_TAGS = (
-    "svg", "text", "rect", "line", "circle", "path",
-    "g", "defs", "marker",
+    "svg",
+    "text",
+    "rect",
+    "line",
+    "circle",
+    "path",
+    "g",
+    "defs",
+    "marker",
 )
 _P_WRAPS_SVG = re.compile(
     r"<p\b[^>]*>\s*<(?:" + "|".join(_SVG_INTERNAL_TAGS) + r"|!--)\b",
@@ -71,21 +78,25 @@ def validate_html(html: str) -> list[ValidationIssue]:
 
     # Rule 1: <p>-wraps-SVG-internal-tag
     for match in _P_WRAPS_SVG.finditer(html):
-        issues.append(ValidationIssue(
-            kind="p-wraps-svg",
-            line=_line_of(html, match.start()),
-            snippet=html[match.start(): match.start() + 120],
-        ))
+        issues.append(
+            ValidationIssue(
+                kind="p-wraps-svg",
+                line=_line_of(html, match.start()),
+                snippet=html[match.start() : match.start() + 120],
+            )
+        )
 
     # Rule 2: <svg> open count == </svg> close count
     n_open = len(_SVG_OPEN.findall(html))
     n_close = len(_SVG_CLOSE.findall(html))
     if n_open != n_close:
-        issues.append(ValidationIssue(
-            kind="svg-tag-mismatch",
-            line=None,
-            snippet=f"<svg> opens={n_open}, </svg> closes={n_close}",
-        ))
+        issues.append(
+            ValidationIssue(
+                kind="svg-tag-mismatch",
+                line=None,
+                snippet=f"<svg> opens={n_open}, </svg> closes={n_close}",
+            )
+        )
 
     # Rules 3+4 operate per top-level SVG block.
     # We don't try to detect nesting here — top-level SVGs are the only ones
@@ -94,18 +105,22 @@ def validate_html(html: str) -> list[ValidationIssue]:
         block = match.group(0)
         line = _line_of(html, match.start())
         if not _HAS_TITLE_CHILD.search(block):
-            issues.append(ValidationIssue(
-                kind="svg-missing-title",
-                line=line,
-                snippet=block[:120],
-            ))
+            issues.append(
+                ValidationIssue(
+                    kind="svg-missing-title",
+                    line=line,
+                    snippet=block[:120],
+                )
+            )
         # Inspect the opening tag specifically (first match within the block).
         open_match = _SVG_OPEN.match(block)
         if open_match and not _HAS_ROLE_IMG.search(open_match.group(0)):
-            issues.append(ValidationIssue(
-                kind="svg-missing-role",
-                line=line,
-                snippet=open_match.group(0),
-            ))
+            issues.append(
+                ValidationIssue(
+                    kind="svg-missing-role",
+                    line=line,
+                    snippet=open_match.group(0),
+                )
+            )
 
     return issues

--- a/src/services/blog_render.py
+++ b/src/services/blog_render.py
@@ -9,6 +9,10 @@ See `docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md`.
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
+from typing import Literal
+
 from monsterui.all import render_md
 
 
@@ -30,3 +34,78 @@ def render_to_html(body: str) -> str:
 
     # monsterui returns a NotStr (subclass of str). __str__ is the HTML.
     return str(rendered)
+
+
+@dataclass
+class ValidationIssue:
+    """A single issue found by `validate_html`."""
+
+    kind: Literal["p-wraps-svg", "svg-tag-mismatch", "svg-missing-title", "svg-missing-role"]
+    line: int | None
+    snippet: str
+
+
+# Tags whose presence inside a <p> wrap is the diagnostic of the class-3 bug.
+_SVG_INTERNAL_TAGS = (
+    "svg", "text", "rect", "line", "circle", "path",
+    "g", "defs", "marker",
+)
+_P_WRAPS_SVG = re.compile(
+    r"<p\b[^>]*>\s*<(?:" + "|".join(_SVG_INTERNAL_TAGS) + r"|!--)\b",
+    re.IGNORECASE,
+)
+_SVG_OPEN = re.compile(r"<svg\b[^>]*>", re.IGNORECASE)
+_SVG_CLOSE = re.compile(r"</svg\s*>", re.IGNORECASE)
+_SVG_BLOCK = re.compile(r"<svg\b[^>]*>.*?</svg\s*>", re.DOTALL | re.IGNORECASE)
+_HAS_ROLE_IMG = re.compile(r'role\s*=\s*"img"', re.IGNORECASE)
+_HAS_TITLE_CHILD = re.compile(r"<title\b[^>]*>", re.IGNORECASE)
+
+
+def _line_of(html: str, offset: int) -> int:
+    return html.count("\n", 0, offset) + 1
+
+
+def validate_html(html: str) -> list[ValidationIssue]:
+    """Scan rendered HTML for the four known bad patterns. Returns [] on clean output."""
+    issues: list[ValidationIssue] = []
+
+    # Rule 1: <p>-wraps-SVG-internal-tag
+    for match in _P_WRAPS_SVG.finditer(html):
+        issues.append(ValidationIssue(
+            kind="p-wraps-svg",
+            line=_line_of(html, match.start()),
+            snippet=html[match.start(): match.start() + 120],
+        ))
+
+    # Rule 2: <svg> open count == </svg> close count
+    n_open = len(_SVG_OPEN.findall(html))
+    n_close = len(_SVG_CLOSE.findall(html))
+    if n_open != n_close:
+        issues.append(ValidationIssue(
+            kind="svg-tag-mismatch",
+            line=None,
+            snippet=f"<svg> opens={n_open}, </svg> closes={n_close}",
+        ))
+
+    # Rules 3+4 operate per top-level SVG block.
+    # We don't try to detect nesting here — top-level SVGs are the only ones
+    # users author; nested SVGs are not used in this project.
+    for match in _SVG_BLOCK.finditer(html):
+        block = match.group(0)
+        line = _line_of(html, match.start())
+        if not _HAS_TITLE_CHILD.search(block):
+            issues.append(ValidationIssue(
+                kind="svg-missing-title",
+                line=line,
+                snippet=block[:120],
+            ))
+        # Inspect the opening tag specifically (first match within the block).
+        open_match = _SVG_OPEN.match(block)
+        if open_match and not _HAS_ROLE_IMG.search(open_match.group(0)):
+            issues.append(ValidationIssue(
+                kind="svg-missing-role",
+                line=line,
+                snippet=open_match.group(0),
+            ))
+
+    return issues

--- a/src/services/blog_render.py
+++ b/src/services/blog_render.py
@@ -1,0 +1,32 @@
+"""Render linted blog markdown to HTML and validate the output.
+
+This module exists so the blog rendering pipeline runs once at submit time
+(rather than once per page view), surfaces parser foot-guns when they're
+cheap to fix, and stores the final HTML in BigQuery as `body_html`.
+
+See `docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md`.
+"""
+
+from __future__ import annotations
+
+from monsterui.all import render_md
+
+
+class RenderError(Exception):
+    """Raised when mistletoe (via monsterui) fails to render a body."""
+
+
+def render_to_html(body: str) -> str:
+    """Render markdown `body` to an HTML string via monsterui.render_md.
+
+    `monsterui.render_md` returns a `NotStr` wrapping HTML; this function
+    unwraps it to a plain `str` so callers can store it as a BigQuery
+    column or scan it with regex validators.
+    """
+    try:
+        rendered = render_md(body)
+    except Exception as exc:  # noqa: BLE001 - we want to wrap any failure
+        raise RenderError(f"render_md failed: {exc}") from exc
+
+    # monsterui returns a NotStr (subclass of str). __str__ is the HTML.
+    return str(rendered)

--- a/tests/test_backfill_blog_html.py
+++ b/tests/test_backfill_blog_html.py
@@ -3,6 +3,7 @@
 
 def test_iter_blog_paths_returns_sorted_md_files(tmp_path):
     from scripts.backfill_blog_html import iter_blog_paths
+
     (tmp_path / "0003-c.md").write_text("@{}\n", encoding="utf-8")
     (tmp_path / "0001-a.md").write_text("@{}\n", encoding="utf-8")
     (tmp_path / "0002-b.md").write_text("@{}\n", encoding="utf-8")
@@ -26,6 +27,7 @@ def test_dry_run_does_not_call_submit(tmp_path, monkeypatch, capsys):
     # Stub out _payload_from_blog so we don't need real Pydantic frontmatter.
     def fake_payload(path):
         return {"id": "x", "body": path.read_text(), "body_html": "<p>html</p>"}
+
     monkeypatch.setattr(blog_module, "_payload_from_blog", fake_payload)
 
     blogs = tmp_path / "blogs"

--- a/tests/test_backfill_blog_html.py
+++ b/tests/test_backfill_blog_html.py
@@ -1,0 +1,53 @@
+"""Tests for scripts.backfill_blog_html."""
+
+
+def test_iter_blog_paths_returns_sorted_md_files(tmp_path):
+    from scripts.backfill_blog_html import iter_blog_paths
+    (tmp_path / "0003-c.md").write_text("@{}\n", encoding="utf-8")
+    (tmp_path / "0001-a.md").write_text("@{}\n", encoding="utf-8")
+    (tmp_path / "0002-b.md").write_text("@{}\n", encoding="utf-8")
+    (tmp_path / "skip.txt").write_text("not md", encoding="utf-8")
+
+    paths = iter_blog_paths(tmp_path)
+    names = [p.name for p in paths]
+    assert names == ["0001-a.md", "0002-b.md", "0003-c.md"]
+
+
+def test_dry_run_does_not_call_submit(tmp_path, monkeypatch, capsys):
+    """In --dry-run mode, the script previews each file without invoking BigQuery."""
+    from scripts.backfill_blog_html import run_backfill
+    from src.cli import blog as blog_module
+
+    submit_calls: list[str] = []
+    monkeypatch.setattr(
+        blog_module, "_cmd_submit", lambda args: submit_calls.append(str(args.path)) or 0
+    )
+
+    # Stub out _payload_from_blog so we don't need real Pydantic frontmatter.
+    def fake_payload(path):
+        return {"id": "x", "body": path.read_text(), "body_html": "<p>html</p>"}
+    monkeypatch.setattr(blog_module, "_payload_from_blog", fake_payload)
+
+    blogs = tmp_path / "blogs"
+    blogs.mkdir()
+    (blogs / "0001-a.md").write_text("@{}\nbody", encoding="utf-8")
+
+    rc = run_backfill(blogs, dry_run=True)
+    assert rc == 0
+    assert submit_calls == []  # nothing pushed
+    captured = capsys.readouterr()
+    assert "0001-a.md" in captured.out
+
+
+def test_classify_streaming_buffer_error_recognizes_known_message():
+    from scripts.backfill_blog_html import is_streaming_buffer_error
+
+    class MockExc(Exception):
+        pass
+
+    err = MockExc(
+        "UPDATE or DELETE statement over table ... would affect rows in the "
+        "streaming buffer, which is not supported"
+    )
+    assert is_streaming_buffer_error(err)
+    assert not is_streaming_buffer_error(MockExc("permission denied"))

--- a/tests/test_blog_detail_view.py
+++ b/tests/test_blog_detail_view.py
@@ -1,0 +1,30 @@
+"""Tests that the blog detail page reads body_html in preference to body."""
+from src.models.project import Project
+
+
+def test_blog_detail_uses_body_html_when_present():
+    """Renderer prefers body_html when populated."""
+    from src.features.projects import projects_page
+
+    project = Project(
+        id="x", blog_id="x", title="T", description="d", image="i",
+        body="# markdown", body_html="<h1>html-rendered</h1>",
+    )
+    out = projects_page._render_blog_detail(project)
+    rendered = str(out)
+    assert "html-rendered" in rendered
+    assert "# markdown" not in rendered  # markdown text not exposed raw
+
+
+def test_blog_detail_falls_back_to_body_when_html_missing():
+    """Renderer falls back to render_md(body) when body_html is empty."""
+    from src.features.projects import projects_page
+
+    project = Project(
+        id="x", blog_id="x", title="T", description="d", image="i",
+        body="# markdown", body_html="",
+    )
+    out = projects_page._render_blog_detail(project)
+    rendered = str(out)
+    # render_md should have produced an <h1> from the markdown.
+    assert "<h1" in rendered

--- a/tests/test_blog_detail_view.py
+++ b/tests/test_blog_detail_view.py
@@ -1,4 +1,5 @@
 """Tests that the blog detail page reads body_html in preference to body."""
+
 from src.models.project import Project
 
 
@@ -7,8 +8,13 @@ def test_blog_detail_uses_body_html_when_present():
     from src.features.projects import projects_page
 
     project = Project(
-        id="x", blog_id="x", title="T", description="d", image="i",
-        body="# markdown", body_html="<h1>html-rendered</h1>",
+        id="x",
+        blog_id="x",
+        title="T",
+        description="d",
+        image="i",
+        body="# markdown",
+        body_html="<h1>html-rendered</h1>",
     )
     out = projects_page._render_blog_detail(project)
     rendered = str(out)
@@ -21,8 +27,13 @@ def test_blog_detail_falls_back_to_body_when_html_missing():
     from src.features.projects import projects_page
 
     project = Project(
-        id="x", blog_id="x", title="T", description="d", image="i",
-        body="# markdown", body_html="",
+        id="x",
+        blog_id="x",
+        title="T",
+        description="d",
+        image="i",
+        body="# markdown",
+        body_html="",
     )
     out = projects_page._render_blog_detail(project)
     rendered = str(out)

--- a/tests/test_blog_frontmatter.py
+++ b/tests/test_blog_frontmatter.py
@@ -109,3 +109,61 @@ def test_empty_body_raises(tmp_path):
     )
     with pytest.raises(ValidationError):
         parse_blog(md)
+
+
+def test_blog_row_validates_minimal_payload():
+    """BlogRow accepts a complete payload (markdown + html) with no errors."""
+    from datetime import datetime, timezone
+    from src.services.blog_frontmatter import BlogRow
+    row = BlogRow(
+        id="00000000-0000-0000-0000-000000000000",
+        title="Test",
+        date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        tags=["test"],
+        description="d",
+        image="https://example.com/img.svg",
+        type="note",
+        disabled=False,
+        views=0,
+        likes=0,
+        body="# md",
+        body_html="<h1>md</h1>",
+    )
+    assert row.body_html == "<h1>md</h1>"
+
+
+def test_blog_row_rejects_empty_body_html():
+    from datetime import datetime, timezone
+    from pydantic import ValidationError
+    from src.services.blog_frontmatter import BlogRow
+    with pytest.raises(ValidationError, match="body_html"):
+        BlogRow(
+            id="x",
+            title="t",
+            date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            tags=[],
+            description="d",
+            image="https://e.com/i.svg",
+            type="note",
+            disabled=False,
+            views=0,
+            likes=0,
+            body="md",
+            body_html="   ",  # whitespace only — invalid
+        )
+
+
+def test_blog_row_extra_fields_forbidden():
+    from datetime import datetime, timezone
+    from pydantic import ValidationError
+    from src.services.blog_frontmatter import BlogRow
+    with pytest.raises(ValidationError):
+        BlogRow(
+            id="x", title="t",
+            date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            tags=[], description="d",
+            image="https://e.com/i.svg",
+            type="note", disabled=False, views=0, likes=0,
+            body="md", body_html="<h1/>",
+            unexpected="boom",
+        )

--- a/tests/test_blog_frontmatter.py
+++ b/tests/test_blog_frontmatter.py
@@ -115,6 +115,7 @@ def test_blog_row_validates_minimal_payload():
     """BlogRow accepts a complete payload (markdown + html) with no errors."""
     from datetime import datetime, timezone
     from src.services.blog_frontmatter import BlogRow
+
     row = BlogRow(
         id="00000000-0000-0000-0000-000000000000",
         title="Test",
@@ -136,6 +137,7 @@ def test_blog_row_rejects_empty_body_html():
     from datetime import datetime, timezone
     from pydantic import ValidationError
     from src.services.blog_frontmatter import BlogRow
+
     with pytest.raises(ValidationError, match="body_html"):
         BlogRow(
             id="x",
@@ -157,13 +159,20 @@ def test_blog_row_extra_fields_forbidden():
     from datetime import datetime, timezone
     from pydantic import ValidationError
     from src.services.blog_frontmatter import BlogRow
+
     with pytest.raises(ValidationError):
         BlogRow(
-            id="x", title="t",
+            id="x",
+            title="t",
             date=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            tags=[], description="d",
+            tags=[],
+            description="d",
             image="https://e.com/i.svg",
-            type="note", disabled=False, views=0, likes=0,
-            body="md", body_html="<h1/>",
+            type="note",
+            disabled=False,
+            views=0,
+            likes=0,
+            body="md",
+            body_html="<h1/>",
             unexpected="boom",
         )

--- a/tests/test_blog_lint.py
+++ b/tests/test_blog_lint.py
@@ -50,3 +50,37 @@ def test_lint_raises_on_unmapped_entity():
     src = "<svg><text>nonsense &zzznotreal;</text></svg>"
     with pytest.raises(LintError, match="zzznotreal"):
         lint_body(src)
+
+
+def test_lint_collapses_multi_line_svg_open():
+    src = (
+        '<svg viewBox="0 0 100 100"\n'
+        '     xmlns="http://www.w3.org/2000/svg"\n'
+        '     role="img">\n'
+        '  <title>x</title>\n'
+        '</svg>'
+    )
+    fixed, fixes = lint_body(src)
+    first_line = fixed.split("\n", 1)[0]
+    assert first_line == '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img">'
+    assert any(f.kind == "multi-line-svg-open" and f.count == 1 for f in fixes)
+
+
+def test_lint_leaves_single_line_svg_open_alone():
+    src = '<svg viewBox="0 0 100 100" xmlns="..." role="img"><title>x</title></svg>'
+    fixed, fixes = lint_body(src)
+    assert fixed == src
+    assert all(f.kind != "multi-line-svg-open" for f in fixes)
+
+
+def test_lint_collapses_only_svg_tag_not_other_multi_line_tags():
+    # <text> spanning lines is FINE — common in SVG body. We only care about <svg> opens.
+    src = (
+        '<svg viewBox="0 0 100 100" xmlns="..." role="img">\n'
+        '  <text x="10" y="20"\n'
+        '        font-size="13">hello</text>\n'
+        '</svg>'
+    )
+    fixed, _ = lint_body(src)
+    # The multi-line <text> should be unchanged; the <svg> open is already on one line.
+    assert "<text x=\"10\" y=\"20\"\n        font-size=\"13\">" in fixed

--- a/tests/test_blog_lint.py
+++ b/tests/test_blog_lint.py
@@ -1,0 +1,9 @@
+"""Tests for src.services.blog_lint."""
+from src.services.blog_lint import LintError, LintFix, lint_body
+
+
+def test_lint_body_returns_tuple_of_text_and_fixes():
+    text = "no svg here, just prose"
+    fixed, fixes = lint_body(text)
+    assert fixed == text
+    assert fixes == []

--- a/tests/test_blog_lint.py
+++ b/tests/test_blog_lint.py
@@ -1,4 +1,5 @@
 """Tests for src.services.blog_lint."""
+
 import pytest
 
 from src.services.blog_lint import LintError, LintFix, lint_body
@@ -57,8 +58,8 @@ def test_lint_collapses_multi_line_svg_open():
         '<svg viewBox="0 0 100 100"\n'
         '     xmlns="http://www.w3.org/2000/svg"\n'
         '     role="img">\n'
-        '  <title>x</title>\n'
-        '</svg>'
+        "  <title>x</title>\n"
+        "</svg>"
     )
     fixed, fixes = lint_body(src)
     first_line = fixed.split("\n", 1)[0]
@@ -79,25 +80,17 @@ def test_lint_collapses_only_svg_tag_not_other_multi_line_tags():
         '<svg viewBox="0 0 100 100" xmlns="..." role="img">\n'
         '  <text x="10" y="20"\n'
         '        font-size="13">hello</text>\n'
-        '</svg>'
+        "</svg>"
     )
     fixed, _ = lint_body(src)
     # The multi-line <text> should be unchanged; the <svg> open is already on one line.
-    assert "<text x=\"10\" y=\"20\"\n        font-size=\"13\">" in fixed
+    assert '<text x="10" y="20"\n        font-size="13">' in fixed
 
 
 def test_lint_strips_blank_lines_inside_svg():
-    src = (
-        '<svg>\n'
-        '  <title>t</title>\n'
-        '\n'
-        '  <text>line a</text>\n'
-        '\n'
-        '  <text>line b</text>\n'
-        '</svg>'
-    )
+    src = "<svg>\n  <title>t</title>\n\n  <text>line a</text>\n\n  <text>line b</text>\n</svg>"
     fixed, fixes = lint_body(src)
-    inside = fixed[fixed.index("<svg>"):fixed.index("</svg>")]
+    inside = fixed[fixed.index("<svg>") : fixed.index("</svg>")]
     assert "\n\n" not in inside
     assert "<text>line a</text>" in fixed and "<text>line b</text>" in fixed
     assert any(f.kind == "blank-line-in-svg" for f in fixes)
@@ -109,11 +102,11 @@ def test_lint_preserves_blank_lines_outside_svg():
         "\n"
         "Paragraph two.\n"
         "\n"
-        '<svg>\n'
-        '  <title>t</title>\n'
-        '\n'
-        '  <text>x</text>\n'
-        '</svg>\n'
+        "<svg>\n"
+        "  <title>t</title>\n"
+        "\n"
+        "  <text>x</text>\n"
+        "</svg>\n"
         "\n"
         "Paragraph three.\n"
     )
@@ -123,13 +116,7 @@ def test_lint_preserves_blank_lines_outside_svg():
 
 
 def test_lint_preserves_indentation_in_svg():
-    src = (
-        '<svg>\n'
-        '  <title>t</title>\n'
-        '\n'
-        '  <text>indented body</text>\n'
-        '</svg>'
-    )
+    src = "<svg>\n  <title>t</title>\n\n  <text>indented body</text>\n</svg>"
     fixed, _ = lint_body(src)
     assert "  <text>indented body</text>" in fixed
 
@@ -150,7 +137,7 @@ def test_lint_does_not_mangle_fenced_code_blocks():
         "And here's a real one:\n"
         "\n"
         '<svg viewBox="0 0 200 200" xmlns="..." role="img">\n'
-        '  <title>real</title>\n'
+        "  <title>real</title>\n"
         "\n"
         "  <text>real text</text>\n"
         "</svg>\n"
@@ -158,7 +145,7 @@ def test_lint_does_not_mangle_fenced_code_blocks():
     fixed, fixes = lint_body(src)
     # The CODE BLOCK content must be preserved verbatim — multi-line open and blanks stay.
     assert (
-        '```svg\n'
+        "```svg\n"
         '<svg viewBox="0 0 100 100"\n'
         '     xmlns="..."\n'
         '     role="img">\n'
@@ -180,10 +167,10 @@ def test_lint_is_idempotent():
         '<svg viewBox="0 0 100 100"\n'
         '     xmlns="..."\n'
         '     role="img">\n'
-        '  <title>t &mdash; subtitle</title>\n'
-        '\n'
-        '  <text>x &times; y</text>\n'
-        '</svg>'
+        "  <title>t &mdash; subtitle</title>\n"
+        "\n"
+        "  <text>x &times; y</text>\n"
+        "</svg>"
     )
     once, _ = lint_body(src)
     twice, fixes_second = lint_body(once)
@@ -204,10 +191,10 @@ def test_lint_does_not_mangle_indented_widget_svg():
     src = (
         '<div class="ptb-state" id="s1">\n'
         '    <svg viewBox="0 0 100 100" xmlns="..." role="img">\n'
-        '      <title>indented</title>\n'
-        '      <text>x</text>\n'
-        '    </svg>\n'
-        '</div>'
+        "      <title>indented</title>\n"
+        "      <text>x</text>\n"
+        "    </svg>\n"
+        "</div>"
     )
     fixed, fixes = lint_body(src)
     # No changes expected — this SVG is already lint-clean.
@@ -223,10 +210,12 @@ def test_lint_canary_against_real_post_0022():
     assert that after lint, the body has no <svg> block with a blank line in it.
     """
     from pathlib import Path
+
     src = Path("assets/blogs/0022-spike-sparse-sink-anatomy-massive.md").read_text(encoding="utf-8")
     fixed, _ = lint_body(src)
     # Find every <svg>...</svg> and check no blank line inside.
     import re
+
     for m in re.finditer(r"<svg\b[^>]*>.*?</svg>", fixed, re.DOTALL):
         block = m.group(0)
         for line in block.split("\n"):

--- a/tests/test_blog_lint.py
+++ b/tests/test_blog_lint.py
@@ -132,3 +132,43 @@ def test_lint_preserves_indentation_in_svg():
     )
     fixed, _ = lint_body(src)
     assert "  <text>indented body</text>" in fixed
+
+
+def test_lint_does_not_mangle_fenced_code_blocks():
+    src = (
+        "Here's the template:\n"
+        "\n"
+        "```svg\n"
+        '<svg viewBox="0 0 100 100"\n'
+        '     xmlns="..."\n'
+        '     role="img">\n'
+        "\n"
+        "  <text>example</text>\n"
+        "</svg>\n"
+        "```\n"
+        "\n"
+        "And here's a real one:\n"
+        "\n"
+        '<svg viewBox="0 0 200 200" xmlns="..." role="img">\n'
+        '  <title>real</title>\n'
+        "\n"
+        "  <text>real text</text>\n"
+        "</svg>\n"
+    )
+    fixed, fixes = lint_body(src)
+    # The CODE BLOCK content must be preserved verbatim — multi-line open and blanks stay.
+    assert (
+        '```svg\n'
+        '<svg viewBox="0 0 100 100"\n'
+        '     xmlns="..."\n'
+        '     role="img">\n'
+        "\n"
+        "  <text>example</text>\n"
+        "</svg>\n"
+        "```"
+    ) in fixed
+    # The REAL <svg> outside the code block IS linted (no internal blank line).
+    real_block_start = fixed.index('<svg viewBox="0 0 200 200"')
+    real_block_end = fixed.index("</svg>", real_block_start)
+    real_block = fixed[real_block_start:real_block_end]
+    assert "\n\n" not in real_block

--- a/tests/test_blog_lint.py
+++ b/tests/test_blog_lint.py
@@ -1,5 +1,19 @@
 """Tests for src.services.blog_lint."""
+import pytest
+
 from src.services.blog_lint import LintError, LintFix, lint_body
+
+
+def test_module_exports_public_surface():
+    """The module exports `LintError`, `LintFix`, `lint_body` as the public API."""
+    # LintError is an Exception subclass; raising and catching it works.
+    with pytest.raises(LintError):
+        raise LintError("test")
+    # LintFix is a dataclass with the documented fields and Literal constraint.
+    fix = LintFix(kind="named-entity", count=1, detail="example")
+    assert fix.kind == "named-entity"
+    assert fix.count == 1
+    assert fix.detail == "example"
 
 
 def test_lint_body_returns_tuple_of_text_and_fixes():

--- a/tests/test_blog_lint.py
+++ b/tests/test_blog_lint.py
@@ -172,3 +172,62 @@ def test_lint_does_not_mangle_fenced_code_blocks():
     real_block_end = fixed.index("</svg>", real_block_start)
     real_block = fixed[real_block_start:real_block_end]
     assert "\n\n" not in real_block
+
+
+def test_lint_is_idempotent():
+    """Running lint twice on the same input produces the same output as once."""
+    src = (
+        '<svg viewBox="0 0 100 100"\n'
+        '     xmlns="..."\n'
+        '     role="img">\n'
+        '  <title>t &mdash; subtitle</title>\n'
+        '\n'
+        '  <text>x &times; y</text>\n'
+        '</svg>'
+    )
+    once, _ = lint_body(src)
+    twice, fixes_second = lint_body(once)
+    assert once == twice
+    assert fixes_second == []  # second pass is a no-op
+
+
+def test_lint_does_not_mangle_indented_widget_svg():
+    """SVG indented as a child of <div class="ptb-state"> is left alone by the
+    blank-line rule; the surrounding <div> already prevents mistletoe from
+    breaking the SVG, so the lint shouldn't touch the indentation.
+
+    The strip_blank_lines_in_svg rule operates inside <svg>...</svg> regardless
+    of indentation, which is fine because indented SVGs typically don't have
+    blank lines inside in the first place. This test guards against any future
+    rule that might be too aggressive about indentation.
+    """
+    src = (
+        '<div class="ptb-state" id="s1">\n'
+        '    <svg viewBox="0 0 100 100" xmlns="..." role="img">\n'
+        '      <title>indented</title>\n'
+        '      <text>x</text>\n'
+        '    </svg>\n'
+        '</div>'
+    )
+    fixed, fixes = lint_body(src)
+    # No changes expected — this SVG is already lint-clean.
+    assert fixed == src
+    assert fixes == []
+
+
+def test_lint_canary_against_real_post_0022():
+    """Regression guard: lint reduces 0022 to a state with no internal SVG blanks.
+
+    This is the post that originally exhibited all three bug classes. We don't
+    assert byte-equality (that would be brittle if the post is edited); we
+    assert that after lint, the body has no <svg> block with a blank line in it.
+    """
+    from pathlib import Path
+    src = Path("assets/blogs/0022-spike-sparse-sink-anatomy-massive.md").read_text(encoding="utf-8")
+    fixed, _ = lint_body(src)
+    # Find every <svg>...</svg> and check no blank line inside.
+    import re
+    for m in re.finditer(r"<svg\b[^>]*>.*?</svg>", fixed, re.DOTALL):
+        block = m.group(0)
+        for line in block.split("\n"):
+            assert line.strip() != "", f"Blank line found inside SVG block: {block[:120]!r}..."

--- a/tests/test_blog_lint.py
+++ b/tests/test_blog_lint.py
@@ -84,3 +84,51 @@ def test_lint_collapses_only_svg_tag_not_other_multi_line_tags():
     fixed, _ = lint_body(src)
     # The multi-line <text> should be unchanged; the <svg> open is already on one line.
     assert "<text x=\"10\" y=\"20\"\n        font-size=\"13\">" in fixed
+
+
+def test_lint_strips_blank_lines_inside_svg():
+    src = (
+        '<svg>\n'
+        '  <title>t</title>\n'
+        '\n'
+        '  <text>line a</text>\n'
+        '\n'
+        '  <text>line b</text>\n'
+        '</svg>'
+    )
+    fixed, fixes = lint_body(src)
+    inside = fixed[fixed.index("<svg>"):fixed.index("</svg>")]
+    assert "\n\n" not in inside
+    assert "<text>line a</text>" in fixed and "<text>line b</text>" in fixed
+    assert any(f.kind == "blank-line-in-svg" for f in fixes)
+
+
+def test_lint_preserves_blank_lines_outside_svg():
+    src = (
+        "Paragraph one.\n"
+        "\n"
+        "Paragraph two.\n"
+        "\n"
+        '<svg>\n'
+        '  <title>t</title>\n'
+        '\n'
+        '  <text>x</text>\n'
+        '</svg>\n'
+        "\n"
+        "Paragraph three.\n"
+    )
+    fixed, _ = lint_body(src)
+    assert "Paragraph one.\n\nParagraph two." in fixed
+    assert "</svg>\n\nParagraph three." in fixed
+
+
+def test_lint_preserves_indentation_in_svg():
+    src = (
+        '<svg>\n'
+        '  <title>t</title>\n'
+        '\n'
+        '  <text>indented body</text>\n'
+        '</svg>'
+    )
+    fixed, _ = lint_body(src)
+    assert "  <text>indented body</text>" in fixed

--- a/tests/test_blog_lint.py
+++ b/tests/test_blog_lint.py
@@ -21,3 +21,32 @@ def test_lint_body_returns_tuple_of_text_and_fixes():
     fixed, fixes = lint_body(text)
     assert fixed == text
     assert fixes == []
+
+
+def test_lint_replaces_mdash_with_unicode():
+    src = "<svg><text>A &mdash; B</text></svg>"
+    fixed, fixes = lint_body(src)
+    assert "&mdash;" not in fixed
+    assert "—" in fixed
+    assert any(f.kind == "named-entity" and f.count == 1 for f in fixes)
+
+
+def test_lint_replaces_multiple_named_entities():
+    src = "<svg><text>x &times; y &rarr; z</text></svg>"
+    fixed, _ = lint_body(src)
+    assert "&times;" not in fixed
+    assert "&rarr;" not in fixed
+    assert "×" in fixed and "→" in fixed
+
+
+def test_lint_preserves_xml_safe_entities():
+    src = "<svg><text>x &lt; y &amp; z &gt; w</text></svg>"
+    fixed, fixes = lint_body(src)
+    assert fixed == src
+    assert fixes == []
+
+
+def test_lint_raises_on_unmapped_entity():
+    src = "<svg><text>nonsense &zzznotreal;</text></svg>"
+    with pytest.raises(LintError, match="zzznotreal"):
+        lint_body(src)

--- a/tests/test_blog_pipeline_e2e.py
+++ b/tests/test_blog_pipeline_e2e.py
@@ -3,6 +3,7 @@
 Uses real files in assets/blogs/ as fixtures. These tests run BEFORE BigQuery
 is touched — they exercise pure-Python pipeline only.
 """
+
 from pathlib import Path
 
 from src.services.blog_lint import lint_body

--- a/tests/test_blog_pipeline_e2e.py
+++ b/tests/test_blog_pipeline_e2e.py
@@ -1,0 +1,50 @@
+"""End-to-end tests: real posts through the full pipeline (lint → render → validate).
+
+Uses real files in assets/blogs/ as fixtures. These tests run BEFORE BigQuery
+is touched — they exercise pure-Python pipeline only.
+"""
+from pathlib import Path
+
+from src.services.blog_lint import lint_body
+from src.services.blog_render import render_to_html, validate_html
+
+
+def _full_pipeline(md_path: Path) -> tuple[str, list]:
+    """Run a markdown file through lint → render → validate.
+
+    Returns (rendered_html, validation_issues). Does not write to disk.
+    """
+    src = md_path.read_text(encoding="utf-8")
+    fixed, _ = lint_body(src)
+    html = render_to_html(fixed)
+    return html, validate_html(html)
+
+
+def test_e2e_post_0020_renders_clean():
+    """Control: a prose-heavy post with a few SVGs renders with no issues."""
+    html, issues = _full_pipeline(Path("assets/blogs/0020-fm-purturb.md"))
+    assert issues == [], f"Issues found: {[i.kind for i in issues]}"
+    assert len(html) > 1000  # sanity: didn't render to nothing
+
+
+def test_e2e_post_0022_renders_clean():
+    """Canary: post 0022 originally had 33 mistletoe foot-gun sites; must be clean now."""
+    html, issues = _full_pipeline(Path("assets/blogs/0022-spike-sparse-sink-anatomy-massive.md"))
+    assert issues == [], f"Issues found: {[i.kind for i in issues]}"
+    # Spot-check that the SVGs survived.
+    assert html.count("<svg") >= 10
+
+
+def test_e2e_post_0001_renders_clean():
+    """Old prose-only post (no SVG) should still pass through cleanly."""
+    html, issues = _full_pipeline(Path("assets/blogs/0001-fastp.md"))
+    assert issues == [], f"Issues found: {[i.kind for i in issues]}"
+
+
+def test_e2e_lint_is_idempotent_against_real_posts():
+    """Running lint twice on every real post produces identical output."""
+    for md_path in sorted(Path("assets/blogs").glob("*.md")):
+        src = md_path.read_text(encoding="utf-8")
+        once, _ = lint_body(src)
+        twice, _ = lint_body(once)
+        assert once == twice, f"lint is not idempotent on {md_path.name}"

--- a/tests/test_blog_render.py
+++ b/tests/test_blog_render.py
@@ -1,4 +1,5 @@
 """Tests for src.services.blog_render."""
+
 from src.services.blog_render import render_to_html
 from src.services.blog_render import ValidationIssue, validate_html
 
@@ -21,9 +22,9 @@ def test_render_returns_plain_string_not_notstr():
 def test_render_preserves_inline_svg_when_clean():
     md = (
         '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img">\n'
-        '  <title>t</title>\n'
-        '  <text>x</text>\n'
-        '</svg>'
+        "  <title>t</title>\n"
+        "  <text>x</text>\n"
+        "</svg>"
     )
     html = render_to_html(md)
     assert "<svg" in html
@@ -40,7 +41,7 @@ def test_validate_returns_empty_for_clean_html():
 
 
 def test_validate_catches_p_wrapping_svg():
-    bad = '<p><svg></svg></p>'
+    bad = "<p><svg></svg></p>"
     issues = validate_html(bad)
     assert any(i.kind == "p-wraps-svg" for i in issues)
     assert all(isinstance(i, ValidationIssue) for i in issues)
@@ -71,14 +72,14 @@ def test_validate_catches_svg_missing_role_img():
 
 
 def test_validate_returns_multiple_issues_at_once():
-    bad = '<p><svg></svg></p><p><text>x</text></p>'  # two <p> wraps + tag mismatch + missing title
+    bad = "<p><svg></svg></p><p><text>x</text></p>"  # two <p> wraps + tag mismatch + missing title
     issues = validate_html(bad)
     kinds = [i.kind for i in issues]
     assert kinds.count("p-wraps-svg") >= 2
 
 
 def test_validate_issue_includes_snippet():
-    bad = '<p><svg></svg></p>'
+    bad = "<p><svg></svg></p>"
     issues = validate_html(bad)
     p_issues = [i for i in issues if i.kind == "p-wraps-svg"]
     assert len(p_issues) >= 1

--- a/tests/test_blog_render.py
+++ b/tests/test_blog_render.py
@@ -1,0 +1,33 @@
+"""Tests for src.services.blog_render."""
+from src.services.blog_render import render_to_html
+
+
+def test_render_passes_simple_markdown_to_html():
+    md = "# Hello\n\nWorld."
+    html = render_to_html(md)
+    assert "<h1" in html  # monsterui adds classes; just check the tag opened
+    assert "Hello" in html
+    assert "<p" in html
+    assert "World." in html
+
+
+def test_render_returns_plain_string_not_notstr():
+    """The function must return `str`, not a FastHTML NotStr/FT object."""
+    html = render_to_html("plain")
+    assert isinstance(html, str)
+
+
+def test_render_preserves_inline_svg_when_clean():
+    md = (
+        '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img">\n'
+        '  <title>t</title>\n'
+        '  <text>x</text>\n'
+        '</svg>'
+    )
+    html = render_to_html(md)
+    assert "<svg" in html
+    assert "<title" in html  # monsterui may rewrite case but tag stays
+    assert "<text" in html
+    # The diagnostic for the bug we're fixing — must NOT appear:
+    assert "<p><svg" not in html
+    assert "<p><text" not in html

--- a/tests/test_blog_render.py
+++ b/tests/test_blog_render.py
@@ -1,5 +1,6 @@
 """Tests for src.services.blog_render."""
 from src.services.blog_render import render_to_html
+from src.services.blog_render import ValidationIssue, validate_html  # noqa: F401
 
 
 def test_render_passes_simple_markdown_to_html():
@@ -31,3 +32,53 @@ def test_render_preserves_inline_svg_when_clean():
     # The diagnostic for the bug we're fixing — must NOT appear:
     assert "<p><svg" not in html
     assert "<p><text" not in html
+
+
+def test_validate_returns_empty_for_clean_html():
+    html = '<svg viewBox="0 0 1 1" role="img"><title>t</title></svg>'
+    assert validate_html(html) == []
+
+
+def test_validate_catches_p_wrapping_svg():
+    bad = '<p><svg></svg></p>'
+    issues = validate_html(bad)
+    assert any(i.kind == "p-wraps-svg" for i in issues)
+
+
+def test_validate_catches_p_wrapping_text():
+    bad = '<svg role="img"><title>t</title></svg>\n<p><text x="0">stray</text></p>'
+    issues = validate_html(bad)
+    assert any(i.kind == "p-wraps-svg" for i in issues)
+
+
+def test_validate_catches_svg_tag_mismatch():
+    bad = '<svg role="img"><title>t</title>'  # missing </svg>
+    issues = validate_html(bad)
+    assert any(i.kind == "svg-tag-mismatch" for i in issues)
+
+
+def test_validate_catches_svg_missing_title():
+    bad = '<svg viewBox="0 0 1 1" role="img"><text>x</text></svg>'  # no <title>
+    issues = validate_html(bad)
+    assert any(i.kind == "svg-missing-title" for i in issues)
+
+
+def test_validate_catches_svg_missing_role_img():
+    bad = '<svg viewBox="0 0 1 1"><title>t</title></svg>'  # no role="img"
+    issues = validate_html(bad)
+    assert any(i.kind == "svg-missing-role" for i in issues)
+
+
+def test_validate_returns_multiple_issues_at_once():
+    bad = '<p><svg></svg></p><p><text>x</text></p>'  # two <p> wraps + tag mismatch + missing title
+    issues = validate_html(bad)
+    kinds = [i.kind for i in issues]
+    assert kinds.count("p-wraps-svg") >= 2
+
+
+def test_validate_issue_includes_snippet():
+    bad = '<p><svg></svg></p>'
+    issues = validate_html(bad)
+    p_issues = [i for i in issues if i.kind == "p-wraps-svg"]
+    assert len(p_issues) >= 1
+    assert "<svg" in p_issues[0].snippet

--- a/tests/test_blog_render.py
+++ b/tests/test_blog_render.py
@@ -1,6 +1,6 @@
 """Tests for src.services.blog_render."""
 from src.services.blog_render import render_to_html
-from src.services.blog_render import ValidationIssue, validate_html  # noqa: F401
+from src.services.blog_render import ValidationIssue, validate_html
 
 
 def test_render_passes_simple_markdown_to_html():
@@ -43,6 +43,7 @@ def test_validate_catches_p_wrapping_svg():
     bad = '<p><svg></svg></p>'
     issues = validate_html(bad)
     assert any(i.kind == "p-wraps-svg" for i in issues)
+    assert all(isinstance(i, ValidationIssue) for i in issues)
 
 
 def test_validate_catches_p_wrapping_text():

--- a/tests/test_cli_blog.py
+++ b/tests/test_cli_blog.py
@@ -113,3 +113,58 @@ def test_payload_from_blog_raises_on_validation_failure(tmp_path):
     )
     with pytest.raises(ValueError, match="validate_html"):
         _payload_from_blog(md)
+
+
+def test_validate_reports_lint_issues_without_writing(tmp_path, capsys):
+    """`blog validate` reports lint issues but does NOT write the file."""
+    from src.cli.__main__ import main
+    md = tmp_path / "post.md"
+    raw = (
+        "@{id = \"00000000-0000-0000-0000-000000000000\"\n"
+        "  title = \"T\"\n"
+        "  date = \"2026-01-01T00:00:00Z\"\n"
+        "  tags = [\"x\"]\n"
+        "  views = 0\n"
+        "  likes = 0\n"
+        "  image = \"https://e.com/i.svg\"\n"
+        "  description = \"d\"\n"
+        "  type = \"note\"\n"
+        "  disabled = false\n"
+        "}\n"
+        "# B\n"
+        '<svg viewBox="0 0 1 1" xmlns="..." role="img">\n'
+        "  <title>x &mdash; y</title>\n"
+        "</svg>\n"
+    )
+    md.write_text(raw, encoding="utf-8")
+    rc = main(["blog", "validate", str(md)])
+    assert rc == 0
+    after = md.read_text(encoding="utf-8")
+    # File must be unchanged.
+    assert after == raw
+    captured = capsys.readouterr()
+    # Validate should report what lint WOULD do.
+    assert "lint" in captured.out.lower() or "would" in captured.out.lower()
+
+
+def test_validate_exits_nonzero_on_validation_issue(tmp_path):
+    """`blog validate` exits nonzero when validate_html finds an issue."""
+    from src.cli.__main__ import main
+    md = tmp_path / "post.md"
+    md.write_text(
+        "@{id = \"00000000-0000-0000-0000-000000000000\"\n"
+        "  title = \"T\"\n"
+        "  date = \"2026-01-01T00:00:00Z\"\n"
+        "  tags = [\"x\"]\n"
+        "  views = 0\n"
+        "  likes = 0\n"
+        "  image = \"https://e.com/i.svg\"\n"
+        "  description = \"d\"\n"
+        "  type = \"note\"\n"
+        "  disabled = false\n"
+        "}\n"
+        "# B\n<svg viewBox=\"0 0 1 1\"><text>missing title and role</text></svg>\n",
+        encoding="utf-8",
+    )
+    rc = main(["blog", "validate", str(md)])
+    assert rc == 1

--- a/tests/test_cli_blog.py
+++ b/tests/test_cli_blog.py
@@ -6,6 +6,8 @@ plumbing (argparse, dispatch, exit codes) is exercised through the
 ``validate`` subcommand.
 """
 
+import pytest
+
 from src.cli.__main__ import main
 
 
@@ -32,3 +34,82 @@ def test_blog_validate_exits_nonzero_on_invalid_frontmatter(tmp_path, capsys):
     assert rc == 1
     captured = capsys.readouterr()
     assert "INVALID" in captured.err
+
+
+def test_payload_from_blog_includes_body_html(tmp_path):
+    """_payload_from_blog returns a dict with both `body` (markdown) and
+    `body_html` (rendered)."""
+    from src.cli.blog import _payload_from_blog
+    md = tmp_path / "post.md"
+    md.write_text(
+        "@{title = \"T\"\n"
+        "  date = \"2026-01-01T00:00:00Z\"\n"
+        "  tags = [\"x\"]\n"
+        "  views = 0\n"
+        "  likes = 0\n"
+        "  image = \"https://e.com/i.svg\"\n"
+        "  description = \"d\"\n"
+        "  type = \"note\"\n"
+        "  disabled = false\n"
+        "}\n"
+        "# Body\n",
+        encoding="utf-8",
+    )
+    payload = _payload_from_blog(md)
+    assert "body" in payload
+    assert "body_html" in payload
+    assert "<h1" in payload["body_html"]
+
+
+def test_payload_from_blog_persists_lint_fixes_to_disk(tmp_path, capsys):
+    """If lint changes the body, the .md file is overwritten with the linted text."""
+    from src.cli.blog import _payload_from_blog
+    md = tmp_path / "post.md"
+    raw = (
+        "@{title = \"T\"\n"
+        "  date = \"2026-01-01T00:00:00Z\"\n"
+        "  tags = [\"x\"]\n"
+        "  views = 0\n"
+        "  likes = 0\n"
+        "  image = \"https://e.com/i.svg\"\n"
+        "  description = \"d\"\n"
+        "  type = \"note\"\n"
+        "  disabled = false\n"
+        "}\n"
+        "# Body\n"
+        '<svg viewBox="0 0 100 100" xmlns="..." role="img">\n'
+        "  <title>x &mdash; y</title>\n"
+        "  <text>z</text>\n"
+        "</svg>\n"
+    )
+    md.write_text(raw, encoding="utf-8")
+    _payload_from_blog(md)
+    after = md.read_text(encoding="utf-8")
+    assert "&mdash;" not in after
+    assert "—" in after
+    captured = capsys.readouterr()
+    assert "[lint]" in captured.out
+
+
+def test_payload_from_blog_raises_on_validation_failure(tmp_path):
+    """If validate_html finds an issue, _payload_from_blog raises."""
+    from src.cli.blog import _payload_from_blog
+    md = tmp_path / "post.md"
+    # Body contains an SVG with no <title> and no role="img" — both will fail validation.
+    md.write_text(
+        "@{title = \"T\"\n"
+        "  date = \"2026-01-01T00:00:00Z\"\n"
+        "  tags = [\"x\"]\n"
+        "  views = 0\n"
+        "  likes = 0\n"
+        "  image = \"https://e.com/i.svg\"\n"
+        "  description = \"d\"\n"
+        "  type = \"note\"\n"
+        "  disabled = false\n"
+        "}\n"
+        "# Body\n"
+        "<svg viewBox=\"0 0 100 100\"><text>x</text></svg>\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="validate_html"):
+        _payload_from_blog(md)

--- a/tests/test_cli_blog.py
+++ b/tests/test_cli_blog.py
@@ -40,16 +40,17 @@ def test_payload_from_blog_includes_body_html(tmp_path):
     """_payload_from_blog returns a dict with both `body` (markdown) and
     `body_html` (rendered)."""
     from src.cli.blog import _payload_from_blog
+
     md = tmp_path / "post.md"
     md.write_text(
-        "@{title = \"T\"\n"
-        "  date = \"2026-01-01T00:00:00Z\"\n"
-        "  tags = [\"x\"]\n"
+        '@{title = "T"\n'
+        '  date = "2026-01-01T00:00:00Z"\n'
+        '  tags = ["x"]\n'
         "  views = 0\n"
         "  likes = 0\n"
-        "  image = \"https://e.com/i.svg\"\n"
-        "  description = \"d\"\n"
-        "  type = \"note\"\n"
+        '  image = "https://e.com/i.svg"\n'
+        '  description = "d"\n'
+        '  type = "note"\n'
         "  disabled = false\n"
         "}\n"
         "# Body\n",
@@ -64,16 +65,17 @@ def test_payload_from_blog_includes_body_html(tmp_path):
 def test_payload_from_blog_persists_lint_fixes_to_disk(tmp_path, capsys):
     """If lint changes the body, the .md file is overwritten with the linted text."""
     from src.cli.blog import _payload_from_blog
+
     md = tmp_path / "post.md"
     raw = (
-        "@{title = \"T\"\n"
-        "  date = \"2026-01-01T00:00:00Z\"\n"
-        "  tags = [\"x\"]\n"
+        '@{title = "T"\n'
+        '  date = "2026-01-01T00:00:00Z"\n'
+        '  tags = ["x"]\n'
         "  views = 0\n"
         "  likes = 0\n"
-        "  image = \"https://e.com/i.svg\"\n"
-        "  description = \"d\"\n"
-        "  type = \"note\"\n"
+        '  image = "https://e.com/i.svg"\n'
+        '  description = "d"\n'
+        '  type = "note"\n'
         "  disabled = false\n"
         "}\n"
         "# Body\n"
@@ -94,21 +96,22 @@ def test_payload_from_blog_persists_lint_fixes_to_disk(tmp_path, capsys):
 def test_payload_from_blog_raises_on_validation_failure(tmp_path):
     """If validate_html finds an issue, _payload_from_blog raises."""
     from src.cli.blog import _payload_from_blog
+
     md = tmp_path / "post.md"
     # Body contains an SVG with no <title> and no role="img" — both will fail validation.
     md.write_text(
-        "@{title = \"T\"\n"
-        "  date = \"2026-01-01T00:00:00Z\"\n"
-        "  tags = [\"x\"]\n"
+        '@{title = "T"\n'
+        '  date = "2026-01-01T00:00:00Z"\n'
+        '  tags = ["x"]\n'
         "  views = 0\n"
         "  likes = 0\n"
-        "  image = \"https://e.com/i.svg\"\n"
-        "  description = \"d\"\n"
-        "  type = \"note\"\n"
+        '  image = "https://e.com/i.svg"\n'
+        '  description = "d"\n'
+        '  type = "note"\n'
         "  disabled = false\n"
         "}\n"
         "# Body\n"
-        "<svg viewBox=\"0 0 100 100\"><text>x</text></svg>\n",
+        '<svg viewBox="0 0 100 100"><text>x</text></svg>\n',
         encoding="utf-8",
     )
     with pytest.raises(ValueError, match="validate_html"):
@@ -118,17 +121,18 @@ def test_payload_from_blog_raises_on_validation_failure(tmp_path):
 def test_validate_reports_lint_issues_without_writing(tmp_path, capsys):
     """`blog validate` reports lint issues but does NOT write the file."""
     from src.cli.__main__ import main
+
     md = tmp_path / "post.md"
     raw = (
-        "@{id = \"00000000-0000-0000-0000-000000000000\"\n"
-        "  title = \"T\"\n"
-        "  date = \"2026-01-01T00:00:00Z\"\n"
-        "  tags = [\"x\"]\n"
+        '@{id = "00000000-0000-0000-0000-000000000000"\n'
+        '  title = "T"\n'
+        '  date = "2026-01-01T00:00:00Z"\n'
+        '  tags = ["x"]\n'
         "  views = 0\n"
         "  likes = 0\n"
-        "  image = \"https://e.com/i.svg\"\n"
-        "  description = \"d\"\n"
-        "  type = \"note\"\n"
+        '  image = "https://e.com/i.svg"\n'
+        '  description = "d"\n'
+        '  type = "note"\n'
         "  disabled = false\n"
         "}\n"
         "# B\n"
@@ -150,20 +154,21 @@ def test_validate_reports_lint_issues_without_writing(tmp_path, capsys):
 def test_validate_exits_nonzero_on_validation_issue(tmp_path):
     """`blog validate` exits nonzero when validate_html finds an issue."""
     from src.cli.__main__ import main
+
     md = tmp_path / "post.md"
     md.write_text(
-        "@{id = \"00000000-0000-0000-0000-000000000000\"\n"
-        "  title = \"T\"\n"
-        "  date = \"2026-01-01T00:00:00Z\"\n"
-        "  tags = [\"x\"]\n"
+        '@{id = "00000000-0000-0000-0000-000000000000"\n'
+        '  title = "T"\n'
+        '  date = "2026-01-01T00:00:00Z"\n'
+        '  tags = ["x"]\n'
         "  views = 0\n"
         "  likes = 0\n"
-        "  image = \"https://e.com/i.svg\"\n"
-        "  description = \"d\"\n"
-        "  type = \"note\"\n"
+        '  image = "https://e.com/i.svg"\n'
+        '  description = "d"\n'
+        '  type = "note"\n'
         "  disabled = false\n"
         "}\n"
-        "# B\n<svg viewBox=\"0 0 1 1\"><text>missing title and role</text></svg>\n",
+        '# B\n<svg viewBox="0 0 1 1"><text>missing title and role</text></svg>\n',
         encoding="utf-8",
     )
     rc = main(["blog", "validate", str(md)])

--- a/tests/test_project_model.py
+++ b/tests/test_project_model.py
@@ -42,3 +42,29 @@ def test_from_dict_falls_back_to_defaults_for_missing_fields():
     assert project.likes == 0
     assert project.date == ""
     assert project.body == ""
+
+
+def test_project_from_dict_reads_body_html():
+    data = {
+        "id": "x",
+        "title": "T",
+        "description": "d",
+        "image": "https://e.com/i.svg",
+        "tags": ["t"],
+        "disabled": False,
+        "views": 0,
+        "likes": 0,
+        "date": "2026-01-01T00:00:00Z",
+        "body": "# md",
+        "body_html": "<h1>md</h1>",
+    }
+    p = Project.from_dict(data)
+    assert p.body_html == "<h1>md</h1>"
+    assert p.body == "# md"  # transitional: both fields populated
+
+
+def test_project_from_dict_defaults_body_html_to_empty_string():
+    """A row that doesn't have body_html (legacy/transitional) yields an empty string."""
+    data = {"id": "x", "title": "T", "description": "d", "image": "i", "body": "md"}
+    p = Project.from_dict(data)
+    assert p.body_html == ""


### PR DESCRIPTION
## Summary
- Move blog markdown → HTML rendering from view time to submit time
- Lint+render+validate auto-runs on `blog submit`/`blog update`; bugs surface at submit, not at view
- BigQuery `gn-blog` gains `body_html STRING` column (legacy `body` retained during 1-week soak, removed in follow-up)
- All 22 existing posts backfilled with rendered HTML (validated clean: 22/22)
- Live blog detail pages now read `body_html` with `render_md(body)` defensive fallback

## Why
View-time mistletoe rendering produced three distinct SVG-rendering bugs in posts authored by `paper-to-blog` (HTML named entities, multi-line `<svg>` opening tags, blank lines inside SVG). Each was tractable but reactively patching every new mistletoe foot-gun is friction. Pre-rendering at submit time + a strict `validate_html` pass moves bug surfacing to the cheapest moment.

Full design + decision log: `docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md`.
Implementation plan + execution trail: `docs/superpowers/plans/2026-04-30-blog-html-pipeline.md`.

## What ships in this PR
- 2 new modules: `src/services/blog_lint.py` (entity replacement, SVG-tag collapse, blank-line stripping, fenced-code stash), `src/services/blog_render.py` (`render_to_html` + `validate_html` with 4 rules)
- New Pydantic model `BlogRow` for BigQuery payload (carries both `body` and `body_html` during migration)
- CLI rewires: `_payload_from_blog` + `_cmd_validate` now run lint→render→validate; lint fixes auto-persist to `.md`
- `Project.body_html` field, `_render_blog_detail` cutover with safe fallback
- One-shot `scripts/backfill_blog_html.py` (dry-run mode + 35-min streaming-buffer retry)
- 95 tests across 8 suites: lint, render, frontmatter, CLI, e2e, project model, blog detail, backfill, accessibility
- 0020-fm-purturb.md gains `role=\"img\"` + `<title>` on each of its 10 SVGs (legacy accessibility gap caught by E2E test)

## Schema migration status
- **Done:** `ALTER TABLE ... ADD COLUMN body_html STRING` + 22-row backfill
- **Pending soak (≥ 7 days):** monitor live, then `ALTER TABLE ... DROP COLUMN body` and remove transitional model fields

## Test plan
- [x] `pytest tests/ -q` — all 95 passing
- [x] `ruff check` — clean across all touched files
- [x] `python -m src.cli blog submit assets/blogs/0021-portello.md --dry-run` — payload includes both `body` and `body_html`
- [x] BigQuery verification: 22/22 rows have non-null `body_html`; pre-merge `validate_html` sweep returns 0 issues
- [ ] After merge + Cloud Run redeploy: visit `/blogs/slug/portello-…` and `/blogs/slug/the-spike-…` — confirm SVG diagrams + widgets render correctly from the new `body_html` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)