### PR TITLE
chore(gitignore): ignore .claude, .devcontainer, .playwright-mcp dev artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,8 @@ cython_debug/
 
 # Secret directories
 /assets/secrets/*
+
+# Dev environment artifacts (per-developer; not shared)
+.claude/
+.devcontainer/
+.playwright-mcp/


### PR DESCRIPTION
These three directories show up untracked in every dev clone but are per-developer / per-environment scaffolding, not source-of-truth project files. Adding them to \`.gitignore\` so \`git status\` stays clean.

| Pattern | What it is |
|---|---|
| \`.claude/\` | Claude Code per-project settings (settings.local.json, hooks, etc.) |
| \`.devcontainer/\` | Local VSCode devcontainer config |
| \`.playwright-mcp/\` | Playwright MCP run artifacts and cache |

## Verification

Created throwaway test directories matching each pattern in the worktree, ran \`git status\`, confirmed none appeared as untracked. The single change is the 5-line append to \`.gitignore\`.

## Note on \`.mcp.json\`

\`.mcp.json\` also shows up untracked in \`/app\`. I left it out of this PR since you only asked for the three directories. Happy to add it (or set it up as a tracked-but-templatized file) in a follow-up if helpful — let me know.

## Diff

\`\`\`diff
+# Dev environment artifacts (per-developer; not shared)
+.claude/
+.devcontainer/
+.playwright-mcp/
\`\`\`