### PR TITLE
feat(blog): add 0023 training-free GRPO and 0024 DINO-VITS journal-club posts

### DIFF
--- a/assets/blogs/0023-training-free-grpo.md
+++ b/assets/blogs/0023-training-free-grpo.md
@@ -1,0 +1,726 @@
+@{id = "e24bdadd-bd73-43a9-8358-f6cf6e75cf15"
+  title = "Training-Free GRPO: Doing RL on the Prompt, Not the Weights"
+  date = "2026-05-01T00:00:00Z"
+  tags = ['journal club', 'machine learning', 'arxiv', 'language models', 'reinforcement learning', 'agents']
+  views = 0
+  likes = 0
+  image = "https://storage.googleapis.com/gn-portfolio/images/training-free-grpo-thumb.svg"
+  description = "Tencent's Youtu-Agent team adapts GRPO to a frozen LLM by replacing the gradient with a natural-language experience buffer, beating fine-tuned 32B models for around eighteen dollars."
+  type = "note"
+  disabled = "false"
+}
+
+<p align="center">
+  <img src="https://storage.googleapis.com/gn-portfolio/images/training-free-grpo-thumb.svg" max-width="700">
+</p>
+
+
+# Training-Free GRPO: Doing RL on the Prompt, Not the Weights
+
+*Analysis of Youtu-Agent Team (2025), arXiv:2510.08191 — preprint*
+*Generated on April 29, 2026*
+
+---
+
+## Table of Contents
+
+- [Abstract](#abstract)
+- [Introduction](#introduction)
+- [Method: Training-Free GRPO](#method-training-free-grpo)
+- [Mathematical Reasoning Results](#mathematical-reasoning-results)
+- [Web Searching Results](#web-searching-results)
+- [Context Space vs Parameter Space](#context-space-vs-parameter-space)
+- [Related Work in One Page](#related-work-in-one-page)
+- [Conclusion](#conclusion)
+- [Key Takeaways (Summary)](#key-takeaways-summary)
+
+---
+
+## Abstract
+
+### Overview
+
+If you have used a large language model agent to do something specialized — say, multi-step web research or contest math with a code interpreter — you have probably felt the gap between a frontier model's *general* capability and its *domain-specific* habits. The model knows how to reason; it just does not know which moves work in your domain, which tools to skip, which sources to trust. The textbook fix is reinforcement learning: collect ground-truth examples, run a few thousand training rollouts, and update the model's weights so high-reward behaviors become more likely. The recipe most teams reach for, made famous by DeepSeek's R1, is **Group Relative Policy Optimization (GRPO)** — a relative of PPO that drops the value-network critic and instead estimates per-output advantage by comparing each sample to the group mean of a small batch of rollouts. It works, and it is now the default tool for "agentic RL".
+
+The Youtu-Agent team at Tencent argue that the *vast majority of GRPO's value is mechanical* — the multi-epoch rollout structure, the group-relative comparison, the iterative refinement — and that the gradient update at the end is one specific way to capture what was learned, not the only way. Their proposal: keep GRPO's structure, but replace the gradient with a natural-language *experience buffer* that gets read into the prompt. They call it **Training-Free GRPO**. The frozen base model takes the role of the policy; an evolving block of plain-text "lessons" takes the role of the learned weights.
+
+The headline numbers are unflattering to the parameter-update orthodoxy. With **about $18** in API spend, **100 training samples**, and **zero gradient updates**, a frozen DeepSeek-V3.1-Terminus reaches **82.7% on AIME24** and **73.3% on AIME25** (Mean@32), beating the best 32B model fine-tuned via vanilla agentic RL — methods like ReTool [arXiv:2504.11536] and AFM [arXiv:2508.13167] that the paper estimates at ~$10K each. Web search gets the same treatment: WebWalkerQA pass@1 climbs from 63.2% to 67.8% with a different 100-sample buffer.
+
+The fine print matters. The method depends on a *strong* base model — running the same recipe on QwQ-32B for web search actually *hurts* performance (-2.0 pass@1). It also depends on the buffer being learned with proper group-relative comparison: an ablation that just dumps directly-generated tips into the prompt gives essentially no gain (79.8% vs 80.0% baseline). The optimization machinery is doing real work; this is not a glorified prompt template.
+
+What's at stake practically: if this generalizes, the cost calculus of building a vertical agent flips. Instead of paying $10K to fine-tune a model you have to host on a fixed-cost GPU cluster, you pay $20 to learn a small block of natural-language lessons (a few dozen entries, on the order of a few KB) that you append to API calls. For low-traffic specialized agents — most enterprise agents, in practice — that is a different business.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="abs-diag-title">
+  <title id="abs-diag-title">Training-Free GRPO replaces gradient updates with a natural-language experience buffer</title>
+  <defs>
+    <marker id="abs-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Two routes from a query to a better next answer</text>
+  <!-- Vanilla GRPO row -->
+  <text x="40" y="68" font-size="12" font-weight="700" fill="#991b1b">Vanilla GRPO</text>
+  <rect x="40" y="78" width="120" height="50" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="100" y="100" text-anchor="middle" font-weight="600" fill="#1e40af">Query q</text>
+  <text x="100" y="118" text-anchor="middle" font-size="11" fill="#64748b">+ policy π_θ</text>
+  <line x1="160" y1="103" x2="200" y2="103" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <rect x="200" y="78" width="120" height="50" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="260" y="100" text-anchor="middle" font-weight="600" fill="#334155">G rollouts</text>
+  <text x="260" y="118" text-anchor="middle" font-size="11" fill="#64748b">scored by R</text>
+  <line x1="320" y1="103" x2="360" y2="103" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <rect x="360" y="78" width="140" height="50" rx="8" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text x="430" y="100" text-anchor="middle" font-weight="600" fill="#854d0e">Numerical Â_i</text>
+  <text x="430" y="118" text-anchor="middle" font-size="11" fill="#854d0e">(r − μ)/σ</text>
+  <line x1="500" y1="103" x2="540" y2="103" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <rect x="540" y="78" width="140" height="50" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
+  <text x="610" y="100" text-anchor="middle" font-weight="700" fill="#991b1b">Update θ</text>
+  <text x="610" y="118" text-anchor="middle" font-size="11" fill="#991b1b">~$10K, GPUs</text>
+  <!-- Training-Free GRPO row -->
+  <text x="40" y="208" font-size="12" font-weight="700" fill="#166534">Training-Free GRPO</text>
+  <rect x="40" y="218" width="120" height="50" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="100" y="240" text-anchor="middle" font-weight="600" fill="#1e40af">Query q</text>
+  <text x="100" y="258" text-anchor="middle" font-size="11" fill="#64748b">+ frozen π_θ + E</text>
+  <line x1="160" y1="243" x2="200" y2="243" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <rect x="200" y="218" width="120" height="50" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="260" y="240" text-anchor="middle" font-weight="600" fill="#334155">G rollouts</text>
+  <text x="260" y="258" text-anchor="middle" font-size="11" fill="#64748b">scored by R</text>
+  <line x1="320" y1="243" x2="360" y2="243" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <rect x="360" y="218" width="140" height="50" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="430" y="240" text-anchor="middle" font-weight="600" fill="#6b21a8">Semantic A_text</text>
+  <text x="430" y="258" text-anchor="middle" font-size="11" fill="#6b21a8">LLM introspects</text>
+  <line x1="500" y1="243" x2="540" y2="243" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <rect x="540" y="218" width="140" height="50" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="610" y="240" text-anchor="middle" font-weight="700" fill="#166534">Update E</text>
+  <text x="610" y="258" text-anchor="middle" font-size="11" fill="#166534">~$18, API calls</text>
+  <text x="360" y="320" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Same multi-epoch loop. The output of "training" is text the next prompt reads, not weights.</text>
+</svg>
+
+### Key Takeaways
+
+- **The gradient was one option, not the only option.** GRPO's structure (group rollouts, relative comparison, multi-epoch refinement) does most of the work; the parameter update is one specific way to commit the lesson.
+- **The "advantage" can be a paragraph.** Replacing the scalar Â_i with a natural-language explanation of what worked vs what failed — a *semantic advantage* — keeps the optimization signal interpretable and lets the LLM itself do the credit assignment.
+- **Frozen-model RL flips the cost calculus.** $18 + 100 samples beats $10K + thousands of samples when you can use a strong frontier API model as the backbone.
+- **It only works when the base is strong.** On weaker bases (QwQ-32B in web search), the same recipe regresses — the method amplifies an already-capable agent rather than teaching one from scratch.
+
+---
+
+## Introduction
+
+### Overview
+
+A short historical arc helps here. Until about 2017, "reinforcement learning for language models" mostly meant REINFORCE-style policy gradients with a learned baseline — high variance, painful to stabilize. **PPO** (Proximal Policy Optimization, Schulman et al. 2017) tamed that variance by clipping the per-step ratio between the new and old policy and adding a value-network critic to estimate per-token advantages. PPO is what powered the original RLHF wave at OpenAI and Anthropic, and it remains the default for instruction tuning.
+
+PPO has a wart, though: the critic. Training a separate value network roughly doubles your active parameter count and adds its own optimization headaches. **GRPO** (Group Relative Policy Optimization), introduced by DeepSeek's mathematical-reasoning work in 2024 and now widely used in DeepSeek's reasoning-model lineage, throws the critic out. Its trick is to sample G outputs for the same prompt, score them all with the reward model, and define each output's advantage *relative to its group's mean and standard deviation*. No critic, no separate value model, just a small batch of rollouts and a normalized score. It is a remarkably clean idea, and it scales.
+
+When the LLM-agents community adopted GRPO, they kept the gradient-update assumption intact. **"Agentic RL"** — as opposed to ordinary fine-tuning — usually means: build a tool-using ReAct loop, generate multi-step trajectories, score the trajectories, then GRPO-update the policy. The result is a domain-specialized model: ReTool for math with code interpreter, AFM for web research, and so on. Each one is good at its domain and worse than the base elsewhere. Each one costs roughly $10K to train and requires a dedicated GPU cluster to serve.
+
+Now consider the cost calculus the paper opens with. Fine-tuning anything bigger than ~32B parameters is essentially out of reach for most teams (compute budget, but also data scarcity — annotated agentic trajectories are scarce). So you fine-tune a smaller model, get a domain-specific gain, but lose to the *general-purpose* frontier model on everything else. Worse, you pay continuous serving costs even when traffic is low. This is the *cost-performance dilemma* the authors put at the center of the paper: API access to a strong frozen model is cheap and elastic, but you can't fine-tune it; smaller models you can fine-tune are inherently weaker.
+
+The paper's pivot is conceptual. The authors note that GRPO's parameter update is just one mechanism for steering the output distribution toward higher-reward behaviors. **In-context learning** — the GPT-3 finding that LLMs adapt their outputs based on prompt content — provides a second mechanism. If we can manufacture a chunk of text that, when prepended to the prompt, has the same effect on the output distribution as a weight update would have, we have built a non-parametric optimizer. They call this chunk the **experiential knowledge buffer** and treat it as the analog of θ. The optimization loop then becomes: roll out, compare, distill what worked into the buffer, repeat.
+
+The "why now" is mundane but real. Two recent shifts make this feasible: (1) frontier API models like DeepSeek-V3.1 became cheap enough per token to run real multi-epoch rollouts via API; (2) those same models became coherent enough at long-context reasoning to play *both* roles in this loop — they are the policy generating rollouts *and* the judge introspecting on them and updating the buffer. Earlier, weaker models couldn't credibly self-introspect; now they can.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="intro-diag-title">
+  <title id="intro-diag-title">Lineage of policy-gradient methods leading to Training-Free GRPO</title>
+  <defs>
+    <marker id="intro-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Lineage: REINFORCE → PPO → GRPO → Training-Free GRPO</text>
+  <!-- REINFORCE -->
+  <rect x="30" y="80" width="140" height="80" rx="10" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="100" y="108" text-anchor="middle" font-weight="700" fill="#334155">REINFORCE</text>
+  <text x="100" y="128" text-anchor="middle" font-size="11" fill="#475569">policy gradient</text>
+  <text x="100" y="144" text-anchor="middle" font-size="11" fill="#64748b">high variance</text>
+  <line x1="170" y1="120" x2="200" y2="120" stroke="#64748b" stroke-width="1.5" marker-end="url(#intro-arrow)"/>
+  <!-- PPO -->
+  <rect x="200" y="80" width="140" height="80" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="270" y="108" text-anchor="middle" font-weight="700" fill="#1e40af">PPO</text>
+  <text x="270" y="128" text-anchor="middle" font-size="11" fill="#475569">+ critic, + clip</text>
+  <text x="270" y="144" text-anchor="middle" font-size="11" fill="#64748b">2017</text>
+  <line x1="340" y1="120" x2="370" y2="120" stroke="#64748b" stroke-width="1.5" marker-end="url(#intro-arrow)"/>
+  <!-- GRPO -->
+  <rect x="370" y="80" width="140" height="80" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="440" y="108" text-anchor="middle" font-weight="700" fill="#1e40af">GRPO</text>
+  <text x="440" y="128" text-anchor="middle" font-size="11" fill="#475569">drop critic,</text>
+  <text x="440" y="144" text-anchor="middle" font-size="11" fill="#475569">group-relative Â</text>
+  <line x1="510" y1="120" x2="540" y2="120" stroke="#64748b" stroke-width="1.5" marker-end="url(#intro-arrow)"/>
+  <!-- Training-Free GRPO -->
+  <rect x="540" y="80" width="150" height="80" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="615" y="108" text-anchor="middle" font-weight="700" fill="#166534">Training-Free</text>
+  <text x="615" y="124" text-anchor="middle" font-weight="700" fill="#166534">GRPO</text>
+  <text x="615" y="144" text-anchor="middle" font-size="11" fill="#166534">drop gradient</text>
+  <!-- Annotations -->
+  <text x="100" y="190" text-anchor="middle" font-size="11" fill="#64748b">value baseline</text>
+  <text x="270" y="190" text-anchor="middle" font-size="11" fill="#64748b">value network</text>
+  <text x="440" y="190" text-anchor="middle" font-size="11" fill="#64748b">no value net</text>
+  <text x="615" y="190" text-anchor="middle" font-size="11" fill="#166534" font-weight="600">no parameters</text>
+  <!-- What gets updated row -->
+  <rect x="30" y="220" width="660" height="50" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="40" y="242" font-size="11" font-weight="600" fill="#6b21a8">Updated by training:</text>
+  <text x="100" y="262" text-anchor="middle" font-size="11" fill="#475569">θ (gradient)</text>
+  <text x="270" y="262" text-anchor="middle" font-size="11" fill="#475569">θ (gradient)</text>
+  <text x="440" y="262" text-anchor="middle" font-size="11" fill="#475569">θ (gradient)</text>
+  <text x="615" y="262" text-anchor="middle" font-size="11" fill="#6b21a8" font-weight="700">E (text buffer)</text>
+  <text x="360" y="310" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Each step keeps the previous structure and replaces one component. Training-Free GRPO replaces θ.</text>
+</svg>
+
+### Key Takeaways
+
+- **GRPO's value is structural.** The group-relative comparison and multi-epoch loop are the parts that move the needle; the gradient was just the implementation.
+- **The cost-performance dilemma is real.** Fine-tuning is restricted to small models you can afford to train; the strongest models you can only call via API. Training-Free GRPO targets exactly that gap.
+- **Two enabling shifts make this work now.** Cheap frontier API tokens, plus models coherent enough to introspect on their own rollouts.
+- **In-context learning is the optimization channel.** A well-crafted prompt prefix can shift the output distribution the same way a weight update can — if you craft it from the right signal.
+
+---
+
+## Method: Training-Free GRPO
+
+### Overview
+
+Before the algorithm, a 1-sentence orientation: a *rollout* is a complete trajectory the agent produces for a given query — every reasoning step, every tool call, every final answer — and a *group* is the set of G rollouts the algorithm samples for the same query, so it can rank them against each other.
+
+Vanilla GRPO produces, for each query q, a group of G outputs {o_1, …, o_G}. Each output gets a scalar reward r_i from a verifier (in math, a check whether the boxed answer is correct; in web search, a graded comparison to a ground-truth answer). The group-relative advantage is Â_i = (r_i − mean(r)) / std(r). The training loss is a PPO-clipped objective over these advantages, with a KL-divergence penalty pulling the policy back toward a fixed reference model. Gradient ascent on θ.
+
+Training-Free GRPO keeps the rollouts and the rewards, but replaces *every step downstream of "I have G rewards"*. The policy is the frozen base model conditioned on an experiential knowledge buffer E — π_θ(o_i | q, E) — where E is plain text, initialized to the empty string. After scoring, the algorithm checks whether the group has both clear winners (correct answers) and clear losers (incorrect answers). If not, the group is skipped (analogous to the std(r) = 0 case in vanilla GRPO, where Â_i = 0). If yes, the LLM itself is asked to (1) summarize each rollout step-by-step, (2) compare them given the ground-truth answer, and (3) extract a *natural-language experience* — a concise piece of advice for what worked or what to avoid. This natural-language object is the **semantic advantage** A_text, the analog of Â_i.
+
+The "optimization step" is then a buffer update. Given the existing E and the new A_text from this batch, the LLM is prompted to emit one of four operations: **Add** a new lesson, **Delete** a lesson that this batch contradicts, **Modify** an existing lesson with new nuance, or **Keep** E unchanged. The buffer typically grows to a few dozen entries — Appendix A of the paper shows a math buffer of 37 lessons (e.g. *"When solving geometry problems with intersections, validate solutions lie within bounded regions"*) and a web-search buffer with similar style.
+
+Two design notes worth pulling out. First, the frozen base model serves the function of the KL constraint in vanilla GRPO: because π_θ never changes, the policy cannot drift arbitrarily far from a coherent base — the buffer can only steer, not corrupt. Second, the same LLM (DeepSeek-V3.1-Terminus in the main experiments) plays three roles: policy that generates rollouts, judge that produces semantic advantages, and optimizer that emits buffer operations. There is no separate critic, no separate reward model, no separate optimizer. It is the same model called with different prompts.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 460" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="method-diag-title">
+  <title id="method-diag-title">One epoch of Training-Free GRPO: rollouts, semantic advantage, buffer update</title>
+  <defs>
+    <marker id="method-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">One optimization step</text>
+  <!-- Inputs -->
+  <rect x="30" y="60" width="170" height="50" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="115" y="82" text-anchor="middle" font-weight="600" fill="#1e40af">Query q + ground truth</text>
+  <text x="115" y="100" text-anchor="middle" font-size="11" fill="#64748b">from minimal training set</text>
+  <rect x="30" y="130" width="170" height="50" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="115" y="152" text-anchor="middle" font-weight="600" fill="#334155">Frozen π_θ + buffer E</text>
+  <text x="115" y="170" text-anchor="middle" font-size="11" fill="#64748b">(E starts empty)</text>
+  <line x1="200" y1="120" x2="240" y2="160" stroke="#64748b" stroke-width="1.5" marker-end="url(#method-arrow)"/>
+  <line x1="200" y1="155" x2="240" y2="170" stroke="#64748b" stroke-width="1.5" marker-end="url(#method-arrow)"/>
+  <!-- G rollouts -->
+  <rect x="240" y="120" width="180" height="80" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="330" y="146" text-anchor="middle" font-weight="600" fill="#334155">Sample G rollouts</text>
+  <text x="330" y="166" text-anchor="middle" font-size="11" fill="#64748b">o_1, o_2, …, o_G</text>
+  <text x="330" y="184" text-anchor="middle" font-size="11" fill="#64748b">score each: r_1, …, r_G</text>
+  <line x1="420" y1="160" x2="460" y2="160" stroke="#64748b" stroke-width="1.5" marker-end="url(#method-arrow)"/>
+  <!-- Semantic advantage -->
+  <rect x="460" y="120" width="220" height="80" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="2"/>
+  <text x="570" y="146" text-anchor="middle" font-weight="700" fill="#6b21a8">Semantic advantage A_text</text>
+  <text x="570" y="166" text-anchor="middle" font-size="11" fill="#6b21a8">"the winners did X;</text>
+  <text x="570" y="182" text-anchor="middle" font-size="11" fill="#6b21a8">losers got stuck on Y"</text>
+  <!-- Skip note -->
+  <rect x="240" y="220" width="180" height="36" rx="6" fill="#fef2f2" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="330" y="244" text-anchor="middle" font-size="11" fill="#991b1b" font-style="italic">skip group if all win or all fail</text>
+  <!-- Buffer update -->
+  <line x1="570" y1="200" x2="570" y2="290" stroke="#64748b" stroke-width="1.5" marker-end="url(#method-arrow)"/>
+  <rect x="430" y="290" width="280" height="100" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="570" y="316" text-anchor="middle" font-weight="700" fill="#166534">Update buffer E</text>
+  <text x="450" y="340" font-size="11" fill="#166534">• Add — new lesson</text>
+  <text x="450" y="356" font-size="11" fill="#166534">• Delete — drop a stale lesson</text>
+  <text x="450" y="372" font-size="11" fill="#166534">• Modify — refine wording</text>
+  <text x="450" y="388" font-size="11" fill="#166534">• Keep — no change</text>
+  <!-- Loop arrow back -->
+  <path d="M 430 340 Q 280 340 200 240 Q 100 230 100 180" stroke="#22c55e" stroke-width="2" fill="none" stroke-dasharray="6,4" marker-end="url(#method-arrow)"/>
+  <text x="160" y="280" font-size="11" fill="#166534" font-style="italic">next batch reads</text>
+  <text x="160" y="296" font-size="11" fill="#166534" font-style="italic">updated E</text>
+  <text x="360" y="430" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Same LLM plays three roles: policy (rollouts), judge (A_text), and optimizer (buffer ops).</text>
+</svg>
+
+### Try It Yourself
+
+Group size G is the parameter that gives Training-Free GRPO its name. The whole point of "group relative" is that comparing rollouts against each other generates a useful contrast — a judgment of why one path worked and another did not. With G = 1 there is nothing to compare to (and the paper's ablation confirms this collapses the gain). The interesting question is how large G needs to be before the contrast saturates. Click through to feel it:
+
+<style>
+  .ptb-step-grpo { border: 1px solid #e2e8f0; border-radius: 10px; padding: 16px 20px; margin: 16px 0; background: #f8fafc; }
+  .ptb-step-grpo .ptb-label-grpo { display: block; font-size: 13px; color: #475569; margin-bottom: 8px; font-weight: 600; }
+  .ptb-step-grpo .ptb-buttons-grpo { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+  .ptb-step-grpo input[type="radio"] { display: none; }
+  .ptb-step-grpo .ptb-btn-grpo {
+    padding: 6px 14px; border: 1px solid #cbd5e1; border-radius: 6px;
+    cursor: pointer; font-size: 13px; font-weight: 600; color: #475569;
+    background: #ffffff; user-select: none;
+  }
+  .ptb-step-grpo .ptb-btn-grpo:hover { border-color: #3b82f6; color: #1e40af; }
+  .ptb-step-grpo .ptb-state-grpo { display: none; }
+
+  .ptb-step-grpo input#g-1:checked ~ .ptb-buttons-grpo label[for="g-1"],
+  .ptb-step-grpo input#g-2:checked ~ .ptb-buttons-grpo label[for="g-2"],
+  .ptb-step-grpo input#g-5:checked ~ .ptb-buttons-grpo label[for="g-5"],
+  .ptb-step-grpo input#g-8:checked ~ .ptb-buttons-grpo label[for="g-8"] {
+    background: #eff6ff; border-color: #3b82f6; color: #1e40af;
+  }
+  .ptb-step-grpo input#g-1:checked ~ #g-s1,
+  .ptb-step-grpo input#g-2:checked ~ #g-s2,
+  .ptb-step-grpo input#g-5:checked ~ #g-s5,
+  .ptb-step-grpo input#g-8:checked ~ #g-s8 { display: block; }
+</style>
+
+<div class="ptb-step-grpo">
+  <span class="ptb-label-grpo">Group size G — how many rollouts per query before extracting a lesson:</span>
+
+  <input type="radio" name="grpo-g" id="g-1">
+  <input type="radio" name="grpo-g" id="g-2">
+  <input type="radio" name="grpo-g" id="g-5" checked>
+  <input type="radio" name="grpo-g" id="g-8">
+
+  <div class="ptb-buttons-grpo">
+    <label for="g-1" class="ptb-btn-grpo">G = 1</label>
+    <label for="g-2" class="ptb-btn-grpo">G = 2</label>
+    <label for="g-5" class="ptb-btn-grpo">G = 5 (paper)</label>
+    <label for="g-8" class="ptb-btn-grpo">G = 8</label>
+  </div>
+
+  <div class="ptb-state-grpo" id="g-s1">
+    <svg viewBox="0 0 600 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="g-s1-title">
+      <title id="g-s1-title">G=1: one rollout, no contrast available</title>
+      <text x="300" y="22" text-anchor="middle" font-size="13" font-weight="700" fill="#991b1b">G = 1 — no group, no contrast</text>
+      <rect x="220" y="50" width="160" height="50" rx="8" fill="#f1f5f9" stroke="#94a3b8"/>
+      <text x="300" y="74" text-anchor="middle" font-weight="600" fill="#334155">Rollout 1</text>
+      <text x="300" y="92" text-anchor="middle" font-size="11" fill="#64748b">no peer to compare</text>
+      <rect x="160" y="130" width="280" height="50" rx="8" fill="#fef2f2" stroke="#ef4444"/>
+      <text x="300" y="154" text-anchor="middle" font-weight="700" fill="#991b1b">No semantic advantage</text>
+      <text x="300" y="172" text-anchor="middle" font-size="11" fill="#991b1b">Ablation: gains collapse vs G = 5</text>
+      <text x="300" y="206" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Self-reflection on a single trajectory loses the relative signal.</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state-grpo" id="g-s2">
+    <svg viewBox="0 0 600 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="g-s2-title">
+      <title id="g-s2-title">G=2: minimal contrast, often degenerate</title>
+      <text x="300" y="22" text-anchor="middle" font-size="13" font-weight="700" fill="#854d0e">G = 2 — minimal but fragile</text>
+      <rect x="100" y="50" width="160" height="50" rx="8" fill="#f0fdf4" stroke="#22c55e"/>
+      <text x="180" y="74" text-anchor="middle" font-weight="600" fill="#166534">Rollout 1 (correct)</text>
+      <rect x="340" y="50" width="160" height="50" rx="8" fill="#fef2f2" stroke="#ef4444"/>
+      <text x="420" y="74" text-anchor="middle" font-weight="600" fill="#991b1b">Rollout 2 (wrong)</text>
+      <rect x="160" y="130" width="280" height="50" rx="8" fill="#fefce8" stroke="#eab308"/>
+      <text x="300" y="154" text-anchor="middle" font-weight="700" fill="#854d0e">Thin signal</text>
+      <text x="300" y="172" text-anchor="middle" font-size="11" fill="#854d0e">often both right or both wrong → skip</text>
+      <text x="300" y="206" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Many groups have std(r) = 0 and yield no lesson.</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state-grpo" id="g-s5">
+    <svg viewBox="0 0 600 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="g-s5-title">
+      <title id="g-s5-title">G=5: enough contrast for a stable lesson</title>
+      <text x="300" y="22" text-anchor="middle" font-size="13" font-weight="700" fill="#166534">G = 5 — paper's setting (math)</text>
+      <rect x="40"  y="50" width="100" height="40" rx="6" fill="#f0fdf4" stroke="#22c55e"/>
+      <text x="90"  y="75" text-anchor="middle" font-size="11" fill="#166534">correct</text>
+      <rect x="160" y="50" width="100" height="40" rx="6" fill="#f0fdf4" stroke="#22c55e"/>
+      <text x="210" y="75" text-anchor="middle" font-size="11" fill="#166534">correct</text>
+      <rect x="280" y="50" width="100" height="40" rx="6" fill="#fef2f2" stroke="#ef4444"/>
+      <text x="330" y="75" text-anchor="middle" font-size="11" fill="#991b1b">wrong</text>
+      <rect x="400" y="50" width="100" height="40" rx="6" fill="#fef2f2" stroke="#ef4444"/>
+      <text x="450" y="75" text-anchor="middle" font-size="11" fill="#991b1b">wrong</text>
+      <rect x="520" y="50" width="60"  height="40" rx="6" fill="#fef2f2" stroke="#ef4444"/>
+      <text x="550" y="75" text-anchor="middle" font-size="11" fill="#991b1b">wrong</text>
+      <rect x="100" y="130" width="400" height="50" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+      <text x="300" y="154" text-anchor="middle" font-weight="700" fill="#166534">Rich contrast</text>
+      <text x="300" y="172" text-anchor="middle" font-size="11" fill="#166534">winners and losers in most groups → most groups produce a lesson</text>
+      <text x="300" y="206" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Paper used G = 5 for math, G = 3 for web search.</text>
+    </svg>
+  </div>
+
+  <div class="ptb-state-grpo" id="g-s8">
+    <svg viewBox="0 0 600 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="g-s8-title">
+      <title id="g-s8-title">G=8: more contrast, but cost grows linearly</title>
+      <text x="300" y="22" text-anchor="middle" font-size="13" font-weight="700" fill="#1e40af">G = 8 — diminishing returns, higher cost</text>
+      <g>
+        <rect x="20"  y="50" width="60" height="40" rx="6" fill="#f0fdf4" stroke="#22c55e"/>
+        <rect x="90"  y="50" width="60" height="40" rx="6" fill="#f0fdf4" stroke="#22c55e"/>
+        <rect x="160" y="50" width="60" height="40" rx="6" fill="#f0fdf4" stroke="#22c55e"/>
+        <rect x="230" y="50" width="60" height="40" rx="6" fill="#fef2f2" stroke="#ef4444"/>
+        <rect x="300" y="50" width="60" height="40" rx="6" fill="#fef2f2" stroke="#ef4444"/>
+        <rect x="370" y="50" width="60" height="40" rx="6" fill="#fef2f2" stroke="#ef4444"/>
+        <rect x="440" y="50" width="60" height="40" rx="6" fill="#fef2f2" stroke="#ef4444"/>
+        <rect x="510" y="50" width="60" height="40" rx="6" fill="#fef2f2" stroke="#ef4444"/>
+      </g>
+      <rect x="80" y="130" width="440" height="50" rx="8" fill="#eff6ff" stroke="#3b82f6"/>
+      <text x="300" y="154" text-anchor="middle" font-weight="700" fill="#1e40af">Saturating contrast</text>
+      <text x="300" y="172" text-anchor="middle" font-size="11" fill="#1e40af">marginal extra signal · linear extra API cost</text>
+      <text x="300" y="206" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Paper does not directly ablate G beyond 5; budget caps the natural choice.</text>
+    </svg>
+  </div>
+</div>
+
+### Implementation
+
+A minimal sketch of the inner loop. This is a faithful translation of the paper's pseudocode in §2 — same structure, abbreviated for readability. It does not run as-is (it expects a stub `LLM` interface and a reward function), but the shapes and step structure are correct.
+
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class TrainingFreeGRPO:
+    """One epoch of Training-Free GRPO over a small training set.
+
+    Faithful sketch of Algorithm in Youtu-Agent (2025), §2. The same
+    LLM is reused as policy (rollouts), judge (semantic advantage),
+    and optimizer (buffer ops). No gradient is computed anywhere.
+
+    The buffer E starts empty and grows into a few-dozen-line block
+    of natural-language lessons that the next epoch's rollouts read.
+    """
+    llm: "LLM"                              # frontier API client
+    reward_fn: callable                     # scores one trajectory
+    group_size: int = 5                     # paper used G=5 (math), G=3 (web)
+    experience: list[str] = field(default_factory=list)
+
+    def step(self, query: str, ground_truth: str) -> None:
+        # 1. Roll out G trajectories conditioned on the current buffer.
+        prompt = f"{self._render_buffer()}\n\nQuestion: {query}"
+        rollouts = [self.llm.complete(prompt) for _ in range(self.group_size)]
+
+        # 2. Score each rollout. In math, this is exact-match on the boxed
+        #    answer; in web search, the agent's answer is graded vs gt.
+        rewards = [self.reward_fn(r, ground_truth) for r in rollouts]
+
+        # 3. Skip groups with no contrast — same as Â_i = 0 when std(r) = 0.
+        if min(rewards) == max(rewards):
+            return
+
+        # 4. Semantic advantage: have the LLM compare winners and losers,
+        #    extract one lesson in plain text. This is A_text in the paper.
+        a_text = self.llm.judge(
+            query=query,
+            rollouts=rollouts,
+            rewards=rewards,
+            ground_truth=ground_truth,
+            existing_buffer=self._render_buffer(),
+        )
+
+        # 5. Buffer update: ask the LLM to emit Add / Delete / Modify / Keep
+        #    operations on the current buffer given the new advantage.
+        ops = self.llm.optimize_buffer(
+            buffer=self.experience,
+            new_advantage=a_text,
+        )
+        self._apply(ops)
+
+    def _render_buffer(self) -> str:
+        if not self.experience:
+            return ""
+        lines = "\n".join(f"[{i+1}] {e}" for i, e in enumerate(self.experience))
+        return f"Useful experiences from prior problems:\n{lines}"
+
+    def _apply(self, ops: list[dict]) -> None:
+        # ops example: [{"type": "add", "text": "Verify rectangle..."}, ...]
+        for op in ops:
+            match op["type"]:
+                case "add":    self.experience.append(op["text"])
+                case "delete": self.experience.pop(op["index"])
+                case "modify": self.experience[op["index"]] = op["text"]
+                case "keep":   pass
+```
+
+### Key Takeaways
+
+- **The structure is GRPO; only the update rule changes.** Group rollouts, group-relative comparison, multi-epoch refinement — all preserved. Gradient ascent on θ becomes natural-language ops on E.
+- **Skipping the no-contrast groups is critical.** When all G rollouts get the same reward there is no signal — the algorithm declines to fabricate a lesson, mirroring vanilla GRPO's std(r) = 0 case.
+- **The base model serves as the KL anchor.** Because π_θ never moves, the buffer can only steer its prompts within the model's coherent behavior space; unlike weight-tuning, this method cannot "break" the model.
+- **One LLM, three hats.** Same model is policy, judge, and optimizer. The savings come from not having to host a separate reward model or critic.
+
+---
+
+## Mathematical Reasoning Results
+
+### Overview
+
+A quick orientation for the unfamiliar reader: AIME (American Invitational Mathematics Examination) is a 15-question competition for high school students; the AIME24 and AIME25 sets used here are the official problem batches from those years. They are short-answer integer problems requiring multi-step proof-style reasoning. **Mean@32** is the average accuracy across 32 independent runs of the same problem — useful because LLMs at non-zero temperature give different answers across runs, and a single-shot Pass@1 is noisy.
+
+The setup: train on **DAPO-100**, a random sample of 100 problems from the DAPO-Math-17K dataset. 3 epochs, single batch per epoch (so 3 optimization steps total), G = 5, temperature 0.7 during training, 0.3 at evaluation. The base model is **DeepSeek-V3.1-Terminus** (671B total parameters, MoE; called via API), evaluated in two configurations — *Direct* (prompt-only, no tools) and *ReAct* (with a Python code interpreter as a tool).
+
+The headline numbers (Mean@32):
+
+| Configuration | AIME24 | AIME25 |
+| --- | --- | --- |
+| Direct | 68.6% | 52.9% |
+| Direct + Training-Free GRPO | 72.6% (+4.0) | 54.0% (+1.1) |
+| ReAct | 80.0% | 67.9% |
+| ReAct + Training-Free GRPO | **82.7% (+2.7)** | **73.3% (+5.4)** |
+
+Three things to register. First, the gains transfer to a different base — DeepSeek-V3.2-Exp also improves (+2.1, +1.4 on the same benchmarks). Second, the gains transfer to *smaller* bases too, suggesting the method isn't purely a frontier-model phenomenon: Qwen3-32B Non-Thinking gets +4.4 / +5.9, Qwen2.5-72B-Instruct gets +1.4 / +1.8. Third, and this is the loudest finding, the absolute number 82.7% on AIME24 *beats* fully fine-tuned 32B models like ReTool (67.0%) and AFM (66.7%) that cost ~$10K to train — and it does so with $18 of API spend.
+
+The ablations make the case that the optimization machinery is what matters, not just having a longer prompt. The most pointed one: prepending experiences *directly generated* by DeepSeek-V3.1-Terminus (the paper asks the model to produce a list of useful experiences, matched in quantity to what Training-Free GRPO learned) gives **79.8%** — basically identical to the 80.0% baseline. The same model, the same kind of content, but produced without the rollout-then-distill loop, gives no gain. It is the iterative comparison against ground truth that earns the +2.7. A second ablation removes ground truth entirely (the LLM has to compare rollouts against each other only, leveraging implicit majority voting / self-consistency) and recovers most but not all of the gain — 80.7% / 68.9%, still meaningfully above baseline. A third sets G = 1, eliminating the group, and gains collapse — confirming the relative comparison is load-bearing, not just the buffer mechanism.
+
+A subtler observation from Figure 4 of the paper: across the 3 learning steps, the **average number of tool calls per problem decreases** even though accuracy rises. The buffer doesn't just teach the agent which moves are correct — it teaches it which tool calls are wasted. That dual effect (more correct, more efficient) is consistent with what an experienced practitioner internalizes after solving many problems.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="math-diag-title">
+  <title id="math-diag-title">AIME accuracy and learning cost: Training-Free GRPO vs fine-tuned 32B models</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">AIME24 Mean@32 vs learning cost</text>
+  <text x="360" y="42" text-anchor="middle" font-size="11" fill="#64748b">Higher and further left is better</text>
+  <!-- Header -->
+  <text x="240" y="72" text-anchor="end" font-size="11" fill="#64748b" font-weight="600">Method</text>
+  <text x="680" y="72" text-anchor="end" font-size="11" fill="#64748b" font-weight="600">AIME24 (%)</text>
+  <!-- Bar 1: TF-GRPO winner -->
+  <text x="240" y="102" text-anchor="end" fill="#334155" font-size="12">TF-GRPO + DeepSeek-V3.1-T (671B, frozen)</text>
+  <rect x="250" y="90" width="386" height="22" rx="4" fill="#22c55e" opacity="0.8"/>
+  <text x="644" y="106" font-size="11" fill="#166534" font-weight="700">82.7 · ~$18 ✓</text>
+  <!-- Bar 2: ReAct baseline same model -->
+  <text x="240" y="134" text-anchor="end" fill="#334155" font-size="12">ReAct + DeepSeek-V3.1-T (no learning)</text>
+  <rect x="250" y="122" width="373" height="22" rx="4" fill="#3b82f6" opacity="0.6"/>
+  <text x="630" y="138" font-size="11" fill="#1e40af">80.0 · $0</text>
+  <!-- Bar 3: ReTool 32B -->
+  <text x="240" y="166" text-anchor="end" fill="#334155" font-size="12">ReTool — fine-tuned Qwen2.5-32B</text>
+  <rect x="250" y="154" width="313" height="22" rx="4" fill="#94a3b8" opacity="0.55"/>
+  <text x="570" y="170" font-size="11" fill="#64748b">67.0 · ~$10K</text>
+  <!-- Bar 4: AFM 32B -->
+  <text x="240" y="198" text-anchor="end" fill="#334155" font-size="12">AFM — fine-tuned Qwen2.5-32B</text>
+  <rect x="250" y="186" width="311" height="22" rx="4" fill="#94a3b8" opacity="0.55"/>
+  <text x="570" y="202" font-size="11" fill="#64748b">66.7 · ~$10K</text>
+  <!-- Bar 5: SimpleTIR 32B -->
+  <text x="240" y="230" text-anchor="end" fill="#334155" font-size="12">SimpleTIR — fine-tuned Qwen2.5-32B</text>
+  <rect x="250" y="218" width="280" height="22" rx="4" fill="#94a3b8" opacity="0.4"/>
+  <text x="540" y="234" font-size="11" fill="#64748b">59.9 · ~$20K</text>
+  <!-- Bar 6: ZeroTIR -->
+  <text x="240" y="262" text-anchor="end" fill="#334155" font-size="12">ZeroTIR — fine-tuned Qwen2.5-32B</text>
+  <rect x="250" y="250" width="265" height="22" rx="4" fill="#ef4444" opacity="0.4"/>
+  <text x="525" y="266" font-size="11" fill="#dc2626">56.7 · ~$20K</text>
+  <!-- Caption -->
+  <rect x="60" y="290" width="600" height="46" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="360" y="312" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">A frozen 671B model + a $18 prompt buffer beats every fine-tuned 32B model in this slate.</text>
+  <text x="360" y="328" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Source: Tables 1 and 3 of the paper.</text>
+</svg>
+
+### Key Takeaways
+
+- **+2.7 on AIME24, +5.4 on AIME25 with ReAct** — 100 training examples, 3 epochs, no gradient updates, ~$18 in API spend.
+- **The frozen 671B beats fine-tuned 32Bs.** The headline 82.7% on AIME24 is higher than ReTool, AFM, SimpleTIR, ZeroTIR — every fine-tuned 32B in the paper's slate.
+- **Direct experience-prompting is not enough.** Pasting in directly-generated tips (matched in quantity) gives 79.8% — essentially the baseline. The optimization loop is what creates the +2.7.
+- **The agent learns to call fewer tools.** Average tool calls per problem decrease over the 3 training steps even as accuracy rises — the buffer teaches efficiency too.
+- **G = 1 collapses the gain.** Removing the group breaks the method, confirming that *relative* comparison among rollouts is the load-bearing component.
+
+---
+
+## Web Searching Results
+
+### Overview
+
+Before the numbers: **WebWalkerQA** [arXiv:2501.07572] is a benchmark that gives an agent a real web environment plus a natural-language question whose answer requires navigating, clicking, reading, and synthesizing across multiple pages. The reward is whether the final answer matches ground truth. Pass@1 is single-trajectory accuracy; pass@3 is success-among-three-attempts. **AFM-100** is 100 queries randomly sampled from the AFM (Chain-of-Agents) web-RL training corpus.
+
+Same recipe, different domain. 3 epochs, group size G = 3 (smaller than math because web rollouts are more expensive), DeepSeek-V3.1-Terminus, ReAct loop with web tools.
+
+| Configuration | pass@1 | pass@3 |
+| --- | --- | --- |
+| ReAct (baseline) | 63.2% (full set) / 66.7% (51-instance subset) | 74.5% (subset) |
+| + Directly generated experiences | — / 64.7% | 76.5% |
+| + TF-GRPO (no ground truth) | — / 66.7% | 78.4% |
+| + TF-GRPO (full) | **67.8% (full) / 68.6% (subset)** | **78.4% (subset)** |
+
+The +4.6 pass@1 on the full WebWalkerQA set (63.2% → 67.8%) confirms the method generalizes beyond math. The same shape of ablation holds: directly-generated experiences fail (64.7%, slightly *below* baseline), confirming that the optimization is not just "longer prompt = better". And the no-ground-truth variant matches baseline pass@1 but lifts pass@3 to 78.4%, suggesting that even without explicit verification, the LLM-on-LLM relative comparison improves the *consistency* of the agent across attempts.
+
+The buffer the method learns for web search reads like the inside of a research analyst's head. Examples from the paper's Appendix A.2: *"Prioritize systematic extraction from authoritative comprehensive documents over fragmented information for coherent topic coverage"* (Source prioritization), *"Continuously refine search terms based on emerging patterns while periodically re-evaluating previously encountered information"* (Iterative refinement), *"Focus on extracting formal titles and collection names from official metadata and headers rather than inferring relationships from content descriptions"* (Document identification). These are tactical, transferable, and not the kind of thing you would write down a priori — they emerge from comparing successful and failed rollouts on actual queries.
+
+The discordant note: **applying TF-GRPO to QwQ-32B drops pass@1 from 27.5% to 25.5%** — the ablated 32B model regresses below its own ReAct baseline. The authors attribute this to the underlying capability ceiling: the buffer adds advice the model still cannot follow because its reasoning and tool-use foundations are too weak. Pass@3 on QwQ-32B does improve (43.1% → 45.1%), so the method is not pure noise on the smaller model — but the pass@1 regression is a real failure mode and worth taking seriously when planning to apply this to a smaller-base agent.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="web-diag-title">
+  <title id="web-diag-title">WebWalkerQA pass@1 by configuration on the 51-instance subset</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">WebWalkerQA — what the buffer adds vs the prompt alone</text>
+  <text x="360" y="42" text-anchor="middle" font-size="11" fill="#64748b">Stratified 51-instance subset, 2 epochs, DeepSeek-V3.1-Terminus, pass@1 (%)</text>
+  <!-- Header -->
+  <text x="320" y="74" text-anchor="end" font-size="11" fill="#64748b" font-weight="600">Configuration</text>
+  <text x="660" y="74" text-anchor="end" font-size="11" fill="#64748b" font-weight="600">pass@1</text>
+  <!-- TF-GRPO full -->
+  <text x="320" y="104" text-anchor="end" fill="#334155" font-size="12">TF-GRPO (full, with ground truth)</text>
+  <rect x="330" y="92" width="290" height="22" rx="4" fill="#22c55e" opacity="0.8"/>
+  <text x="630" y="108" font-size="11" fill="#166534" font-weight="700">68.6 ✓</text>
+  <!-- TF-GRPO no GT -->
+  <text x="320" y="136" text-anchor="end" fill="#334155" font-size="12">TF-GRPO (without ground truth)</text>
+  <rect x="330" y="124" width="282" height="22" rx="4" fill="#3b82f6" opacity="0.65"/>
+  <text x="622" y="140" font-size="11" fill="#1e40af">66.7</text>
+  <!-- ReAct baseline -->
+  <text x="320" y="168" text-anchor="end" fill="#334155" font-size="12">ReAct (no buffer)</text>
+  <rect x="330" y="156" width="282" height="22" rx="4" fill="#94a3b8" opacity="0.55"/>
+  <text x="622" y="172" font-size="11" fill="#64748b">66.7</text>
+  <!-- Direct experiences -->
+  <text x="320" y="200" text-anchor="end" fill="#334155" font-size="12">Directly-generated experiences</text>
+  <rect x="330" y="188" width="274" height="22" rx="4" fill="#ef4444" opacity="0.5"/>
+  <text x="614" y="204" font-size="11" fill="#dc2626">64.7 ✗</text>
+  <!-- QwQ regression -->
+  <text x="320" y="232" text-anchor="end" fill="#334155" font-size="12">TF-GRPO on QwQ-32B (weaker base)</text>
+  <rect x="330" y="220" width="108" height="22" rx="4" fill="#ef4444" opacity="0.6"/>
+  <text x="448" y="236" font-size="11" fill="#dc2626" font-weight="600">25.5 (regresses)</text>
+  <!-- Caption -->
+  <rect x="60" y="262" width="600" height="46" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="360" y="284" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Direct prompt-injection of tips slightly hurts. The optimization-derived buffer wins by ~2 points.</text>
+  <text x="360" y="300" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">On a weaker base (QwQ-32B) the same recipe regresses below baseline.</text>
+</svg>
+
+### Key Takeaways
+
+- **+4.6 pass@1 on WebWalkerQA** (63.2% → 67.8%) on the full benchmark — same recipe as math, different buffer.
+- **Directly-injected tips slightly hurt.** 64.7% vs 66.7% baseline on the subset confirms the optimization-distilled buffer is qualitatively different from a hand-written tips list.
+- **The buffer captures real research craft.** "Prioritize primary sources", "extract exact official quotes", "iterate from broad to targeted queries" — tactical knowledge that emerges from comparing trajectories.
+- **No-ground-truth variant lifts pass@3.** Even without verification, the relative comparison between rollouts pushes consistency up (74.5% → 78.4% pass@3).
+- **Weaker base = regression risk.** QwQ-32B drops 27.5% → 25.5% pass@1; the method amplifies a capable agent and hurts an incapable one.
+
+---
+
+## Context Space vs Parameter Space
+
+### Overview
+
+The most damaging comparison in the paper is the cross-domain transfer table. Take ReTool, fine-tuned via PPO on math; it scores 67.0% on AIME24 (good, in-domain) and **18.3% on WebWalker** (worse than the un-tuned ReAct baseline of 31.9% on the same model). Take MiroThinker, fine-tuned for web research; it scores 53.6% on WebWalker but only 43.5% on AIME24. Each fine-tuned specialist trades cross-domain capability for in-domain gains.
+
+Training-Free GRPO does not have this trade-off because the model never changes — only the buffer does. The authors maintain *two* buffers, one for math, one for web search, and plug whichever is appropriate into the prompt. The frozen DeepSeek-V3.1-Terminus then scores 82.7% on AIME24 *and* 67.8% on WebWalker — best in both columns simultaneously. A weight-tuned model is one specialist; a frozen-base + buffer system is N specialists for the cost of N text files.
+
+The compute cost story is even more lopsided. ReTool's reported training cost is roughly **20K GPU-hours × $0.50 = ~$10K**, plus a dedicated 32B model deployment. Training-Free GRPO with DeepSeek-V3.1-Terminus takes **6 hours** to run 3 steps on 100 samples, consuming **38M input tokens + 6.6M output tokens ≈ $18** at DeepSeek's pricing (most input qualifies for cache-hit pricing because the prompt prefix is reused across rollouts). That is a three-orders-of-magnitude reduction in training cost.
+
+Inference cost is the one place fine-tuning has an edge — but only conditionally. ReTool-32B running on a 4×GPU vLLM server at $0.50/GPU-hour processes ~400 problems/hour, costing about **$0.005 per problem** *if you can keep the GPUs saturated*. Training-Free GRPO via API is **~$0.02 per problem** (60K input + 8K output tokens at cache-hit pricing). Per-call, the API is 4× more expensive. But the API has zero fixed serving cost: you pay $0 when there is no traffic. Most enterprise agentic deployments have spiky, low-volume traffic — the kind where a dedicated GPU sits idle most of the day. The break-even is roughly: if you would have utilized a 4-GPU cluster less than ~25% of the time, the API model is cheaper *in total*.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="cmp-diag-title">
+  <title id="cmp-diag-title">Cross-domain capability of fine-tuned specialists vs Training-Free GRPO</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Cross-domain transfer (Pass@1, %)</text>
+  <text x="360" y="42" text-anchor="middle" font-size="11" fill="#64748b">Each method's score in its trained domain (in-domain) vs the other domain (off-domain)</text>
+  <!-- Header -->
+  <text x="220" y="76" text-anchor="end" font-size="11" fill="#64748b" font-weight="600">Method (trained on)</text>
+  <text x="380" y="76" text-anchor="middle" font-size="11" fill="#64748b" font-weight="600">AIME24</text>
+  <text x="540" y="76" text-anchor="middle" font-size="11" fill="#64748b" font-weight="600">WebWalker</text>
+  <!-- ReTool (Math) -->
+  <text x="220" y="106" text-anchor="end" fill="#334155" font-size="12">ReTool — Math specialist</text>
+  <rect x="320" y="94" width="120" height="22" rx="4" fill="#22c55e" opacity="0.7"/>
+  <text x="385" y="110" text-anchor="middle" font-size="11" fill="#166534" font-weight="700">67.0</text>
+  <rect x="480" y="94" width="33"  height="22" rx="4" fill="#ef4444" opacity="0.55"/>
+  <text x="545" y="110" text-anchor="middle" font-size="11" fill="#dc2626" font-weight="600">18.3 ✗</text>
+  <!-- MiroThinker (Web) -->
+  <text x="220" y="138" text-anchor="end" fill="#334155" font-size="12">MiroThinker — Web specialist</text>
+  <rect x="320" y="126" width="78"  height="22" rx="4" fill="#eab308" opacity="0.55"/>
+  <text x="385" y="142" text-anchor="middle" font-size="11" fill="#854d0e">43.5 ◐</text>
+  <rect x="480" y="126" width="96"  height="22" rx="4" fill="#22c55e" opacity="0.65"/>
+  <text x="545" y="142" text-anchor="middle" font-size="11" fill="#166534" font-weight="700">53.6</text>
+  <!-- ReAct base 32B for context -->
+  <text x="220" y="170" text-anchor="end" fill="#334155" font-size="12">ReAct (Qwen2.5-32B, no train)</text>
+  <rect x="320" y="158" width="53"  height="22" rx="4" fill="#94a3b8" opacity="0.5"/>
+  <text x="385" y="174" text-anchor="middle" font-size="11" fill="#64748b">29.6</text>
+  <rect x="480" y="158" width="57"  height="22" rx="4" fill="#94a3b8" opacity="0.5"/>
+  <text x="545" y="174" text-anchor="middle" font-size="11" fill="#64748b">31.9</text>
+  <!-- TF-GRPO -->
+  <text x="220" y="202" text-anchor="end" fill="#334155" font-size="12">TF-GRPO + DeepSeek-V3.1-T (Math + Web)</text>
+  <rect x="320" y="190" width="149" height="22" rx="4" fill="#22c55e" opacity="0.85"/>
+  <text x="385" y="206" text-anchor="middle" font-size="11" fill="#166534" font-weight="700">82.7 ✓</text>
+  <rect x="480" y="190" width="121" height="22" rx="4" fill="#22c55e" opacity="0.85"/>
+  <text x="545" y="206" text-anchor="middle" font-size="11" fill="#166534" font-weight="700">67.8 ✓</text>
+  <!-- Caption -->
+  <rect x="60" y="240" width="600" height="100" rx="6" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="360" y="262" text-anchor="middle" font-size="12" fill="#1e293b" font-weight="600">Domain specialization is a trade — context-space optimization avoids it.</text>
+  <text x="80" y="284" font-size="11" fill="#475569">• ReTool (math) collapses to 18.3% on web — worse than the un-tuned base (31.9%).</text>
+  <text x="80" y="302" font-size="11" fill="#475569">• MiroThinker (web) loses ~10 points on AIME relative to a math-trained 32B.</text>
+  <text x="80" y="320" font-size="11" fill="#475569">• TF-GRPO is best in both columns by swapping the buffer, not the model.</text>
+</svg>
+
+### Key Takeaways
+
+- **Specialization is a trade in parameter space.** Fine-tuned math models lose at web (ReTool: 67.0 → 18.3); fine-tuned web models lose at math.
+- **Specialization is free in context space.** Two buffers, one frozen model — best-in-class on both AIME and WebWalker simultaneously.
+- **Three orders of magnitude cheaper to train.** ~$18 vs ~$10K. 6 hours and 100 samples vs 20K GPU-hours and thousands of samples.
+- **Inference economics flip on traffic shape.** Per-call API cost is ~4× higher; total cost is *lower* for any deployment with under-25% utilization.
+- **No specialist deployments.** A dedicated GPU cluster per fine-tuned model becomes one shared API endpoint plus a folder of buffer files.
+
+---
+
+## Related Work in One Page
+
+### Overview
+
+The paper's place in the landscape is worth pinning down. Three lines converge here.
+
+**Line 1 — agentic RL.** Started with ReAct (interleave reasoning and acting), formalized by GRPO and its derivatives (DAPO, GSPO, GiGPO), instantiated for tool use by ReTool, AFM, Tongyi DeepResearch, and similar systems. All of these update model weights.
+
+**Line 2 — training-free / in-context methods.** GPT-3 demonstrated few-shot in-context learning. **Self-Refine** has a model critique its own output and revise within a single trajectory. **Reflexion** layers a verbal critic on top of an agent loop. **TextGrad** generalizes this to "back-propagation through text", treating LLM calls as differentiable nodes whose gradients are natural-language critiques. **In-context RL** (Song et al. 2025; Monea et al. 2024) explicitly feeds reward signals into the prompt across attempts. The common thread: optimization happens *within* a single query's lifetime.
+
+**Line 3 — shared-experience agents.** **Agent KB** maintains a hierarchical knowledge base across tasks but uses a complex retrieve-refine pipeline and collects training trajectories off-policy.
+
+Training-Free GRPO sits at the intersection. From Line 1 it inherits the multi-epoch on-policy structure and the explicit group-relative comparison. From Line 2 it inherits the "no gradients" stance. From Line 3 it inherits the shared, persistent buffer. What is new is the combination: an on-policy multi-epoch RL loop whose update is buffer-edit operations on a single shared text artifact. Self-Refine and Reflexion give per-query corrections; TextGrad gives per-call gradients; Agent KB gives a static knowledge base. None of them have all three pieces — multi-epoch, group-relative, single shared buffer — at once.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="rel-diag-title">
+  <title id="rel-diag-title">Three lines of related work converging at Training-Free GRPO</title>
+  <defs>
+    <marker id="rel-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Where Training-Free GRPO sits in the landscape</text>
+  <!-- Line 1: agentic RL -->
+  <rect x="40" y="60" width="180" height="80" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="130" y="84" text-anchor="middle" font-weight="700" fill="#991b1b">Agentic RL</text>
+  <text x="130" y="104" text-anchor="middle" font-size="11" fill="#475569">GRPO, ReTool, AFM</text>
+  <text x="130" y="120" text-anchor="middle" font-size="11" fill="#64748b">multi-epoch · groups</text>
+  <text x="130" y="134" text-anchor="middle" font-size="11" fill="#991b1b" font-style="italic">updates θ</text>
+  <!-- Line 2: training-free -->
+  <rect x="270" y="60" width="180" height="80" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="360" y="84" text-anchor="middle" font-weight="700" fill="#1e40af">Training-Free</text>
+  <text x="360" y="104" text-anchor="middle" font-size="11" fill="#475569">Self-Refine, Reflexion</text>
+  <text x="360" y="120" text-anchor="middle" font-size="11" fill="#475569">ICRL, TextGrad</text>
+  <text x="360" y="134" text-anchor="middle" font-size="11" fill="#1e40af" font-style="italic">within-query refinement</text>
+  <!-- Line 3: shared-buffer -->
+  <rect x="500" y="60" width="180" height="80" rx="10" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text x="590" y="84" text-anchor="middle" font-weight="700" fill="#854d0e">Shared Experience</text>
+  <text x="590" y="104" text-anchor="middle" font-size="11" fill="#475569">Agent KB</text>
+  <text x="590" y="120" text-anchor="middle" font-size="11" fill="#64748b">cross-task buffer</text>
+  <text x="590" y="134" text-anchor="middle" font-size="11" fill="#854d0e" font-style="italic">off-policy collection</text>
+  <!-- Convergence -->
+  <line x1="130" y1="140" x2="320" y2="220" stroke="#64748b" stroke-width="1.5" marker-end="url(#rel-arrow)"/>
+  <line x1="360" y1="140" x2="360" y2="220" stroke="#64748b" stroke-width="1.5" marker-end="url(#rel-arrow)"/>
+  <line x1="590" y1="140" x2="400" y2="220" stroke="#64748b" stroke-width="1.5" marker-end="url(#rel-arrow)"/>
+  <rect x="220" y="230" width="280" height="80" rx="12" fill="#f0fdf4" stroke="#22c55e" stroke-width="2.5"/>
+  <text x="360" y="258" text-anchor="middle" font-weight="700" fill="#166534" font-size="14">Training-Free GRPO</text>
+  <text x="360" y="278" text-anchor="middle" font-size="11" fill="#166534">on-policy + multi-epoch + group-relative</text>
+  <text x="360" y="294" text-anchor="middle" font-size="11" fill="#166534">+ no gradients + single shared buffer</text>
+  <text x="360" y="350" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Inherits structure from Line 1, the no-gradient stance from Line 2, and the shared buffer from Line 3.</text>
+</svg>
+
+### Key Takeaways
+
+- **Most "training-free" methods optimize within one query.** Self-Refine, Reflexion, and TextGrad refine a single trajectory or a small chain; they do not learn across separate examples.
+- **Most "agentic RL" methods update weights.** GRPO and its descendants assume gradient ascent is the way the lesson is committed.
+- **Agent KB is the closest sibling but not the same shape.** It has a shared buffer, but its collection is off-policy and its retrieval pipeline is more complex; Training-Free GRPO is on-policy and uses the buffer directly in the prompt.
+- **The new piece is the combination.** Three separate ideas — group-relative comparison, on-policy multi-epoch loops, shared text buffer — combined into a single training-free RL paradigm.
+
+---
+
+## Conclusion
+
+### Overview
+
+The point of the paper, in one sentence: **the optimization that matters in modern agentic RL can be done in context space rather than parameter space, with most of the benefit and a small fraction of the cost**. The authors do not claim parameter updates are obsolete — they explicitly note their method depends on a strong base model and would not replace fine-tuning when the base is too weak to introspect on its own behavior. What they do show is that for the very real case of "I have access to a strong frontier API model and I need it to behave better in my domain", the GRPO recipe ports cleanly to a no-gradient setting. The fine-tune-or-prompt question, often answered with "fine-tune for serious work, prompt for prototypes", now has a third option that competes on serious work.
+
+If the technique generalizes — and the cross-domain transfer experiment is encouraging here — the operational implication is significant. Building a domain-specialized agent becomes a matter of curating ~100 ground-truth examples, paying $20 of API spend, and shipping a text file alongside the rest of your prompt template. Specialists multiply with low marginal cost. Updates to the base model carry the buffer forward without retraining. The agentic-RL pipeline, as it currently exists, is mostly compute and infrastructure overhead designed to enable parameter updates that, this paper argues, may not have been the most efficient way to encode the lesson.
+
+A fair criticism: the paper's evaluation is narrow. AIME math and WebWalkerQA are real benchmarks, but they are also benchmarks where verification is cleanly available (correct answer or not). For domains without easy verification — open-ended writing, scientific hypothesis generation — the no-ground-truth ablation suggests the method still works partially, but the gap between "with GT" and "without GT" widens. The technique is also not the unconditional win a casual reading might suggest: on QwQ-32B the same recipe hurts. There is a regime where this works; the paper has mapped a useful slice of it.
+
+### Key Takeaways (Summary)
+
+- **Training-Free GRPO ports the GRPO recipe to a frozen-model setting** by replacing gradient updates with edit operations on a natural-language experience buffer that gets prepended to subsequent prompts.
+- **The "advantage" becomes a paragraph.** Instead of Â_i = (r_i − μ) / σ, the model produces a natural-language explanation of why winners beat losers (the *semantic advantage*), and that paragraph is what updates the buffer.
+- **Headline result: 82.7% on AIME24 + 73.3% on AIME25 + 67.8% on WebWalkerQA** with a single frozen DeepSeek-V3.1-Terminus and two domain-specific buffers — beating fine-tuned 32B specialists in both math and web search.
+- **Cost: ~$18 and 100 samples vs ~$10K and thousands of samples** for standard agentic RL — three orders of magnitude cheaper, and no fixed serving infrastructure required.
+- **Cross-domain wins are essentially free** because the model never changes — swap the buffer to swap the specialty. Fine-tuned specialists collapse off-domain (ReTool: 67% on AIME → 18% on web).
+- **It depends on a strong base.** On QwQ-32B the same recipe regresses (-2.0 pass@1) — the buffer amplifies a capable agent, not an incapable one.
+- **Directly-injected tips do not work** (79.8% vs 80.0% baseline). The optimization loop, not the buffer-mechanism alone, is what produces the gain.
+- **Tools get used more efficiently too** — average tool calls per problem decreases over training even as accuracy rises.
+
+---
+
+*Code: [TencentCloudADP/youtu-agent — training_free_GRPO branch](https://github.com/TencentCloudADP/youtu-agent/tree/training_free_GRPO). Paper: [arXiv:2510.08191](https://arxiv.org/abs/2510.08191).*

--- a/assets/blogs/0024-dino-vits.md
+++ b/assets/blogs/0024-dino-vits.md
@@ -1,0 +1,616 @@
+@{id = "7d49b82f-5ce0-4215-8beb-fc569f9a468e"
+  title = "DINO-VITS: A Self-Supervised Sidecar for Noise-Robust Zero-Shot Voice Cloning"
+  date = "2026-05-06T00:00:00Z"
+  tags = ['journal club', 'machine learning', 'arxiv', 'speech synthesis', 'self-supervised learning']
+  views = 0
+  likes = 0
+  image = "https://storage.googleapis.com/gn-portfolio/images/dino-vits-thumb.svg"
+  description = "Pankov et al. attach a DINO self-supervised loss to the speaker encoder of a VITS-based zero-shot TTS system. Noise robustness improves; here is what survives an honest read."
+  type = "note"
+  disabled = "false"
+}
+
+<p align="center">
+  <img src="https://storage.googleapis.com/gn-portfolio/images/dino-vits-thumb.svg" max-width="700">
+</p>
+
+
+# DINO-VITS: A Self-Supervised Sidecar for Noise-Robust Zero-Shot Voice Cloning
+
+*Analysis of Pankov, Pronina, Kuzmin, Borisov, Usoltsev, Zeng, Golubkov, Ermolenko, Shirshova, Matveeva (Huawei + ITMO + HSE + SPbU), arXiv:2311.09770v3, June 2024*
+*Generated on May 6, 2026*
+
+---
+
+## Table of Contents
+
+- [Abstract](#abstract)
+- [Introduction](#introduction)
+- [Method: a Dual-Objective Speaker Encoder](#method-a-dual-objective-speaker-encoder)
+- [Results — Noisy Reference at Inference](#results-noisy-reference-at-inference)
+- [Results — Training from Noisy, Untranscribed Data](#results-training-from-noisy-untranscribed-data)
+- [Critical Read — What Survives an Honest Audit](#critical-read-what-survives-an-honest-audit)
+- [Key Takeaways (Summary)](#key-takeaways-summary)
+
+---
+
+## Abstract
+
+### Overview
+
+Zero-shot voice cloning is the task of synthesizing speech in a target speaker's voice from a *single* reference audio at inference time, without any finetuning. The dominant recipe through 2023 — and the one DINO-VITS lives inside — slots a pretrained **speaker encoder** (a small network that maps an audio clip to a fixed-dimensional embedding capturing "who is speaking") into a sequence-to-sequence speech synthesizer. The encoder produces an embedding from the reference audio; the synthesizer is conditioned on that embedding to read arbitrary text in that voice. *Speaker encoder* + *acoustic decoder* — both pretrained, glued together at training time, frozen at inference.
+
+The recipe has a load-bearing failure mode: the speaker encoder is usually trained for **speaker verification** (the binary task of "is this the same speaker?"), and verification training pushes embeddings of the same speaker into a tight cluster regardless of the speech's emotion, prosody, or acoustic environment. That invariance is exactly *wrong* for voice cloning, which wants to *transfer* style, not erase it. It is also brittle to noise — a noisy reference clip lands in a slightly different region of the embedding space than its clean counterpart, and the synthesizer faithfully reproduces the perturbed embedding as a degraded voice.
+
+Pankov et al. attack both problems with one move: they keep the verification-pretrained CAM++ speaker encoder ([Wang et al. 2023, INTERSPEECH](https://arxiv.org/abs/2303.00332)) but, during the joint TTS training stage, attach a **DINO** self-supervised loss ([Caron et al. 2021, ICCV](https://arxiv.org/abs/2104.14294)) as a sidecar objective. DINO — borrowed unchanged from self-supervised vision — uses a teacher exponential moving average (EMA) and a student network looking at two random crops of the *same* audio, then minimizes cross-entropy between their projected output distributions. Because DINO uses *soft* targets and never trains a classifier head, it produces a speaker embedding space that captures within-speaker variation (style, emotion, recording conditions) rather than collapsing it. The whole thing is trained jointly with VITS ([Kim et al. 2021, ICML](https://arxiv.org/abs/2106.06103)) — the variational-autoencoder-plus-flow-plus-GAN backbone that has anchored open-source TTS for half a decade.
+
+The headline numbers, on a ChiME3 noisy-environment subset rated by Toloka crowdworkers (Table 1 of the paper): naturalness MOS in noisy conditions of **3.55 ± 0.03** vs. 3.11 ± 0.11 for YourTTS and 3.28 ± 0.04 for YourTTS plus a DEMUCS denoiser; similarity MOS of **3.52 ± 0.08** vs. 3.20 ± 0.08 / 3.35 ± 0.08 for the same baselines. A separate ablation run (Table 2 — re-rated by a fresh listener panel, hence different absolute values) tells you what is doing the work: relative to a 4.07 ± 0.05 noisy naturalness for the full DINO-VITS arm, replacing DINO with the standard AAM-Softmax verification loss collapses it to 3.58 ± 0.05; removing reference-audio noise augmentations on top of that collapses it further to 2.47 ± 0.05. DINO is doing real work, and the work is concentrated in the noisy condition — clean-condition naturalness is statistically a tie (4.03 / 4.00 / 4.04 across the three ablation arms), and the paper says so.
+
+<aside class="critical-read">
+The MOS confidence intervals (±0.04 to ±0.08) are tight because each cell aggregates ten Toloka raters across 120 reference audios — about 1200 ratings. The paper does not disclose its variance model. If rater-clustering within an audio is unaccounted for, the effective N is smaller than 1200 and the CIs are mildly underestimated. None of that overturns the noisy-condition gap (~10 standard errors apart), but it is worth flagging on tighter calls.
+</aside>
+
+A second contribution rides along: in the *training-data-noise* regime, where you train on uncurated noisy speech without transcripts, the paper shows that using HuBERT-derived discrete units as the linguistic content representation outperforms a Whisper-ASR transcription baseline. The dramatic comparison is on noisy *target* audio: Whisper-N gets a character error rate of **24.05%** while DINO-VITS-N gets **5.04%** — the ASR-based pipeline catastrophically degrades when transcripts are noisy, the HuBERT-based one barely moves.
+
+What is at stake practically: most "voice cloning in the wild" use cases — accessibility, dubbing from podcast clips, voice restoration, agent personalization — get reference audio from voicemails, recordings, and remote calls, not studio booths. A speaker encoder that quietly degrades on a 0 dB SNR clip is a pipeline that quietly fails on the data its users actually have. DINO-VITS argues that you can buy a meaningful chunk of that robustness by *attaching* a self-supervised loss to an off-the-shelf speaker verifier, not by replacing the architecture. Whether the trick generalizes beyond VITS is the open question — and one we will return to.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 420" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="abs-diag-title">
+  <title id="abs-diag-title">DINO-VITS adds a DINO self-supervised sidecar to the speaker encoder of a VITS-based zero-shot TTS system</title>
+  <defs>
+    <marker id="abs-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">A speaker encoder trained for verification, not cloning — and the DINO patch</text>
+  <!-- Reference audio block -->
+  <rect x="20" y="60" width="130" height="60" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="85" y="84" text-anchor="middle" font-weight="600" fill="#1e40af">Reference audio</text>
+  <text x="85" y="102" text-anchor="middle" font-size="11" fill="#64748b">3 sec, possibly noisy</text>
+  <!-- Two crops -->
+  <rect x="180" y="40" width="130" height="40" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="245" y="64" text-anchor="middle" font-size="11" fill="#334155">crop x_a1 + noise aug</text>
+  <rect x="180" y="100" width="130" height="40" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="245" y="124" text-anchor="middle" font-size="11" fill="#334155">crop x_a2 + noise aug</text>
+  <line x1="150" y1="80" x2="180" y2="60" stroke="#64748b" stroke-width="1.2" marker-end="url(#abs-arrow)"/>
+  <line x1="150" y1="100" x2="180" y2="120" stroke="#64748b" stroke-width="1.2" marker-end="url(#abs-arrow)"/>
+  <!-- Teacher EMA + Student -->
+  <rect x="340" y="30" width="140" height="60" rx="8" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text x="410" y="54" text-anchor="middle" font-weight="600" fill="#854d0e">Teacher EMA</text>
+  <text x="410" y="72" text-anchor="middle" font-size="11" fill="#854d0e">CAM++ + projection</text>
+  <text x="410" y="86" text-anchor="middle" font-size="11" fill="#854d0e" font-style="italic">stop-grad, EMA(student)</text>
+  <rect x="340" y="100" width="140" height="60" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="410" y="124" text-anchor="middle" font-weight="600" fill="#6b21a8">Student</text>
+  <text x="410" y="142" text-anchor="middle" font-size="11" fill="#6b21a8">CAM++ + projection</text>
+  <text x="410" y="156" text-anchor="middle" font-size="11" fill="#6b21a8" font-style="italic">trainable, joint w/ VITS</text>
+  <line x1="310" y1="60" x2="340" y2="60" stroke="#64748b" stroke-width="1.2" marker-end="url(#abs-arrow)"/>
+  <line x1="310" y1="120" x2="340" y2="130" stroke="#64748b" stroke-width="1.2" marker-end="url(#abs-arrow)"/>
+  <!-- DINO loss node -->
+  <rect x="510" y="60" width="170" height="70" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="595" y="84" text-anchor="middle" font-weight="700" fill="#166534">DINO loss</text>
+  <text x="595" y="102" text-anchor="middle" font-size="11" fill="#166534">cross-entropy between</text>
+  <text x="595" y="118" text-anchor="middle" font-size="11" fill="#166534">teacher and student</text>
+  <line x1="480" y1="60" x2="510" y2="80" stroke="#16a34a" stroke-width="1.4" marker-end="url(#abs-arrow)"/>
+  <line x1="480" y1="130" x2="510" y2="110" stroke="#16a34a" stroke-width="1.4" marker-end="url(#abs-arrow)"/>
+  <!-- Speech synthesis path -->
+  <text x="360" y="225" text-anchor="middle" font-size="12" font-style="italic" fill="#475569">Same student embedding feeds the synthesis path:</text>
+  <rect x="20" y="250" width="130" height="60" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="85" y="274" text-anchor="middle" font-weight="600" fill="#1e40af">Text (ARPABET)</text>
+  <text x="85" y="292" text-anchor="middle" font-size="11" fill="#64748b">at inference</text>
+  <rect x="180" y="250" width="130" height="60" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="245" y="274" text-anchor="middle" font-weight="600" fill="#334155">mBART (T2U)</text>
+  <text x="245" y="292" text-anchor="middle" font-size="11" fill="#64748b">text → HuBERT units</text>
+  <rect x="340" y="250" width="140" height="60" rx="8" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="410" y="274" text-anchor="middle" font-weight="600" fill="#6b21a8">VITS (U2S)</text>
+  <text x="410" y="292" text-anchor="middle" font-size="11" fill="#6b21a8">flow + VAE + GAN</text>
+  <rect x="510" y="250" width="170" height="60" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
+  <text x="595" y="274" text-anchor="middle" font-weight="700" fill="#991b1b">Cloned speech</text>
+  <text x="595" y="292" text-anchor="middle" font-size="11" fill="#991b1b">target voice, target text</text>
+  <line x1="150" y1="280" x2="180" y2="280" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <line x1="310" y1="280" x2="340" y2="280" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <line x1="480" y1="280" x2="510" y2="280" stroke="#64748b" stroke-width="1.5" marker-end="url(#abs-arrow)"/>
+  <!-- Speaker embedding feeds VITS -->
+  <line x1="410" y1="160" x2="410" y2="250" stroke="#a855f7" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#abs-arrow)"/>
+  <text x="430" y="205" font-size="11" fill="#6b21a8" font-style="italic">speaker embedding e</text>
+  <!-- Caption -->
+  <text x="360" y="365" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">The DINO loop above runs only at training time; at inference, only the student encoder is used.</text>
+  <text x="360" y="385" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">VITS is jointly fine-tuned with the speaker encoder for 175k iterations after a 95k-iteration warmup with the encoder frozen.</text>
+</svg>
+
+### Key Takeaways
+
+- **Sidecar, not replacement.** DINO-VITS keeps the off-the-shelf CAM++ speaker encoder; it just adds a self-supervised auxiliary loss during the joint TTS training stage. This is a smaller architectural commitment than retraining the encoder from scratch.
+- **Verification embeddings are too tight for cloning.** AAM-Softmax pretraining clusters every utterance from a speaker into one point, erasing exactly the within-speaker variation (emotion, style, noise condition) that a clone-the-style task needs to model.
+- **The win is concentrated in noisy conditions.** Clean-condition naturalness is a statistical tie across the ablation arms; the noisy-condition naturalness gap (4.07 vs. 3.58 vs. 2.47) is where DINO and noise augmentation each carry their weight, separately and additively.
+- **A second, independent trick.** HuBERT-based discrete-unit content modeling beats a Whisper-ASR transcription baseline on noisy training data, with a 5× CER advantage when both reference and target are noisy. This is a separate contribution that rides on the same paper.
+
+---
+
+## Introduction
+
+### Overview
+
+To place DINO-VITS, picture the last decade of neural TTS as a sequence of bottleneck moves. Around 2017, Tacotron and its successors made TTS *neural and end-to-end*: a sequence-to-sequence model went from text to mel-spectrograms, and a separate vocoder went from mel-spectrograms to waveforms. The vocoder was the early bottleneck — Griffin-Lim phase reconstruction was scratchy, autoregressive WaveNet was slow — and the next several years bled improvements out of the vocoder side: Parallel WaveNet, WaveGlow, HiFi-GAN. By 2021, **VITS** ([Kim, Kong, Son 2021](https://arxiv.org/abs/2106.06103)) folded the acoustic model and vocoder into one variational-autoencoder-plus-flow-plus-GAN trained end-to-end on waveforms. Mel-spectrograms became an internal representation rather than a hand-off interface. VITS is still the synthesizer underneath much of this paper.
+
+The next bottleneck moved upstream, to *who* the model could synthesize. Single-speaker TTS was solved; **zero-shot multi-speaker TTS** — clone any voice from a single reference clip — was not. The 2022 reference here is **YourTTS** ([Casanova et al. 2022, ICML](https://proceedings.mlr.press/v162/casanova22a.html)), which conditioned a VITS variant on a pretrained speaker-verification embedding and got recognizable cross-speaker cloning out of it. YourTTS made the *speaker-encoder-based* recipe — pretrained verifier + acoustic decoder, glued at training time — the workhorse of open-source zero-shot TTS for the next 18 months. DINO-VITS is, in lineage terms, a refinement of that recipe.
+
+But by mid-2023 the speaker-encoder-based recipe was no longer the only game. **P-Flow** ([Kim et al. 2023, NeurIPS](https://proceedings.neurips.cc/paper_files/paper/2023/hash/eb0965da1d2cb3fbbbb8dbbad5fa0bfc-Abstract-Conference.html)) and **VoiceBox** ([Le et al. 2023, NeurIPS](https://arxiv.org/abs/2306.15687)) replaced the speaker encoder with **in-context speech prompting**: instead of a 192-dim embedding, the model receives a chunk of the reference audio directly and uses flow-matching to fill in continuation audio that matches its acoustic signature. Conceptually closer to how GPT does few-shot text — and harder for an external speaker encoder to be the bottleneck of, because there is no external speaker encoder. DINO-VITS predates much of that work in submission but lives in a world where it has already landed; the paper acknowledges as much in its Conclusion, and we will pick the thread up in the Critical Read.
+
+The two specific challenges DINO-VITS addresses are noise-related and orthogonal to the architecture choice:
+
+- **Robustness to noisy reference audios at inference.** If a user records their reference clip in a coffee shop, the clean-corpus assumption breaks. Prior work has thrown denoising diffusion ([Yang et al. 2022](https://arxiv.org/abs/2211.02448)), domain-adversarial training ([Cong et al. 2020](https://arxiv.org/abs/2008.12281)), additional disentanglement encoders ([Swiatkowski et al. 2023](https://www.isca-archive.org/interspeech_2023/swiatkowski23_interspeech.html)), pretrained external denoisers, and BYOL-A self-supervised features ([Klapsas et al. 2022](https://www.isca-archive.org/interspeech_2022/klapsas22_interspeech.html)) at this problem. None of those approaches has settled the field.
+- **Training from noisy, untranscribed data.** Most clean-corpus TTS training data comes from audiobooks (LibriTTS, LibriLight) or controlled studio recordings (VCTK). Real-world data — call recordings, podcasts, voicemails — is messier. Recent work uses self-supervised audio representations like wav2vec 2.0 features ([Ni et al. 2022](https://arxiv.org/abs/2204.02524)) or HuBERT discrete units ([Hsu et al. 2021](https://arxiv.org/abs/2106.07447)) to bypass the transcript requirement entirely.
+
+DINO-VITS attacks the first problem with a dual-objective speaker encoder (the title contribution) and the second with a HuBERT-based content-representation pipeline (a smaller second contribution that rides on the same paper).
+
+The "why now?" — what enabling shifts make this paper possible — comes from three directions converging in 2023. **CAM++** ([Wang et al. 2023, INTERSPEECH](https://arxiv.org/abs/2303.00332)) gave the field a fast, AAM-Softmax-trained speaker verifier that is small enough (6M parameters) to cheaply joint-train. **DINO** ([Caron et al. 2021, ICCV](https://arxiv.org/abs/2104.14294)) — originally for self-supervised vision — provided a teacher-EMA-plus-student framework whose centering trick prevents representation collapse in a non-contrastive setting. **HuBERT** k-means-clustered units gave a discrete content representation that is downstream-trainable like phonemes but does not require transcripts. The cross-domain transfer of DINO to speaker embeddings is the paper's main contribution; the other ingredients were sitting on the shelf.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="intro-diag-title">
+  <title id="intro-diag-title">A short lineage of zero-shot TTS — speaker-encoder-based recipes vs. flow-matching prompting</title>
+  <defs>
+    <marker id="intro-arrow" markerWidth="7" markerHeight="6" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Two branches of the zero-shot TTS lineage</text>
+  <!-- Year axis -->
+  <line x1="60" y1="320" x2="660" y2="320" stroke="#94a3b8" stroke-width="1"/>
+  <text x="80" y="340" font-size="11" fill="#64748b">2017</text>
+  <text x="220" y="340" font-size="11" fill="#64748b">2021</text>
+  <text x="340" y="340" font-size="11" fill="#64748b">2022</text>
+  <text x="460" y="340" font-size="11" fill="#64748b">2023</text>
+  <text x="600" y="340" font-size="11" fill="#64748b">2024</text>
+  <!-- Speaker-encoder branch (top, blue) -->
+  <text x="60" y="70" font-size="12" font-weight="700" fill="#1e40af">Speaker-encoder-based</text>
+  <rect x="60" y="80" width="100" height="44" rx="6" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="110" y="100" text-anchor="middle" font-weight="600" fill="#1e40af">Tacotron</text>
+  <text x="110" y="116" text-anchor="middle" font-size="10" fill="#1e40af">single-speaker</text>
+  <rect x="200" y="80" width="100" height="44" rx="6" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="250" y="100" text-anchor="middle" font-weight="600" fill="#1e40af">VITS</text>
+  <text x="250" y="116" text-anchor="middle" font-size="10" fill="#1e40af">VAE+flow+GAN</text>
+  <rect x="320" y="80" width="100" height="44" rx="6" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="370" y="100" text-anchor="middle" font-weight="600" fill="#1e40af">YourTTS</text>
+  <text x="370" y="116" text-anchor="middle" font-size="10" fill="#1e40af">verifier + VITS</text>
+  <rect x="440" y="80" width="100" height="44" rx="6" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="490" y="100" text-anchor="middle" font-weight="600" fill="#1e40af">CAM++</text>
+  <text x="490" y="116" text-anchor="middle" font-size="10" fill="#1e40af">faster verifier</text>
+  <rect x="580" y="80" width="100" height="44" rx="6" fill="#fefce8" stroke="#eab308" stroke-width="2"/>
+  <text x="630" y="100" text-anchor="middle" font-weight="700" fill="#854d0e">DINO-VITS</text>
+  <text x="630" y="116" text-anchor="middle" font-size="10" fill="#854d0e">+ DINO sidecar</text>
+  <line x1="160" y1="102" x2="200" y2="102" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#intro-arrow)"/>
+  <line x1="300" y1="102" x2="320" y2="102" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#intro-arrow)"/>
+  <line x1="420" y1="102" x2="440" y2="102" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#intro-arrow)"/>
+  <line x1="540" y1="102" x2="580" y2="102" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#intro-arrow)"/>
+  <!-- Flow-matching branch (bottom, purple) -->
+  <text x="60" y="190" font-size="12" font-weight="700" fill="#6b21a8">Flow-matching / in-context prompting</text>
+  <rect x="200" y="200" width="100" height="44" rx="6" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5" stroke-dasharray="3 3"/>
+  <text x="250" y="220" text-anchor="middle" font-weight="600" fill="#6b21a8">CFM theory</text>
+  <text x="250" y="236" text-anchor="middle" font-size="10" fill="#6b21a8">conditional flow</text>
+  <rect x="440" y="200" width="100" height="44" rx="6" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="490" y="220" text-anchor="middle" font-weight="600" fill="#6b21a8">P-Flow</text>
+  <text x="490" y="236" text-anchor="middle" font-size="10" fill="#6b21a8">prompt + flow</text>
+  <rect x="560" y="200" width="100" height="44" rx="6" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="610" y="220" text-anchor="middle" font-weight="600" fill="#6b21a8">VoiceBox</text>
+  <text x="610" y="236" text-anchor="middle" font-size="10" fill="#6b21a8">flow + 50k h</text>
+  <line x1="300" y1="222" x2="440" y2="222" stroke="#a855f7" stroke-width="1.5" stroke-dasharray="3 3"/>
+  <line x1="540" y1="222" x2="560" y2="222" stroke="#a855f7" stroke-width="1.5" marker-end="url(#intro-arrow)"/>
+  <!-- Annotation -->
+  <text x="360" y="280" text-anchor="middle" font-size="11" font-style="italic" fill="#475569">DINO-VITS sits on the speaker-encoder branch. The flow-matching branch is the contemporaneous SOTA bracket the paper does not compare against.</text>
+</svg>
+
+### Key Takeaways
+
+- **DINO-VITS lives on a specific branch.** It is a refinement of the speaker-encoder-based recipe (YourTTS lineage), not a competitor to flow-matching prompting (P-Flow / VoiceBox lineage). Reading it as either is a category error.
+- **The "why now" is convergent.** CAM++ (small fast verifier), DINO (non-collapsing self-distillation), and HuBERT (transcript-free units) all landed in the right window. The cross-domain transfer is the contribution; the components were sitting on the shelf.
+- **Two problems, two ideas.** The DINO sidecar handles noisy *reference* audio; the HuBERT-based content pipeline handles noisy *training* data. They are independent and could in principle be combined with other backbones.
+
+---
+
+## Method: a Dual-Objective Speaker Encoder
+
+### Overview
+
+Before the architecture, a one-line orientation: the system has four pretrained components, two of which are co-trained at TTS time. The four are HuBERT (speech-to-unit, 95M params), mBART (text-to-unit, 610M params), CAM++ (speaker encoder, 6M params), and VITS (unit-to-speech, 40M params). At training time, HuBERT extracts discrete content units from the input speech and the speaker encoder extracts an embedding from the same speech; VITS reads the units and the embedding and reconstructs the speech, optimizing a standard VITS loss plus the DINO sidecar. At inference time, mBART replaces HuBERT — text is converted to the same unit space — and the same VITS-plus-encoder pipeline runs.
+
+The architectural commitment that matters for the rest of this section is the speaker encoder. The CAM++ verifier is pretrained on the [VoxCeleb2](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/vox2.html) speaker-rich dataset using **AAM-Softmax**, the standard angular-margin softmax loss for verification ([Wang et al. 2023](https://arxiv.org/abs/2303.00332)). AAM-Softmax does two things: it pulls embeddings of the same speaker into a tight cluster, and it pushes embeddings of different speakers apart on the unit hypersphere. Both are great for "is this the same speaker?" — and both are problematic for cloning. A tight cluster *erases* within-speaker variation, but voice cloning needs to *transfer* style: emotion, prosody, recording acoustics. The encoder you want for verification is approximately the encoder you do not want for cloning.
+
+The naive fix — unfreeze CAM++ during VITS training and let the synthesis loss drag it toward more cloning-friendly representations — runs into catastrophic forgetting. The encoder loses its noise robustness and its speaker discriminability before it picks up useful style sensitivity. The paper's fix is to keep CAM++ trainable but constrain it with a **DINO** auxiliary loss applied to two augmented crops of the reference audio.
+
+DINO ([Caron et al. 2021](https://arxiv.org/abs/2104.14294)) is a self-distillation framework originally proposed for self-supervised vision transformers. It maintains two networks with the same architecture: a *student* whose weights are updated by gradient descent, and a *teacher* whose weights are an exponential moving average (EMA) of the student's weights. Both networks see different augmentations of the same input, project their outputs through a small head into a K-dimensional logit space, and the loss is the cross-entropy between the teacher's softmax distribution (with a tight temperature) and the student's. Two anti-collapse tricks make this stable: **centering** subtracts a running mean of teacher outputs before the softmax (preventing the trivial solution where all inputs map to the same point), and **sharpening** uses a much lower temperature for the teacher than the student (preventing the trivial solution where all outputs are uniform). The loss the paper uses is
+
+L_DINO = − Σᵢ σ((P_T(x_a1)ᵢ − C) / τ) · log σ(P_S(x_a2)ᵢ / τ)
+
+where σ is the softmax, C is the EMA centering vector, τ is the teacher temperature, and x_a1, x_a2 are two random crops of the same audio with independent noise augmentations. The student is the speaker encoder (CAM++) plus a three-layer MLP projection head producing K-dimensional output; the teacher shares the architecture with EMA-coupled weights.
+
+The full training schedule has three stages. Stage 1: pretrain CAM++ on VoxCeleb2 with AAM-Softmax (noise augmentations from MUSAN and RIRS). Stage 2: train the joint TTS system — VITS plus speaker encoder — minimizing the standard VITS loss plus λ · L_DINO. Stage 2 itself splits in two: 95k iterations with the speaker encoder frozen except for its last layer, then 175k iterations with it fully unfrozen. Stage 3: at inference, unit sequences come from mBART (text-to-unit) instead of HuBERT (speech-to-unit), and only the student speaker encoder is used to embed the reference audio. Total training time: 5 days on 2× RTX 3090, batch size 80.
+
+<aside class="critical-read">
+DINO is borrowed unchanged from self-supervised vision — Caron et al. 2021 is the original. The paper's contribution is the cross-domain transfer to speaker embeddings inside a TTS pipeline, which is non-obvious because vision DINO uses spatial multi-crop and the audio adaptation has to choose between time crops, frequency crops, and crop-plus-augment. The paper takes only two random temporal segments per utterance (vs. multi-local-crop in vision DINO), which is a reasonable but unmotivated simplification.
+</aside>
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="dino-diag-title">
+  <title id="dino-diag-title">DINO loss applied to the speaker encoder — two augmented audio crops, teacher EMA, student gradient, centering and sharpening anti-collapse tricks</title>
+  <defs>
+    <marker id="dino-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">DINO loss: self-distillation on two crops of the same audio</text>
+  <!-- Reference audio -->
+  <rect x="20" y="60" width="140" height="60" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="90" y="84" text-anchor="middle" font-weight="600" fill="#1e40af">Reference audio x</text>
+  <text x="90" y="102" text-anchor="middle" font-size="11" fill="#64748b">3 sec speech, MUSAN noise</text>
+  <!-- Two crops -->
+  <rect x="200" y="20" width="140" height="44" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="270" y="40" text-anchor="middle" font-weight="600" fill="#334155">crop x_a1</text>
+  <text x="270" y="56" text-anchor="middle" font-size="10" fill="#64748b">random temporal segment + noise</text>
+  <rect x="200" y="116" width="140" height="44" rx="6" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="270" y="136" text-anchor="middle" font-weight="600" fill="#334155">crop x_a2</text>
+  <text x="270" y="152" text-anchor="middle" font-size="10" fill="#64748b">different segment + noise</text>
+  <line x1="160" y1="80" x2="200" y2="42" stroke="#64748b" stroke-width="1.2" marker-end="url(#dino-arrow)"/>
+  <line x1="160" y1="100" x2="200" y2="138" stroke="#64748b" stroke-width="1.2" marker-end="url(#dino-arrow)"/>
+  <!-- Teacher and Student -->
+  <rect x="380" y="20" width="120" height="44" rx="6" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text x="440" y="40" text-anchor="middle" font-weight="600" fill="#854d0e">Teacher P_T</text>
+  <text x="440" y="56" text-anchor="middle" font-size="10" fill="#854d0e">CAM++ + head, stop-grad</text>
+  <rect x="380" y="116" width="120" height="44" rx="6" fill="#faf5ff" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="440" y="136" text-anchor="middle" font-weight="600" fill="#6b21a8">Student P_S</text>
+  <text x="440" y="152" text-anchor="middle" font-size="10" fill="#6b21a8">CAM++ + head, trainable</text>
+  <line x1="340" y1="42" x2="380" y2="42" stroke="#64748b" stroke-width="1.2" marker-end="url(#dino-arrow)"/>
+  <line x1="340" y1="138" x2="380" y2="138" stroke="#64748b" stroke-width="1.2" marker-end="url(#dino-arrow)"/>
+  <!-- EMA arrow -->
+  <path d="M 440 116 Q 360 90 440 64" stroke="#854d0e" stroke-width="1.2" stroke-dasharray="3 3" fill="none" marker-end="url(#dino-arrow)"/>
+  <text x="350" y="92" font-size="10" font-style="italic" fill="#854d0e">EMA</text>
+  <!-- Center subtract + softmax -->
+  <rect x="540" y="20" width="160" height="44" rx="6" fill="#fff7ed" stroke="#fb923c" stroke-width="1.2"/>
+  <text x="620" y="40" text-anchor="middle" font-size="11" font-weight="600" fill="#9a3412">σ((P_T − C) / τ_T)</text>
+  <text x="620" y="56" text-anchor="middle" font-size="10" fill="#9a3412">center C = EMA mean, sharp τ_T</text>
+  <rect x="540" y="116" width="160" height="44" rx="6" fill="#fdf4ff" stroke="#c084fc" stroke-width="1.2"/>
+  <text x="620" y="136" text-anchor="middle" font-size="11" font-weight="600" fill="#86198f">σ(P_S / τ_S)</text>
+  <text x="620" y="152" text-anchor="middle" font-size="10" fill="#86198f">student temperature τ_S &gt; τ_T</text>
+  <line x1="500" y1="42" x2="540" y2="42" stroke="#64748b" stroke-width="1.2" marker-end="url(#dino-arrow)"/>
+  <line x1="500" y1="138" x2="540" y2="138" stroke="#64748b" stroke-width="1.2" marker-end="url(#dino-arrow)"/>
+  <!-- Loss node -->
+  <rect x="280" y="220" width="160" height="60" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="360" y="244" text-anchor="middle" font-weight="700" fill="#166534">L_DINO</text>
+  <text x="360" y="262" text-anchor="middle" font-size="11" fill="#166534">cross-entropy</text>
+  <text x="360" y="276" text-anchor="middle" font-size="11" fill="#166534">teacher → student</text>
+  <line x1="620" y1="64" x2="440" y2="220" stroke="#16a34a" stroke-width="1.4" marker-end="url(#dino-arrow)"/>
+  <line x1="620" y1="160" x2="440" y2="240" stroke="#16a34a" stroke-width="1.4" marker-end="url(#dino-arrow)"/>
+  <!-- Backprop arrow -->
+  <line x1="280" y1="260" x2="180" y2="260" stroke="#dc2626" stroke-width="1.4" stroke-dasharray="4 3"/>
+  <text x="180" y="252" text-anchor="end" font-size="11" font-style="italic" fill="#991b1b">backprop into student only</text>
+  <text x="360" y="330" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">Centering keeps the teacher distribution from collapsing to a single point;</text>
+  <text x="360" y="346" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">the lower teacher temperature sharpens the target so it does not collapse to uniform.</text>
+  <text x="360" y="362" text-anchor="middle" font-size="11" fill="#475569" font-style="italic">In DINO-VITS, the student speaker encoder is the same network whose embedding feeds VITS.</text>
+</svg>
+
+### Implementation
+
+A minimal PyTorch reference for the DINO loss adapted to two audio crops. The full DINO codebase ships multi-crop logic, momentum schedules, and projection heads — this is the *load* of the loss function itself, the part the paper substitutes for AAM-Softmax.
+
+```python
+import torch
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+
+class DinoSpeakerLoss(nn.Module):
+    """Two-crop DINO self-distillation loss for a speaker encoder.
+
+    The student is the trainable speaker encoder + projection head; the teacher
+    shares its architecture with EMA-coupled weights. Loss is cross-entropy
+    between the (centered, sharpened) teacher distribution and the student
+    distribution over augmented crops of the same utterance. Centering is the
+    anti-collapse trick that lets DINO work without negative pairs.
+
+    Args:
+        out_dim: dimensionality K of the projection-head output.
+        teacher_temp: τ_T, sharpens teacher targets to prevent uniform collapse.
+        student_temp: τ_S > τ_T, smoother student distribution.
+        center_momentum: EMA factor for the running mean over teacher outputs.
+    """
+
+    def __init__(
+        self,
+        out_dim: int,
+        teacher_temp: float = 0.04,
+        student_temp: float = 0.1,
+        center_momentum: float = 0.9,
+    ) -> None:
+        super().__init__()
+        self.teacher_temp = teacher_temp
+        self.student_temp = student_temp
+        self.center_momentum = center_momentum
+        self.register_buffer("center", torch.zeros(1, out_dim))
+
+    def forward(self, student_out: Tensor, teacher_out: Tensor) -> Tensor:
+        # Teacher is stop-grad: detach so gradients only flow into student.
+        teacher_logits = (teacher_out.detach() - self.center) / self.teacher_temp
+        teacher_probs = F.softmax(teacher_logits, dim=-1)
+        student_log_probs = F.log_softmax(student_out / self.student_temp, dim=-1)
+        loss = -(teacher_probs * student_log_probs).sum(dim=-1).mean()
+        # Update center as EMA over the batch mean of (un-centered) teacher outputs.
+        batch_center = teacher_out.detach().mean(dim=0, keepdim=True)
+        self.center.mul_(self.center_momentum).add_(
+            batch_center, alpha=1.0 - self.center_momentum
+        )
+        return loss
+```
+
+In the joint training loop, this loss is computed on student/teacher outputs from two augmented crops `x_a1`, `x_a2` of the *same* reference audio, and added to the standard VITS reconstruction + KL + duration + adversarial losses with a scalar weight λ. The student encoder's gradients flow from both objectives simultaneously, and the student embedding is what conditions VITS at inference — there is no separate "DINO encoder" path at deployment.
+
+### Key Takeaways
+
+- **DINO is a soft, label-free clustering objective.** Unlike AAM-Softmax (which optimizes a hard speaker-classification head), DINO has no class labels. The student learns to match a softened teacher distribution over an arbitrary K-dim projection space — useful when the task is "preserve within-speaker variation," because no classifier is forcing a collapse.
+- **Two anti-collapse tricks hold the loss together.** Centering subtracts a running EMA mean from teacher outputs before the softmax; sharpening uses a tight teacher temperature. Either alone fails; both together stabilize the loss without negatives.
+- **The student is the production encoder.** At inference, only the student speaker encoder + its projection head feed VITS. The teacher and the centering state are training-time scaffolding, discarded at deployment.
+- **The schedule matters.** Unfreezing CAM++ from step 0 catastrophically forgets verification capability; a 95k-iteration warmup with the encoder frozen, then 175k iterations of joint training, is the schedule that worked.
+
+---
+
+## Results — Noisy Reference at Inference
+
+### Overview
+
+This is the headline experiment. The setup: the **ChiME3** dataset ([Barker et al. 2017](https://www.sciencedirect.com/science/article/abs/pii/S0885230816301959)) provides recordings of speakers reading the same prompt in a quiet "booth" environment and in four real-world noisy environments (bus, cafe, pedestrian area, street junction). A subset is selected: 8 speakers, 15 reference audios per speaker (roughly evenly distributed across the four environments) — 120 reference audios per condition. For each reference, a different ground-truth source audio + text from the *same* speaker is selected as the cloning target. All test reference audios are trimmed to 3 seconds. Quality is measured by **MOS** (mean opinion score) on naturalness and similarity, gathered via the Toloka crowdsourcing platform with 10 raters per audio. Total: ~1200 ratings per cell.
+
+The baselines: **YourTTS** ([Casanova et al. 2022](https://proceedings.mlr.press/v162/casanova22a.html)) reproduced without the multilingual head; **YourTTS + DEMUCS denoiser** ([Défossez 2021](https://hal.archives-ouvertes.fr/hal-03559435)) where a pretrained denoiser cleans the reference before YourTTS sees it, giving a stronger noisy-condition baseline; and **BYOL-A**-encoder-conditioned VITS ([Klapsas et al. 2022](https://www.isca-archive.org/interspeech_2022/klapsas22_interspeech.html)), where the speaker encoder is a frozen BYOL-A self-supervised audio encoder. Reading these together, the relevant comparisons are: vs. YourTTS = "did adding DINO and joint training help over the standard speaker-encoder recipe?" vs. YourTTS+DEMUCS = "did learning robustness internally beat externalizing it to a denoiser?" vs. BYOL-A = "is multi-task learning beating a generic SSL audio encoder?"
+
+The Table 1 numbers (MOS ± 95% CI):
+
+| System | Naturalness Clean | Naturalness Noisy | Similarity Clean | Similarity Noisy |
+|---|---:|---:|---:|---:|
+| Ground truth | 4.68 ± 0.03 | — | 3.94 ± 0.07 | — |
+| **DINO-VITS (ours)** | **4.00 ± 0.05** | **3.55 ± 0.03** | **3.85 ± 0.08** | **3.52 ± 0.08** |
+| YourTTS | 3.96 ± 0.05 | 3.11 ± 0.11 | 3.33 ± 0.08 | 3.20 ± 0.08 |
+| YourTTS + DEMUCS | — | 3.28 ± 0.04 | — | 3.35 ± 0.08 |
+| BYOL-A frozen | — | 1.85 ± 0.09 | — | 1.89 ± 0.07 |
+
+Three readings of these numbers. **First**, the headline win is in noisy similarity: 3.52 vs. 3.20 (YourTTS) and 3.35 (YourTTS+DEMUCS). The denoiser helps YourTTS by 0.15 MOS but does not close the gap to DINO-VITS. **Second**, BYOL-A frozen lands far below — a frozen generic SSL encoder is not a substitute for a multi-task-trained one, even one that started from the same kind of self-supervised objective. **Third**, in clean conditions, DINO-VITS and YourTTS naturalness are essentially tied (4.00 vs. 3.96, overlapping CIs); the win is concentrated, again, in the noisy regime where the speaker encoder is exposed to out-of-distribution input.
+
+The ablation in Table 2 makes the role of DINO sharper. (Note: Table 2 is a separate MOS evaluation from Table 1, with its own listener panel — the absolute values shift slightly across panels, but the within-table comparisons are clean.) Three arms: full DINO-VITS (Ours), AAM-Softmax replacing DINO (AV), and AAM-Softmax with reference-noise augmentations also removed (NV). Naturalness in the noisy condition: 4.07 ± 0.05 / 3.58 ± 0.05 / 2.47 ± 0.05. Each ablation step costs roughly 0.5 MOS in noisy naturalness, then another 1.1. DINO loss and noise augmentation are *both* doing work, and they are *additive* rather than substitutes — pulling either one out is a meaningful regression. (In clean conditions, the three arms are statistically indistinguishable, 4.03 / 4.00 / 4.04, and the paper says so explicitly.)
+
+A second, smaller experiment in Section 3.2.1 probes whether the DINO sidecar actually changes *what* the speaker embedding encodes. The authors train a small two-layer classifier on top of the speaker encoder to predict emotion category on **CREMA-D** ([Cao et al. 2014](https://ieeexplore.ieee.org/document/6849440)) and **IEMOCAP** ([Busso et al. 2008](https://link.springer.com/article/10.1007/s10579-008-9076-6)). The DINO-jointly-trained encoder reaches 62.4% on CREMA-D vs. 53.4% for the AAM-Softmax-only baseline (a 9.0 pp gain), and 45.8% on IEMOCAP vs. 39.8% (a 6.0 pp gain). The paper rounds this to "+9% accuracy" in passing — the larger of the two numbers — but the gain is meaningfully smaller on IEMOCAP. Either way, it is a probe, not a cloning result, but it is consistent with the hypothesis that DINO loosens the embedding cluster enough to encode style.
+
+<aside class="critical-read">
+The 1200 ratings give tight per-cell CIs, but the bottleneck for generalization claims is not rating count — it is speaker and noise diversity. Eight speakers from one corpus across four environments cannot tell you whether the trick generalizes across accents, languages, recording devices, or noise classes outside the four ChiME3 environments. Toloka annotator quality is a known concern (no skill gating disclosed). Within the regime tested, the gap is robust; outside that regime, the paper does not yet speak.
+</aside>
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="results-bars-title">
+  <title id="results-bars-title">MOS naturalness and similarity in noisy conditions across baselines, showing DINO-VITS leading on both</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Noisy-condition MOS — DINO-VITS vs. baselines</text>
+  <!-- Naturalness panel -->
+  <text x="180" y="58" text-anchor="middle" font-size="13" font-weight="700" fill="#475569">Naturalness (MOS, noisy)</text>
+  <line x1="60" y1="280" x2="320" y2="280" stroke="#94a3b8" stroke-width="1"/>
+  <line x1="60" y1="80" x2="60" y2="280" stroke="#94a3b8" stroke-width="1"/>
+  <text x="55" y="84" text-anchor="end" font-size="10" fill="#64748b">5</text>
+  <text x="55" y="184" text-anchor="end" font-size="10" fill="#64748b">3</text>
+  <text x="55" y="284" text-anchor="end" font-size="10" fill="#64748b">1</text>
+  <!-- Bars: scale (MOS-1) * 50 (so 4 → 150, 3 → 100, etc.) -->
+  <!-- DINO-VITS 3.55 -->
+  <rect x="80" y="152.5" width="40" height="127.5" fill="#22c55e"/>
+  <text x="100" y="148" text-anchor="middle" font-size="10" font-weight="700" fill="#166534">3.55</text>
+  <text x="100" y="294" text-anchor="middle" font-size="10" fill="#475569">Ours</text>
+  <!-- YT+DEMUCS 3.28 -->
+  <rect x="140" y="166" width="40" height="114" fill="#3b82f6"/>
+  <text x="160" y="161" text-anchor="middle" font-size="10" font-weight="700" fill="#1e40af">3.28</text>
+  <text x="160" y="294" text-anchor="middle" font-size="10" fill="#475569">YT+D</text>
+  <!-- YT 3.11 -->
+  <rect x="200" y="174.5" width="40" height="105.5" fill="#60a5fa"/>
+  <text x="220" y="170" text-anchor="middle" font-size="10" font-weight="700" fill="#1e40af">3.11</text>
+  <text x="220" y="294" text-anchor="middle" font-size="10" fill="#475569">YT</text>
+  <!-- BYOL-A 1.85 -->
+  <rect x="260" y="237.5" width="40" height="42.5" fill="#cbd5e1"/>
+  <text x="280" y="232" text-anchor="middle" font-size="10" font-weight="700" fill="#475569">1.85</text>
+  <text x="280" y="294" text-anchor="middle" font-size="10" fill="#475569">BY</text>
+  <!-- Similarity panel -->
+  <text x="540" y="58" text-anchor="middle" font-size="13" font-weight="700" fill="#475569">Similarity (MOS, noisy)</text>
+  <line x1="420" y1="280" x2="680" y2="280" stroke="#94a3b8" stroke-width="1"/>
+  <line x1="420" y1="80" x2="420" y2="280" stroke="#94a3b8" stroke-width="1"/>
+  <text x="415" y="84" text-anchor="end" font-size="10" fill="#64748b">5</text>
+  <text x="415" y="184" text-anchor="end" font-size="10" fill="#64748b">3</text>
+  <text x="415" y="284" text-anchor="end" font-size="10" fill="#64748b">1</text>
+  <!-- DINO-VITS 3.52 -->
+  <rect x="440" y="154" width="40" height="126" fill="#22c55e"/>
+  <text x="460" y="149" text-anchor="middle" font-size="10" font-weight="700" fill="#166534">3.52</text>
+  <text x="460" y="294" text-anchor="middle" font-size="10" fill="#475569">Ours</text>
+  <!-- YT+DEMUCS 3.35 -->
+  <rect x="500" y="162.5" width="40" height="117.5" fill="#3b82f6"/>
+  <text x="520" y="157" text-anchor="middle" font-size="10" font-weight="700" fill="#1e40af">3.35</text>
+  <text x="520" y="294" text-anchor="middle" font-size="10" fill="#475569">YT+D</text>
+  <!-- YT 3.20 -->
+  <rect x="560" y="170" width="40" height="110" fill="#60a5fa"/>
+  <text x="580" y="165" text-anchor="middle" font-size="10" font-weight="700" fill="#1e40af">3.20</text>
+  <text x="580" y="294" text-anchor="middle" font-size="10" fill="#475569">YT</text>
+  <!-- BYOL-A 1.89 -->
+  <rect x="620" y="235.5" width="40" height="44.5" fill="#cbd5e1"/>
+  <text x="640" y="230" text-anchor="middle" font-size="10" font-weight="700" fill="#475569">1.89</text>
+  <text x="640" y="294" text-anchor="middle" font-size="10" fill="#475569">BY</text>
+  <!-- Caption -->
+  <text x="360" y="335" text-anchor="middle" font-size="11" font-style="italic" fill="#475569">DINO-VITS leads on both metrics. The DEMUCS denoiser helps YourTTS by ~0.15 MOS but does not close the gap.</text>
+  <text x="360" y="352" text-anchor="middle" font-size="11" font-style="italic" fill="#475569">Frozen BYOL-A as a speaker encoder collapses below 2.0 MOS — a generic SSL audio encoder is not a substitute for a jointly-trained one.</text>
+</svg>
+
+### Key Takeaways
+
+- **The win is concentrated where the encoder is stressed.** Clean-condition naturalness is a tie across DINO-VITS, YourTTS, and the AAM-Softmax ablation arms — all hover around 4.00 MOS with overlapping CIs. The DINO sidecar earns its keep specifically when the reference audio is out-of-distribution noisy.
+- **Internalized robustness beats an external denoiser.** Adding DEMUCS in front of YourTTS recovers 0.15 MOS in noisy conditions but does not catch DINO-VITS. The model that learns to handle noise during training outperforms the pipeline that tries to remove noise at inference — a familiar pattern across modalities.
+- **DINO and noise augmentation are additive.** The ablation is clean: removing DINO costs ~0.5 MOS in noisy naturalness; additionally removing noise augmentations costs another ~1.1 MOS. Each component is doing real work, and removing one does not erase the value of keeping the other.
+- **The emotion-classifier probe is corroborating, not load-bearing.** A classifier-accuracy bump of 9 pp on CREMA-D and 6 pp on IEMOCAP is consistent with "DINO loosens the cluster enough to encode style" but does not by itself prove the synthesis system uses that information for cloning. Read it as a sanity check, not the experiment.
+
+---
+
+## Results — Training from Noisy, Untranscribed Data
+
+### Overview
+
+A short orientation before the result: this section is a *separate* contribution from the DINO sidecar, addressing a different problem. The DINO experiments above assumed clean training data and stressed the system at inference time with noisy *reference* audios. This section instead stresses the system at *training* time: what happens if you train on noisy speech without transcripts? The architectural lever here is not the speaker encoder but the **content** representation — the bridge between text input and acoustic output.
+
+The standard recipe before HuBERT-style discrete units was: run an ASR system over the training audio to get phoneme transcripts, then train TTS on `(audio, phonemes)` pairs. This works while transcripts are accurate, and degrades catastrophically once the ASR can no longer transcribe — exactly what happens with noisy data. The HuBERT-based alternative bypasses transcripts: HuBERT extracts continuous self-supervised features from raw audio, k-means clusters them into 1000 discrete units, and TTS learns to map text → unit sequences (via mBART) and unit sequences → speech (via VITS). No transcripts; the units are the bridge.
+
+The experiment compares the two recipes head-to-head. Train each on a 60% clean / 40% noisy variant of LibriTTS (noises from MUSAN, SNR 0 dB on the noisy subset), retain the original VCTK + LibriTTS as the clean variant. The ASR baseline uses Whisper-medium ([Radford et al. 2023](https://arxiv.org/abs/2212.04356)) — a strong, recent, large-pretrained ASR system — to convert content audio to phonemes; HuBERT does the same job in the proposed system. Inference happens with both clean and noisy *target* audios; metrics are MOS naturalness, MOS similarity, and **CER** (character error rate of the synthesized speech, measured by running an ASR over the output and comparing to the ground-truth text).
+
+The key Table 4 result, on noisy *target* audios:
+
+| Train data | System | Naturalness | Similarity | CER |
+|---|---|---:|---:|---:|
+| — | Ground truth | 4.79 ± 0.02 | 3.86 ± 0.08 | 3.86 ± 0.20 |
+| Clean | Whisper-C | 3.04 ± 0.05 | 2.99 ± 0.08 | 7.29 ± 0.38 |
+| Clean | DINO-VITS-C | 3.57 ± 0.05 | 3.16 ± 0.08 | 4.56 ± 0.25 |
+| Noisy | Whisper-N | 1.29 ± 0.04 | 1.86 ± 0.07 | **24.05 ± 0.97** |
+| Noisy | DINO-VITS-N | 3.52 ± 0.05 | 3.32 ± 0.08 | 5.04 ± 0.28 |
+
+The Whisper-N row is the dramatic one. Trained on noisy data, the Whisper-based pipeline produces synthesized speech whose CER at inference (with a noisy target reference) is **24%** — about a quarter of the characters are wrong — and whose MOS naturalness collapses to 1.29. The DINO-VITS-N row, by contrast, holds: CER 5.04%, naturalness 3.52, similarity 3.32. The HuBERT-based pipeline barely degrades when its training data goes from clean to noisy.
+
+The mechanism, per the paper's diagnosis: noisy training data corrupts the Whisper transcripts that the ASR-based pipeline relies on. Whisper itself is robust enough at the noise levels used (0 dB SNR on 40% of clips), but "robust" is not "perfect" — small transcription errors propagate as noise into the TTS training signal and *cumulatively* destabilize the synthesizer. HuBERT, by contrast, does not produce transcripts; its discrete units encode noise *and* content together, and the TTS model learns to associate noisy units with noisy targets and (separately) clean units with clean targets. At inference, when the unit sequence comes from mBART (clean by construction, since mBART runs on text), the system synthesizes clean speech.
+
+A tiny corroborating experiment in Section 3.3.2: train a binary CatBoost classifier ([Prokhorenkova et al. 2018](https://proceedings.neurips.cc/paper/2018/hash/14491b756b3a51daac41c24863285549-Abstract.html)) on HuBERT features to distinguish noisy from clean speech, leave-one-noise-out across the four ChiME3 environments. F-scores exceed 0.97. The paper presents this as evidence that HuBERT features encode noise, which is *separability*, not invariance — and arguably the opposite of what you would naively want from a content encoder. The reason it still works for the TTS task is that the synthesizer has learned to associate the noise-encoded part of the units with the noise-encoded part of the target, so at inference (with units from clean text) the noise channel is silent.
+
+<aside class="critical-read">
+The paper's title and section 3.3 framing of "data-efficient" can mislead a casual reader. Here it does not mean "trains on less data overall" — the pipeline still uses VCTK + LibriTTS + LibriLight + VoxCeleb2 + MUSAN + RIRS, which is substantial. It means "can use unlabeled, noisy speech without transcripts," removing a constraint on which data is admissible. Whether that buys you compute or label efficiency is the relevant practical question, and the paper does not quantify it.
+</aside>
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 380" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="cer-collapse-title">
+  <title id="cer-collapse-title">CER on noisy target audio — Whisper-N catastrophically collapses to 24% while DINO-VITS-N stays near 5%</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Noisy-data training: ASR-baseline collapse vs. HuBERT stability</text>
+  <text x="360" y="44" text-anchor="middle" font-size="11" fill="#64748b">CER (%) on noisy target audio, lower is better</text>
+  <!-- Axes -->
+  <line x1="80" y1="320" x2="680" y2="320" stroke="#94a3b8" stroke-width="1"/>
+  <line x1="80" y1="80" x2="80" y2="320" stroke="#94a3b8" stroke-width="1"/>
+  <text x="74" y="84" text-anchor="end" font-size="10" fill="#64748b">25</text>
+  <text x="74" y="180" text-anchor="end" font-size="10" fill="#64748b">15</text>
+  <text x="74" y="276" text-anchor="end" font-size="10" fill="#64748b">5</text>
+  <text x="74" y="324" text-anchor="end" font-size="10" fill="#64748b">0</text>
+  <!-- Bars: scale CER * 9.6 (0 to 25 → 0 to 240, so y = 320 - 9.6*CER) -->
+  <!-- GT 3.86 -->
+  <rect x="120" y="282.9" width="50" height="37.1" fill="#a3a3a3"/>
+  <text x="145" y="278" text-anchor="middle" font-size="10" font-weight="700" fill="#475569">3.86</text>
+  <text x="145" y="338" text-anchor="middle" font-size="10" fill="#475569">GT</text>
+  <!-- Whisper-C 7.29 -->
+  <rect x="200" y="250.0" width="50" height="70.0" fill="#fb923c"/>
+  <text x="225" y="245" text-anchor="middle" font-size="10" font-weight="700" fill="#9a3412">7.29</text>
+  <text x="225" y="338" text-anchor="middle" font-size="10" fill="#475569">Whisper-C</text>
+  <!-- DINO-VITS-C 4.56 -->
+  <rect x="280" y="276.2" width="50" height="43.8" fill="#22c55e"/>
+  <text x="305" y="271" text-anchor="middle" font-size="10" font-weight="700" fill="#166534">4.56</text>
+  <text x="305" y="338" text-anchor="middle" font-size="10" fill="#475569">Ours-C</text>
+  <!-- Whisper-N 24.05 — the collapse -->
+  <rect x="360" y="89.1" width="50" height="230.9" fill="#dc2626"/>
+  <text x="385" y="84" text-anchor="middle" font-size="11" font-weight="700" fill="#991b1b">24.05</text>
+  <text x="385" y="338" text-anchor="middle" font-size="10" fill="#475569">Whisper-N</text>
+  <!-- DINO-VITS-N 5.04 -->
+  <rect x="440" y="271.6" width="50" height="48.4" fill="#22c55e"/>
+  <text x="465" y="266" text-anchor="middle" font-size="10" font-weight="700" fill="#166534">5.04</text>
+  <text x="465" y="338" text-anchor="middle" font-size="10" fill="#475569">Ours-N</text>
+  <!-- Annotation arrow + text -->
+  <line x1="540" y1="120" x2="425" y2="100" stroke="#991b1b" stroke-width="1.2" stroke-dasharray="3 3"/>
+  <text x="550" y="120" font-size="11" font-weight="700" fill="#991b1b">5× the CER of Ours-N</text>
+  <text x="550" y="135" font-size="10" fill="#991b1b">when both train on noisy data</text>
+  <line x1="540" y1="290" x2="490" y2="285" stroke="#166534" stroke-width="1.2" stroke-dasharray="3 3"/>
+  <text x="550" y="290" font-size="11" font-weight="700" fill="#166534">~1.1× ground truth CER</text>
+  <text x="550" y="305" font-size="10" fill="#166534">despite noisy training</text>
+</svg>
+
+### Key Takeaways
+
+- **Whisper-N is the cautionary tale.** When a strong recent ASR is trained on noisy data and asked to transcribe noisy targets, the resulting TTS pipeline produces 24% CER speech and 1.29 MOS naturalness — effectively unintelligible. The ASR-bridge recipe is fragile in the noisy-training-data regime in a way that is not obvious from the ASR's own benchmark numbers.
+- **HuBERT discrete units are noise-tolerant *for the synthesis task*.** They are not noise-invariant — a CatBoost classifier separates noisy from clean units with F > 0.97. They are tolerant in a specific sense: the synthesizer learns to associate the noise channel of the units with the noise channel of the target, and at inference (with units from clean text) the noise channel is silent.
+- **The contribution is independent of the DINO sidecar.** This whole section is about the *content* representation, not the speaker encoder. A reader could in principle adopt the HuBERT-units-instead-of-Whisper-transcripts trick on top of any TTS backbone, including non-VITS ones — and the gain reported here would presumably transfer.
+- **"Data-efficient" has a specific technical meaning in this paper.** It is shorthand for "can train on unlabeled noisy speech without transcripts," not "trains on less data overall." The pipeline still uses several large speech corpora; the constraint that is removed is the transcript requirement, not the volume requirement.
+
+---
+
+## Critical Read — What Survives an Honest Audit
+
+### Overview
+
+The paper makes two bounded claims, both of which survive scrutiny: (1) attaching a DINO loss to the speaker encoder of a VITS-based zero-shot TTS system improves robustness to *reference-audio noise at inference*, and (2) using HuBERT-derived discrete units as the content representation makes the TTS pipeline robust to *training on noisy, untranscribed speech*. The evidence for each is well-scoped — internally consistent, statistically tight at the per-cell level, and ablation-validated.
+
+What remains open is more interesting: the *mechanism behind* the wins, and how far they generalize beyond the specific recipe and test set evaluated. The paper itself flags some of this in its Conclusion (limited speaker-encoder-based scope, no flow-matching comparisons). The synthesis below restates those open threads as **three experiments that would convince me the contribution generalizes**, framed constructively rather than as gotchas. None of these are killers; they are the experiments that move the result from "a clever trick that works in this regime" to "a load-bearing pattern that other systems can adopt."
+
+**Experiment 1 — Cross-loss ablation.** The paper claims DINO loss specifically improves the speaker encoder. The broader truth might be that *any* non-discriminative self-supervised auxiliary loss with a soft target distribution would work — DINO, MoCo ([He et al. 2020](https://arxiv.org/abs/1911.05722)), BYOL ([Grill et al. 2020](https://arxiv.org/abs/2006.07733)), or SimCLR ([Chen et al. 2020](https://arxiv.org/abs/2002.05709)) — because the load-bearing property is *not optimizing a hard classification head*, not the centering-and-sharpening trick specifically. An ablation that swaps DINO for one of these alternatives, holding everything else fixed, would tell you whether the contribution is "DINO works here" (as the paper says) or the broader "non-discriminative SSL teachers preserve within-speaker variation, and DINO is one example." The latter would be the more useful result for the community; the former leaves a hyperparameter-search-shaped hole.
+
+**Experiment 2 — Speaker generality.** The Toloka MOS values are tight per-cell because each cell aggregates 1200 ratings. But the test set is 8 ChiME3 speakers across 4 noise environments. That is enough to estimate MOS *for those speakers in those environments* with confidence; it is not enough to claim generalization across speaker demographics, accents, recording devices, or noise classes outside the four ChiME3 environments. A re-run on a corpus with ≥50 speakers spanning ≥3 accent groups, with noise from at least one corpus other than ChiME3 + MUSAN, reporting MOS variance *across* speakers (not just within), would clarify whether the gap in Table 1 is a global property of the recipe or a property of this specific test slice. The paper's evidence is consistent with either reading.
+
+**Experiment 3 — Cross-architecture transfer.** The paper restricts its claims to speaker-encoder-based TTS and explicitly does not compare against P-Flow or VoiceBox, the contemporaneous flow-matching SOTA. This is a fair scope choice — the paper is making a point about a specific recipe, not staking a SOTA claim. But it leaves the most interesting question unanswered: is the DINO sidecar a *property of speaker encoders* that any system using one would benefit from, or is it a *property of VITS* that does not transfer to other backbones? Grafting the DINO sidecar onto a flow-matching backbone (P-Flow-style speech prompting still uses an internal embedding pathway; you could attach a DINO loss to that) and measuring noise robustness would resolve the question. If it helps, the contribution is general; if not, it is a regularizer specific to VITS-style architectures.
+
+There is a fourth thread worth noting briefly. The HuBERT noise-encoding probe (Section 3.3.2) shows F > 0.97 separability of noisy vs. clean HuBERT features — *separability*, not *invariance*. The paper presents this as evidence the recipe works "because" HuBERT encodes noise. That is a defensible reading of the *mechanism* (the synthesizer learns to associate the noise channel of units with the noise channel of the target), but it is also a yellow flag: a content encoder that explicitly encodes noise is, in principle, the *opposite* of what you would naively want. The reason it works here is the joint training of the synthesizer; the reason it might fail elsewhere is that you depend on that joint training to "absorb" the noise channel into the right output behavior. Replacing VITS with a different decoder could re-expose this dependency.
+
+### Concept Diagram
+
+<svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" role="img" aria-labelledby="defended-not-title">
+  <title id="defended-not-title">What the paper defends versus what remains open after the audit</title>
+  <text x="360" y="24" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">Scope of the contribution: defended vs. open</text>
+  <!-- Defended column -->
+  <rect x="40" y="55" width="300" height="270" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="190" y="78" text-anchor="middle" font-size="13" font-weight="700" fill="#166534">Defended by the data</text>
+  <text x="60" y="110" font-size="12" font-weight="600" fill="#166534">DINO sidecar improves noise robustness</text>
+  <text x="60" y="126" font-size="11" fill="#475569">in the speaker-encoder-based recipe.</text>
+  <text x="60" y="140" font-size="11" fill="#475569">Table 1 + Table 2 ablation, ~10 SEM.</text>
+  <text x="60" y="170" font-size="12" font-weight="600" fill="#166534">DINO and noise aug are additive.</text>
+  <text x="60" y="186" font-size="11" fill="#475569">Each ablation step costs ~0.5 MOS</text>
+  <text x="60" y="200" font-size="11" fill="#475569">in noisy naturalness, independently.</text>
+  <text x="60" y="230" font-size="12" font-weight="600" fill="#166534">HuBERT units beat Whisper-ASR</text>
+  <text x="60" y="246" font-size="11" fill="#475569">when training on noisy data:</text>
+  <text x="60" y="260" font-size="11" fill="#475569">5.04% vs. 24.05% CER on noisy target.</text>
+  <text x="60" y="290" font-size="12" font-weight="600" fill="#166534">Style-encoding improvement</text>
+  <text x="60" y="306" font-size="11" fill="#475569">corroborated by emotion classifier</text>
+  <text x="60" y="320" font-size="11" fill="#475569">probe: +9 pp CREMA-D, +6 pp IEMOCAP.</text>
+  <!-- Open column -->
+  <rect x="380" y="55" width="300" height="270" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="530" y="78" text-anchor="middle" font-size="13" font-weight="700" fill="#991b1b">Open after the audit</text>
+  <text x="400" y="110" font-size="12" font-weight="600" fill="#991b1b">Cross-loss ablation</text>
+  <text x="400" y="126" font-size="11" fill="#475569">Is DINO doing the work, or any</text>
+  <text x="400" y="140" font-size="11" fill="#475569">non-discriminative SSL teacher?</text>
+  <text x="400" y="170" font-size="12" font-weight="600" fill="#991b1b">Speaker / noise generality</text>
+  <text x="400" y="186" font-size="11" fill="#475569">8 ChiME3 speakers + 4 environments</text>
+  <text x="400" y="200" font-size="11" fill="#475569">does not test demographic spread.</text>
+  <text x="400" y="230" font-size="12" font-weight="600" fill="#991b1b">Cross-architecture transfer</text>
+  <text x="400" y="246" font-size="11" fill="#475569">Does the DINO sidecar help when</text>
+  <text x="400" y="260" font-size="11" fill="#475569">grafted onto a P-Flow / VoiceBox backbone?</text>
+  <text x="400" y="290" font-size="12" font-weight="600" fill="#991b1b">Mechanism dependency</text>
+  <text x="400" y="306" font-size="11" fill="#475569">HuBERT separability of noise depends</text>
+  <text x="400" y="320" font-size="11" fill="#475569">on joint training to absorb that channel.</text>
+</svg>
+
+### Key Takeaways
+
+- **The paper's bounded claims survive scrutiny.** Both contributions — DINO sidecar for noisy reference robustness, HuBERT units for noisy training — are well-scoped, statistically supported within their evaluation regime, and ablation-validated. The criticisms below are about *generality*, not about whether the reported numbers are real.
+- **The cross-loss ablation is the highest-leverage open experiment.** If MoCo, BYOL, or SimCLR work just as well in place of DINO, the contribution generalizes to "use any non-discriminative SSL teacher on the speaker encoder" — a much more useful pattern than "use DINO specifically."
+- **Speaker and noise diversity are the bottleneck for generality claims.** Tight per-cell CIs do not generalize across speaker demographics, accents, devices, or noise types outside ChiME3. This is a scoping concern, not a methodological one.
+- **The flow-matching question is the one that decides the recipe's relevance going forward.** P-Flow and VoiceBox are the post-2023 SOTA bracket for zero-shot TTS. Whether the DINO sidecar transfers to that bracket is the question that determines whether DINO-VITS is a polish on a fading recipe or a pattern with legs.
+
+---
+
+## Key Takeaways (Summary)
+
+- **Speaker verification embeddings are too tight for cloning.** AAM-Softmax pretraining clusters every utterance from a speaker into one point, erasing within-speaker variation. The right fix is not to discard verification training but to constrain joint fine-tuning with a soft, label-free auxiliary loss — DINO is one such loss, and the contribution is its cross-domain transfer from vision.
+- **Internalized robustness beats external denoising, in this regime.** Adding DEMUCS in front of YourTTS recovers some of the noise-robustness gap, but does not catch DINO-VITS. The model that learns to handle noise during training outperforms the pipeline that tries to remove noise at inference.
+- **The training-data-noise contribution is independent and possibly more transferable.** HuBERT discrete units, used in place of Whisper-ASR transcripts, give a 5× CER advantage when both training and target are noisy. This is an architectural pattern decoupled from the DINO sidecar; it could transfer to non-VITS backbones unchanged.
+- **The bracket of the claim is "speaker-encoder-based zero-shot TTS."** Not "zero-shot TTS in general." P-Flow and VoiceBox are not compared, the paper acknowledges this, and the open question is whether the DINO sidecar is a property of speaker encoders that transfers to flow-matching backbones, or a regularizer specific to VITS.
+- **Three experiments would close the gap from "clever trick" to "general pattern":** cross-loss ablation (DINO vs. BYOL vs. MoCo), speaker generality (≥50 speakers across accent groups), and cross-architecture transfer (DINO sidecar on P-Flow / VoiceBox). The paper's evidence does not contradict any of those experiments succeeding — but it also does not run them.
+
+---
+
+## References
+
+- Pankov et al. *DINO-VITS: Data-Efficient Zero-Shot TTS with Self-Supervised Speaker Verification Loss for Noise Robustness.* [arXiv:2311.09770v3](https://arxiv.org/abs/2311.09770)
+- Caron et al. *Emerging Properties in Self-Supervised Vision Transformers.* ICCV 2021. [arXiv:2104.14294](https://arxiv.org/abs/2104.14294)
+- Wang et al. *CAM++: A Fast and Efficient Network for Speaker Verification Using Context-Aware Masking.* INTERSPEECH 2023. [arXiv:2303.00332](https://arxiv.org/abs/2303.00332)
+- Kim, Kong, Son. *Conditional Variational Autoencoder with Adversarial Learning for End-to-End Text-to-Speech (VITS).* ICML 2021. [arXiv:2106.06103](https://arxiv.org/abs/2106.06103)
+- Casanova et al. *YourTTS: Towards Zero-Shot Multi-Speaker TTS and Zero-Shot Voice Conversion for Everyone.* ICML 2022. [Proceedings](https://proceedings.mlr.press/v162/casanova22a.html)
+- Kim et al. *P-Flow: A Fast and Data-Efficient Zero-Shot TTS through Speech Prompting.* NeurIPS 2023. [Proceedings](https://proceedings.neurips.cc/paper_files/paper/2023/hash/eb0965da1d2cb3fbbbb8dbbad5fa0bfc-Abstract-Conference.html)
+- Le et al. *Voicebox: Text-Guided Multilingual Universal Speech Generation at Scale.* NeurIPS 2023. [arXiv:2306.15687](https://arxiv.org/abs/2306.15687)
+- Hsu et al. *HuBERT: Self-Supervised Speech Representation Learning by Masked Prediction of Hidden Units.* IEEE/ACM TASLP 2021. [arXiv:2106.07447](https://arxiv.org/abs/2106.07447)
+- Radford et al. *Robust Speech Recognition via Large-Scale Weak Supervision (Whisper).* ICML 2023. [arXiv:2212.04356](https://arxiv.org/abs/2212.04356)
+- Défossez. *Hybrid Spectrogram and Waveform Source Separation (DEMUCS).* MDX Workshop 2021. [HAL](https://hal.archives-ouvertes.fr/hal-03559435)

--- a/docs/superpowers/specs/2026-05-06-dino-vits-blog-design.md
+++ b/docs/superpowers/specs/2026-05-06-dino-vits-blog-design.md
@@ -1,0 +1,153 @@
+# DINO-VITS journal-club blog post — design
+
+**Date:** 2026-05-06
+**Author:** working spec for paper-to-blog execution
+**Target file:** `/app/assets/blogs/0024-dino-vits.md`
+**Source paper:** Pankov et al. (2024), *DINO-VITS: Data-Efficient Zero-Shot TTS with Self-Supervised Speaker Verification Loss for Noise Robustness*, arXiv:2311.09770v3 (Huawei Technologies + ITMO + HSE + SPbU)
+
+---
+
+## Goal
+
+Convert the DINO-VITS paper into a blog post matching the voice and structure of `0017-0020` and `0023`, with an embedded **devil's-advocate critical read** that pushes the paper to its limits constructively (never insultingly).
+
+The post must work as a stand-alone explainer — a smart, capable reader new to noise-robust voice cloning should walk away understanding the *idea*, the *evidence*, and the *legitimate critique* — and as a journal-club artifact that does not hand-wave the limits of the result.
+
+## Non-goals
+
+- Re-deriving the DINO loss from first principles. We summarize, cite Caron et al. (2021), and link to a 25-line reference implementation.
+- Comparing against P-Flow / VoiceBox quantitatively. The paper itself defers this; we flag it as a scope clarification, not a missing experiment.
+- Adding a parametric widget. The paper does not ablate temperature τ, EMA momentum, or noise SNR. A widget against parameters the paper did not probe would dress up speculation as data.
+
+---
+
+## Output structure
+
+| § | Blog section | Source | SVG | Code | Critical inline |
+|---|---|---|---|---|---|
+| 1 | Abstract | Paper Abstract | Architecture overview (4-block pipeline with DINO sidecar on CAM++) | – | rater-clustering / effective-N |
+| 2 | Introduction | Paper §1, extended with field history | Lineage diagram (FastSpeech-era → YourTTS → BYOL-A → DINO-VITS; P-Flow/VoiceBox parallel branch) | – | – |
+| 3 | Method: dual-objective training | Paper §2 | DINO loss schematic (teacher EMA + student, two crops, center subtract, KL) | DINO loss in ~25 lines of PyTorch (with type hints, Google docstring) | "DINO is from vision SSL — the contribution is the cross-domain transfer" |
+| 4 | Results — noisy reference at inference | Paper §3.2 (Tables 1, 2) | Bar comparison: Naturalness/Similarity × Clean/Noisy × {GT, Ours, YT, YTd, BY} | – | speaker diversity (8 speakers, 4 noise environments) |
+| 5 | Results — training from noisy data | Paper §3.3 (Tables 3, 4) | Bar/scatter highlighting Whisper-N CER collapse vs Ours-N | – | "data-efficient" definitional clarification |
+| 6 | Critical Read (synthesis) | – | "What's defended / what isn't" two-column SVG showing scope of contribution | – | full synthesis (see below) |
+| 7 | Key Takeaways | – | – | – | 4–5 insight bullets |
+
+Total: 6 SVGs, 1 code block, 0 widgets, 3 inline `<aside class="critical-read">` call-outs, 1 dedicated synthesis section.
+
+## Devil's-advocate weaving (Hybrid C structure)
+
+Three **inline `<aside class="critical-read">` call-outs**, 1–2 sentences each, placed adjacent to the relevant claim. Pattern: muted left border (CSS in `_components.py`), small font, italic prefix "Critical read:".
+
+One **dedicated synthesis section §6** that reorganizes the audited critiques into three constructive prompts framed as "experiments that would convince me":
+
+1. **Cross-loss ablation.** DINO vs BYOL vs MoCo as the auxiliary speaker-encoder loss. Paper claim: "DINO works." Likely broader truth: "any non-discriminative SSL teacher works."
+2. **Speaker generality.** Re-run on a corpus with ≥50 speakers spanning ≥3 accent groups; report MOS variance *across* speakers, not just within. ChiME3's 8 speakers × 4 environments is the bottleneck.
+3. **Cross-architecture transfer.** Graft the DINO sidecar onto a flow-matching backbone (P-Flow / VoiceBox style). If it still helps, the contribution generalizes; if not, it's a regularizer specific to VITS.
+
+### Audited critique register (post-validation)
+
+These six angles were audited against the PDF before drafting. The audit log:
+
+| # | Original framing | Audit verdict | Final framing in post |
+|---|---|---|---|
+| (a) | "CIs overlap; clean naturalness is a tie" | **Revise** — paper itself states clean is similar; noisy gap (4.07±0.05 vs 3.58±0.05) is ~10 SEM apart and statistically robust | Inline §1: rater-clustering may inflate effective N; the noisy claim survives |
+| (b) | "Small N (8 speakers × 15 refs × 10 raters)" | **Revise** — 1200 ratings give tight CIs; the bottleneck is **speaker / noise diversity** | Inline §4: 8 speakers from one corpus, 4 environments; tight per-condition CIs but limited generalization scope |
+| (c) | "'Zero-shot' misleading" | **Drop** — paper defines it standardly | Not in post |
+| (d) | "'Data-efficient' overclaim" | **Revise** — paper means "uses unlabeled noisy speech," not "less data" | Inline §5: definitional flag, not a critique of overclaim |
+| (e) | "P-Flow / VoiceBox not compared" | **Keep, reframe** — paper acknowledges the limitation in Conclusion | §6 synthesis prompt 3: cross-architecture transfer experiment |
+| (f) | "DINO loss not novel" | **Reframe as orientation** — paper never claims novelty of the loss | §3 framing: cross-domain transfer is the contribution being defended |
+
+## Visual style
+
+- All inline SVGs use `viewBox` (typical 700×400), 3–6 colors from project palette, `role="img"` + `<title>` first child, `<marker>` arrowheads, single-line opening tag.
+- Cover art viewBox `1200×630` (Open Graph aspect).
+- No HTML named entities anywhere — Unicode literals only (`—`, `×`, `→`, `≥`, `±`).
+
+## CSS addition
+
+Add a `.critical-read` rule to `/app/src/styles/_components.py` (concatenated into `FACTORY_CSS`):
+
+```css
+aside.critical-read {
+  border-left: 3px solid var(--muted-border, #cbd5e1);
+  padding: 0.5rem 0.75rem 0.5rem 1rem;
+  margin: 1rem 0;
+  font-size: 0.92em;
+  color: var(--muted-fg, #475569);
+  background: var(--muted-bg, #f8fafc);
+}
+aside.critical-read::before {
+  content: "Critical read: ";
+  font-weight: 600;
+  font-style: italic;
+  color: var(--muted-fg-strong, #334155);
+}
+```
+
+(Final values resolved against existing palette in `_base.py` — substitute concrete hexes if no CSS vars exist.)
+
+## Skill update
+
+Document the call-out pattern in `/app/.claude/skills/paper-to-blog/SKILL.md` so future paper-to-blog work uses the same convention:
+
+- New short subsection under §2.1 ("Intuitive Interpretation") titled "Optional: critical-read inline call-outs" describing the `<aside class="critical-read">` pattern, when to use it (load-bearing claim that survives but has a caveat), and example markup.
+
+## Cover art plan
+
+Generate four candidates in `/app/.claude/skills/paper-to-blog/work/dino-vits/cover-{A,B,C,D}.svg`:
+
+- **A — Geometric abstraction.** Two interlocking waveform crops + KL divergence symbol overlay
+- **B — Schematic.** Stripped-down architecture (CAM++ ↔ VITS with DINO sidecar)
+- **C — Typographic poster.** Big "DINO-VITS" with subtitle + a single hero metric
+- **D — Data-viz hint (primary candidate).** The Whisper-N CER collapse (24.05% vs Ours-N 5.04%) as the visual hook
+
+Per user direction, **D is the primary candidate** and gets the most polish; A/B/C are honest alternates. After review, the chosen cover is written to the path the frontmatter `image` field implies, and the user uploads to GCS.
+
+## Research-lookup plan (pre-Stage 2)
+
+Targeted lookups via the `research-lookup` skill before drafting Stage 2 analyses, to ground background facts in citable sources:
+
+1. DINO (Caron et al. 2021) — title, venue, "centering + sharpening" mechanism
+2. CAM++ — confirm INTERSPEECH 2023, what AAM-Softmax is
+3. VITS (Kim, Kong, Son 2021) — ICML, flow-VAE-GAN hybrid description
+4. YourTTS (Casanova et al. 2022) — ICML, what it does
+5. BYOL-A — confirm Niizumi 2021 audio adaptation of BYOL
+6. P-Flow (Kim et al. 2023) + VoiceBox (Le et al. 2023) — confirm both NeurIPS 2023
+7. HuBERT, MUSAN, RIRS — short identifications
+
+Output: a small references block at the foot of the post (footnote-style links), and inline parenthetical citations the first time each name appears.
+
+## Frontmatter (legacy `@{...}` format)
+
+```
+@{title = "DINO-VITS: A Self-Supervised Sidecar for Noise-Robust Zero-Shot Voice Cloning"
+  date = "2026-05-06T00:00:00Z"
+  tags = ['journal club', 'machine learning', 'arxiv', 'speech synthesis', 'self-supervised learning']
+  views = 0
+  likes = 0
+  image = "https://storage.googleapis.com/gn-portfolio/images/dino-vits-thumb.svg"
+  description = "Pankov et al. attach a DINO self-supervised loss to the speaker encoder of a VITS-based zero-shot TTS system. Noise robustness improves; here is what survives an honest read."
+  type = "note"
+  disabled = false
+}
+```
+
+(No `id` field — minted by `python -m src.cli blog submit`.)
+
+## Validation gates (must pass before claiming done)
+
+1. `python -m src.cli blog submit /app/assets/blogs/0024-dino-vits.md --dry-run` succeeds.
+2. Every `<svg>` has `role="img"` and exactly one `<title>` (counts must match).
+3. Code blocks fenced as `python`.
+4. No `<script>` tags.
+5. No HTML named entities other than `&amp; &lt; &gt; &apos; &quot;`.
+6. No multi-line `<svg ...>` opening tags.
+7. `work/dino-vits/validation_log.md` exists with ≥3 entries documenting fact-check fixes.
+8. The Stage 4 fact/logic pass has been done (every numerical claim, mechanism description, and "the authors X" attribution is verified against the PDF).
+
+## Open risks
+
+- **CSS variable existence.** `_base.py` may not define `--muted-fg` etc.; the spec assumes these or substitutes hexes. Verify on first edit.
+- **Whisper-N comparison fairness.** The paper presents Whisper-N (Whisper trained on noisy data) as a degraded baseline, but Whisper is an ASR system, not a TTS system — the comparison is "use Whisper as the S2U module" vs "use HuBERT as the S2U module". The post must be careful not to imply Whisper itself is the baseline.
+- **Toloka annotator quality** — known concern in the field but the paper doesn't disclose screening procedures. The post mentions this in passing, doesn't dwell on it.

--- a/src/styles/_components.py
+++ b/src/styles/_components.py
@@ -357,4 +357,32 @@ pre.shiki::after, .uk-codeblock::after {
         padding-top: 0;
     }
 }
+
+/* Inline critical-read call-out for journal-club / paper-analysis posts.
+   Used in blog markdown via <aside class="critical-read">...</aside>.
+   See /app/.claude/skills/paper-to-blog for usage convention. */
+aside.critical-read {
+    border-left: 3px solid var(--color-accent-100);
+    padding: 0.6rem 0.9rem 0.6rem 1rem;
+    margin: 1.25rem 0;
+    font-size: 0.92em;
+    line-height: 1.55;
+    color: var(--color-base-300);
+    background: rgba(239, 111, 46, 0.06);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+aside.critical-read::before {
+    content: "Critical read \\2014\\00a0";
+    font-weight: 600;
+    font-style: italic;
+    color: var(--color-accent-100);
+}
+aside.critical-read p {
+    display: inline;
+    margin: 0;
+}
+aside.critical-read p + p {
+    display: block;
+    margin-top: 0.5rem;
+}
 """


### PR DESCRIPTION
## Summary

- Adds two journal-club blog posts and a `.critical-read` aside CSS pattern used by the second one for inline devil's-advocate call-outs.
- **0023** — *Training-Free GRPO* (Youtu-Agent Team 2025, arXiv:2510.08191). Tencent's adaptation of GRPO to a frozen LLM via a natural-language experience buffer; ~\$18 in API spend matches/beats fine-tuned 32B agents.
- **0024** — *DINO-VITS* (Pankov et al. 2024, arXiv:2311.09770v3). Self-supervised DINO loss as a sidecar on the speaker encoder of a VITS-based zero-shot TTS pipeline. 7 sections, 6 inline SVGs, 1 PyTorch reference impl of the DINO loss, three inline `<aside class="critical-read">` call-outs, and a dedicated *Critical Read* synthesis section.
- **CSS** — new `aside.critical-read` rule in [src/styles/_components.py](../blob/feature/0024-dino-vits-blog/src/styles/_components.py) (left orange-accent border, muted background, auto-prefixed "Critical read — ").
- **Spec** — design doc at [docs/superpowers/specs/2026-05-06-dino-vits-blog-design.md](../blob/feature/0024-dino-vits-blog/docs/superpowers/specs/2026-05-06-dino-vits-blog-design.md) capturing brainstormed framing, audited devil's-advocate angles, and validation gates.
- Cover D for 0024 already uploaded to `gs://gn-portfolio/images/dino-vits-thumb.svg`.

## Test plan

- [ ] CI green (ruff + pytest)
- [ ] `python -m src.cli blog submit assets/blogs/0024-dino-vits.md --dry-run` parses and mints id (verified locally — passes)
- [ ] `python -m src.cli blog submit assets/blogs/0023-training-free-grpo.md --dry-run` (0023 already has its `id` in frontmatter, just confirming it still validates)
- [ ] After merge, Cloud Run auto-deploy lands the new posts at https://gabriel.navarro.bio/blogs/0024-dino-vits and /blogs/0023-training-free-grpo
- [ ] Visual check on rendered post — `.critical-read` aside renders with left orange border + muted background + auto prefix

## Validation log (Stage 4 of paper-to-blog)

The 0024 post went through a full Stage 4 fact/logic audit against the source PDF — see `.claude/skills/paper-to-blog/work/dino-vits/validation_log.md` (gitignored, lives outside this PR). Notable fixes during the audit:

- Caught a **table-mixing bug** in the original Abstract: had compared "Ours noisy naturalness 4.07" (Table 2 ablation) to YourTTS values from Table 1; fixed to use Table 1's "Ours = 3.55" when comparing to Table 1 baselines, with explicit attribution.
- Caught an **inherited cherry-pick** in the paper: it claims "+9% emotion-classifier accuracy" but that's only true on CREMA-D (+9.0 pp); IEMOCAP is +6.0 pp. Reported both correctly, named the cherry-pick.
- Verified all bibliographic claims via WebSearch (DINO ICCV 2021, CAM++ INTERSPEECH 2023, P-Flow + VoiceBox NeurIPS 2023).

🤖 Generated with [Claude Code](https://claude.com/claude-code)