### PR TITLE
fix(blog-0024): align frontmatter UUID with the BigQuery row

### DIFF
--- a/assets/blogs/0024-dino-vits.md
+++ b/assets/blogs/0024-dino-vits.md
@@ -1,4 +1,4 @@
-@{id = "7d49b82f-5ce0-4215-8beb-fc569f9a468e"
+@{id = "b805efc1-8155-496e-bc7c-d48eb5bff03e"
   title = "DINO-VITS: A Self-Supervised Sidecar for Noise-Robust Zero-Shot Voice Cloning"
   date = "2026-05-06T00:00:00Z"
   tags = ['journal club', 'machine learning', 'arxiv', 'speech synthesis', 'self-supervised learning']


### PR DESCRIPTION
## Summary

The 0024 DINO-VITS post landed in PR #123 with a frontmatter id of `7d49b82f-...` that was a *dry-run-leaked* UUID — not a real BigQuery row id. Cause: [`_cmd_submit`](https://github.com/gabenavarro/gabriel-navarro-bio/blob/main/src/cli/blog.py#L193) calls `ensure_id(args.path)` unconditionally before the dry-run check, so an earlier `blog submit --dry-run` mutated the working copy and the polluted UUID rode the cherry-pick into the merge.

This PR replaces that stale id with the UUID minted by the real `python -m src.cli blog submit` just now (`b805efc1-8155-496e-bc7c-d48eb5bff03e`), which **does** correspond to a row in `noble-office-299208.portfolio.gn-blog`.

Verified via:

```
$ python -m src.cli blog list | grep DINO-VITS
b805efc1-8155-496e-bc7c-d48eb5bff03e	DINO-VITS: A Self-Supervised Sidecar for Noise-Robust Zero-Shot Voice Cloning	enabled
```

## Notes for follow-up (not in this PR)

- **CLI bug**: `_cmd_submit` should respect `--dry-run` and skip `ensure_id()`. Right now dry-run has side effects (writes id to disk), which is exactly how this id-mismatch happened. Worth a separate `fix(cli-blog)` PR.
- **`disabled` serialization**: the `ensure_id` round-trip writes `disabled = "false"` (string) instead of `disabled = false` (literal bool). Several other posts in `assets/blogs/` already have this; not worth fixing in this PR but worth a separate sweep.

## Test plan

- [ ] CI green
- [ ] Spot-check that the rendered post at https://gabriel.navarro.bio/blogs/0024-dino-vits still loads (BQ row exists; the rendering layer joins on id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)