### PR TITLE
chore(gitignore): ignore .mcp.json local MCP server config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,4 +186,5 @@ cython_debug/
 # Dev environment artifacts (per-developer; not shared)
 .claude/
 .devcontainer/
+.mcp.json
 .playwright-mcp/


### PR DESCRIPTION
## Summary

Adds `.mcp.json` back to the "Dev environment artifacts (per-developer; not shared)" block in `.gitignore`.

## Why

`.mcp.json` holds per-developer MCP server definitions — `playwright`, `context7`, and `deepwiki`, all launched via `npx`, with no secrets or credentials in the file.

It was previously ignored, but was dropped from the list when the ignore block was rewritten to cover `.devcontainer/`. The result is that it shows up as an untracked file in every working copy and can be committed by accident.

This restores it alongside `.claude/` and `.playwright-mcp/`, which are the same category of local tooling config.

## Verification

- `git status` in a synced checkout is clean with this applied (previously showed `?? .mcp.json`)
- No tracked file is affected — `.mcp.json` has never been tracked on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)