### PR TITLE
chore(lint): adopt ruff 0.16 default rule set

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 import argparse
+
 from fasthtml.common import serve
+
 from src.core.app_factory import create_app
 from src.core.routes import register_routes
 

--- a/assets/blogs/0012-flashattn.md
+++ b/assets/blogs/0012-flashattn.md
@@ -71,13 +71,13 @@ We download a minute-resolution Bitcoin CSV from Kaggle, then:
 import pandas as pd, numpy as np
 
 df = pd.read_csv("btc_usd_1-min.csv").sort_values("Timestamp")
-for col in ["Open","High","Low","Close"]:
+for col in ["Open", "High", "Low", "Close"]:
     df[col] = np.log(df[col].clip(lower=0.01))
 df["Volume"] = np.log1p(df["Volume"].clip(lower=0))
 
 # Z-score normalization per feature
 stats = {}
-for feat in ["Open","High","Low","Close","Volume"]:
+for feat in ["Open", "High", "Low", "Close", "Volume"]:
     μ, σ = df[feat].mean(), df[feat].std() or 1.0
     stats[feat] = (μ, σ)
     df[feat] = (df[feat] - μ) / σ
@@ -104,27 +104,32 @@ from flash_attn.modules.mha import MHA
 from flash_attn.ops.rms_norm import RMSNorm
 import torch.nn as nn
 
+
 class TransformerLayer(nn.Module):
     def __init__(self, dim, heads):
         super().__init__()
         self.attn = MHA(dim, heads, causal=True, use_flash_attn=True)
         self.norm1 = RMSNorm(dim)
-        self.mlp   = nn.Sequential(nn.Linear(dim, 4*dim), nn.GELU(), nn.Linear(4*dim, dim))
+        self.mlp = nn.Sequential(nn.Linear(dim, 4 * dim), nn.GELU(), nn.Linear(4 * dim, dim))
         self.norm2 = RMSNorm(dim)
+
     def forward(self, x):
         x = x + self.attn(self.norm1(x))
         x = x + self.mlp(self.norm2(x))
         return x
 
+
 class BTCTransformer(nn.Module):
     def __init__(self):
         super().__init__()
-        self.in_proj  = nn.Linear(5, 64)
-        self.layers   = nn.ModuleList([TransformerLayer(64,8) for _ in range(4)])
+        self.in_proj = nn.Linear(5, 64)
+        self.layers = nn.ModuleList([TransformerLayer(64, 8) for _ in range(4)])
         self.out_proj = nn.Linear(64, 5)
+
     def forward(self, x):
         x = self.in_proj(x)
-        for l in self.layers: x = l(x)
+        for l in self.layers:
+            x = l(x)
         return self.out_proj(x)
 ```
 
@@ -144,11 +149,11 @@ We wrap our model in a `pl.LightningModule` to handle:
 ```python
 trainer = pl.Trainer(
     max_epochs=10,
-    accelerator="gpu", devices=1,
+    accelerator="gpu",
+    devices=1,
     precision="bf16-mixed",
     gradient_clip_val=0.5,
-    callbacks=[EarlyStopping("val_loss", patience=5),
-               ModelCheckpoint(monitor="val_loss")]
+    callbacks=[EarlyStopping("val_loss", patience=5), ModelCheckpoint(monitor="val_loss")],
 )
 trainer.fit(model, train_loader, val_loader)
 ```

--- a/assets/blogs/0013-mambassm.md
+++ b/assets/blogs/0013-mambassm.md
@@ -148,12 +148,15 @@ We leverage **PyTorch Lightning** for:
 ```python
 trainer = pl.Trainer(
     max_epochs=100,
-    accelerator="gpu", devices=1,
+    accelerator="gpu",
+    devices=1,
     precision="bf16-mixed",
     accumulate_grad_batches=8,
     gradient_clip_val=0.5,
-    callbacks=[EarlyStopping("val_loss", patience=10),
-               ModelCheckpoint(monitor="val_loss", save_top_k=1)]
+    callbacks=[
+        EarlyStopping("val_loss", patience=10),
+        ModelCheckpoint(monitor="val_loss", save_top_k=1),
+    ],
 )
 trainer.fit(model, train_loader, val_loader)
 ```

--- a/assets/blogs/0015-flashattn-docker.md
+++ b/assets/blogs/0015-flashattn-docker.md
@@ -212,13 +212,12 @@ HEALTHCHECK --interval=30s --timeout=30s --retries=3 \
 
 	# Vertex AI Configuration
 	SERVICE_KEY_PATH = os.getenv(
-		"GOOGLE_APPLICATION_CREDENTIALS",
-		"/path/to/your/service_account_key.json"
+	    "GOOGLE_APPLICATION_CREDENTIALS", "/path/to/your/service_account_key.json"
 	)
-	LOCATION = "your-gcp-region"         # e.g., "us-central1"
-	ZONE = "your-gcp-zone"               # e.g., "us-central1-a"
-	PROJECT_ID = "your-gcp-project-id"   # e.g., "my-project-12345"
-	RESERVATION_TYPE = "ANY"             # or "ANY_RESERVATION"
+	LOCATION = "your-gcp-region"  # e.g., "us-central1"
+	ZONE = "your-gcp-zone"  # e.g., "us-central1-a"
+	PROJECT_ID = "your-gcp-project-id"  # e.g., "my-project-12345"
+	RESERVATION_TYPE = "ANY"  # or "ANY_RESERVATION"
 	STAGING_BUCKET = "gs://your-gcp-training-bucket/flash-attn-example/staging"
 	SERVICE_ACCOUNT = f"vertex-ai@{PROJECT_ID}.iam.gserviceaccount.com"
 	TRAIN_IMAGE = f"your-location-docker.pkg.dev/{PROJECT_ID}/repositories/flash-attention:latest"
@@ -232,50 +231,43 @@ HEALTHCHECK --interval=30s --timeout=30s --retries=3 \
 
 	# Training Command
 	CMD = [
-		"python3",
-		"/gcs/your-gcp-training-bucket/flash-attn-example/scripts/flash_attn_train.py",
-		"--config",
-		"/gcs/your-gcp-training-bucket/flash-attn-example/config/flash_attn_crypto_model_config.yaml",
+	    "python3",
+	    "/gcs/your-gcp-training-bucket/flash-attn-example/scripts/flash_attn_train.py",
+	    "--config",
+	    "/gcs/your-gcp-training-bucket/flash-attn-example/config/flash_attn_crypto_model_config.yaml",
 	]
 
 	# Worker pool specification
-	worker_pool_specs=[
-		{
-			"replica_count": NODES,
-			"machine_spec": {
-				"machine_type": MACHINE_TYPE,
-				"accelerator_type": ACCELERATOR_TYPE,
-				"accelerator_count": ACCELERATOR_COUNT,
-				"reservation_affinity": {
-					"reservation_affinity_type": RESERVATION_TYPE,
-				}
-			},
-			"container_spec": {
-				"image_uri": TRAIN_IMAGE,
-				"command": CMD
-			}
-		}
+	worker_pool_specs = [
+	    {
+	        "replica_count": NODES,
+	        "machine_spec": {
+	            "machine_type": MACHINE_TYPE,
+	            "accelerator_type": ACCELERATOR_TYPE,
+	            "accelerator_count": ACCELERATOR_COUNT,
+	            "reservation_affinity": {
+	                "reservation_affinity_type": RESERVATION_TYPE,
+	            },
+	        },
+	        "container_spec": {"image_uri": TRAIN_IMAGE, "command": CMD},
+	    }
 	]
 
 	# Initialize Vertex AI
 	aiplatform.init(
-		project=PROJECT_ID,
-		location=LOCATION,
-		credentials=service_account.Credentials.from_service_account_file(
-			SERVICE_KEY_PATH
-		)
+	    project=PROJECT_ID,
+	    location=LOCATION,
+	    credentials=service_account.Credentials.from_service_account_file(SERVICE_KEY_PATH),
 	)
 
 	# Create and submit the training job
 	job = aiplatform.CustomJob(
-		display_name=DISPLAY_NAME,
-		worker_pool_specs=worker_pool_specs,
-		staging_bucket=STAGING_BUCKET,
+	    display_name=DISPLAY_NAME,
+	    worker_pool_specs=worker_pool_specs,
+	    staging_bucket=STAGING_BUCKET,
 	)
 
-	job.submit(
-		service_account=SERVICE_ACCOUNT
-	)
+	job.submit(service_account=SERVICE_ACCOUNT)
 
 	# Print job details
 	print(f"Job ID: {job.resource_name}")

--- a/assets/blogs/0016-vertex-ai-gcp.md
+++ b/assets/blogs/0016-vertex-ai-gcp.md
@@ -125,19 +125,20 @@ from google.oauth2 import service_account
 import os
 
 # ——— Configuration ———
-PROJECT_ID  = "my-project"
-REGION      = "us-central1"
-BUCKET      = "gs://flashattn-example"
-IMAGE_URI   = f"{REGION}-docker.pkg.dev/{PROJECT_ID}/repo/flash-attention:latest"
+PROJECT_ID = "my-project"
+REGION = "us-central1"
+BUCKET = "gs://flashattn-example"
+IMAGE_URI = f"{REGION}-docker.pkg.dev/{PROJECT_ID}/repo/flash-attention:latest"
 SERVICE_KEY = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-SERVICE_ACCT= f"vertex-ai@{PROJECT_ID}.iam.gserviceaccount.com"
-DISPLAY     = "flash-attn-crypto-training"
+SERVICE_ACCT = f"vertex-ai@{PROJECT_ID}.iam.gserviceaccount.com"
+DISPLAY = "flash-attn-crypto-training"
 
 # Command to launch inside container
 CMD = [
     "python3",
     "/gcs/flashattn-example/scripts/flash_attn_train.py",
-    "--config", "/gcs/flashattn-example/config/flash_attn_crypto_model_config.yaml",
+    "--config",
+    "/gcs/flashattn-example/config/flash_attn_crypto_model_config.yaml",
 ]
 
 # GPU machine spec
@@ -148,12 +149,9 @@ worker_pool_specs = [
             "machine_type": "a3-megagpu-8g",
             "accelerator_type": "NVIDIA_H100_MEGA_80GB",
             "accelerator_count": 8,
-            "reservation_affinity": { "reservation_affinity_type": "ANY" }
+            "reservation_affinity": {"reservation_affinity_type": "ANY"},
         },
-        "container_spec": {
-            "image_uri": IMAGE_URI,
-            "command": CMD
-        }
+        "container_spec": {"image_uri": IMAGE_URI, "command": CMD},
     }
 ]
 
@@ -161,14 +159,12 @@ worker_pool_specs = [
 aiplatform.init(
     project=PROJECT_ID,
     location=REGION,
-    credentials=service_account.Credentials.from_service_account_file(SERVICE_KEY)
+    credentials=service_account.Credentials.from_service_account_file(SERVICE_KEY),
 )
 
 # Create & submit the CustomJob
 job = aiplatform.CustomJob(
-    display_name=DISPLAY,
-    worker_pool_specs=worker_pool_specs,
-    staging_bucket=BUCKET + "/staging"
+    display_name=DISPLAY, worker_pool_specs=worker_pool_specs, staging_bucket=BUCKET + "/staging"
 )
 job.submit(service_account=SERVICE_ACCT)
 

--- a/assets/blogs/0017-batch-ml-size.md
+++ b/assets/blogs/0017-batch-ml-size.md
@@ -220,10 +220,9 @@ Here's how to implement the β₂ scaling rule in practice:
 import numpy as np
 from typing import Tuple
 
+
 def compute_beta2_from_halflife(
-    token_halflife: float,
-    batch_size: int,
-    sequence_length: int = 1024
+    token_halflife: float, batch_size: int, sequence_length: int = 1024
 ) -> float:
     """
     Compute β₂ (second moment decay) from desired token half-life.
@@ -257,9 +256,7 @@ def compute_beta2_from_halflife(
 
 
 def scale_beta2_for_new_batch_size(
-    current_beta2: float,
-    current_batch_size: int,
-    new_batch_size: int
+    current_beta2: float, current_batch_size: int, new_batch_size: int
 ) -> float:
     """
     Scale β₂ when changing batch size to maintain constant token half-life.
@@ -284,7 +281,7 @@ def scale_beta2_for_new_batch_size(
     batch_ratio = new_batch_size / current_batch_size
 
     # Scale β₂ by raising to the power of batch ratio
-    new_beta2 = current_beta2 ** batch_ratio
+    new_beta2 = current_beta2**batch_ratio
 
     return float(new_beta2)
 
@@ -292,11 +289,12 @@ def scale_beta2_for_new_batch_size(
 # Practical example: Setting up optimizers for different batch sizes
 # ===================================================================
 
+
 def setup_adam_for_batch_size(
     batch_size: int,
     token_halflife: float = 10_000_000,
     beta1: float = 0.9,
-    learning_rate: float = 0.001
+    learning_rate: float = 0.001,
 ) -> dict:
     """
     Configure Adam hyperparameters for a given batch size.
@@ -318,11 +316,11 @@ def setup_adam_for_batch_size(
     beta2 = compute_beta2_from_halflife(token_halflife, batch_size)
 
     config = {
-        'batch_size': batch_size,
-        'beta1': beta1,
-        'beta2': beta2,
-        'learning_rate': learning_rate,
-        'epsilon': 1e-8,
+        "batch_size": batch_size,
+        "beta1": beta1,
+        "beta2": beta2,
+        "learning_rate": learning_rate,
+        "epsilon": 1e-8,
     }
 
     print(f"Batch Size {batch_size:4d}: β₂ = {beta2:.8f}")
@@ -465,6 +463,7 @@ from typing import Tuple, List
 # Simple 2D optimization problem demonstrating batch size effects
 # ================================================================
 
+
 def loss_function(x: float, y: float) -> float:
     """
     Simple loss function that's steep in y, gradual in x.
@@ -505,12 +504,7 @@ def gradient(x: float, y: float, noise_scale: float = 0.0) -> Tuple[float, float
     return grad_x, grad_y
 
 
-def sgd_step(
-    x: float,
-    y: float,
-    learning_rate: float,
-    noise_scale: float
-) -> Tuple[float, float]:
+def sgd_step(x: float, y: float, learning_rate: float, noise_scale: float) -> Tuple[float, float]:
     """
     Take one SGD step.
 
@@ -531,7 +525,7 @@ def sgd_with_momentum_step(
     vy: float,
     learning_rate: float,
     momentum: float,
-    noise_scale: float
+    noise_scale: float,
 ) -> Tuple[float, float, float, float]:
     """
     Take one SGD step with momentum.
@@ -554,7 +548,7 @@ def sgd_with_momentum_step(
 def run_optimization_experiment(
     batch_size_type: str,  # "large" or "small"
     use_momentum: bool,
-    n_steps: int = 100
+    n_steps: int = 100,
 ) -> List[Tuple[float, float]]:
     """
     Run optimization experiment with specified configuration.
@@ -775,9 +769,11 @@ import numpy as np
 from dataclasses import dataclass
 from typing import Optional
 
+
 @dataclass
 class OptimizerConfig:
     """Configuration for Adam-style optimizer."""
+
     batch_size: int
     learning_rate: float
     beta1: float
@@ -800,7 +796,7 @@ class OptimizerConfig:
 def scale_optimizer_config(
     base_config: OptimizerConfig,
     new_batch_size: int,
-    learning_rate_scale_factor: Optional[float] = None
+    learning_rate_scale_factor: Optional[float] = None,
 ) -> OptimizerConfig:
     """
     Scale optimizer configuration to a new batch size.
@@ -826,7 +822,7 @@ def scale_optimizer_config(
 
     # Rule 2: Scale β₂ to maintain constant token half-life
     # Formula from Equation 2 in paper: β₂* = β₂^(B*/B)
-    new_beta2 = base_config.beta2 ** batch_ratio
+    new_beta2 = base_config.beta2**batch_ratio
 
     # Rule 3: Scale learning rate
     # The paper shows this is NOT sqrt scaling; it's sub-linear
@@ -835,7 +831,7 @@ def scale_optimizer_config(
     if learning_rate_scale_factor is None:
         # Heuristic: scale proportional to batch_ratio^0.3
         # (This is a rough approximation; tune for your use case)
-        learning_rate_scale_factor = batch_ratio ** 0.3
+        learning_rate_scale_factor = batch_ratio**0.3
 
     new_learning_rate = base_config.learning_rate * learning_rate_scale_factor
 
@@ -849,7 +845,7 @@ def scale_optimizer_config(
         learning_rate=new_learning_rate,
         beta1=new_beta1,
         beta2=new_beta2,
-        weight_decay=new_weight_decay
+        weight_decay=new_weight_decay,
     )
 
 
@@ -858,11 +854,7 @@ def scale_optimizer_config(
 
 # Start with GPT-3 baseline from Brown et al.
 gpt3_baseline = OptimizerConfig(
-    batch_size=512,
-    learning_rate=0.001,
-    beta1=0.9,
-    beta2=0.95,
-    weight_decay=0.1
+    batch_size=512, learning_rate=0.001, beta1=0.9, beta2=0.95, weight_decay=0.1
 )
 
 print("GPT-3 Baseline (Brown et al.):")
@@ -873,7 +865,7 @@ print("\n" + "=" * 60 + "\n")
 batch_1_config = scale_optimizer_config(
     gpt3_baseline,
     new_batch_size=1,
-    learning_rate_scale_factor=1.0  # Paper kept LR the same
+    learning_rate_scale_factor=1.0,  # Paper kept LR the same
 )
 
 print("Scaled to Batch Size 1:")
@@ -889,6 +881,7 @@ print(f"Computed: {batch_1_config.beta2:.8f}")
 print(f"Match: {np.isclose(theoretical_beta2, batch_1_config.beta2)}")
 print()
 
+
 # Calculate token half-life to verify it's constant
 def calculate_token_halflife(beta2: float, batch_size: int, seq_len: int = 1024):
     """Calculate token half-life from β₂."""
@@ -896,12 +889,9 @@ def calculate_token_halflife(beta2: float, batch_size: int, seq_len: int = 1024)
     tokens_per_step = batch_size * seq_len
     return steps_to_halflife * tokens_per_step
 
-halflife_baseline = calculate_token_halflife(
-    gpt3_baseline.beta2, gpt3_baseline.batch_size
-)
-halflife_batch1 = calculate_token_halflife(
-    batch_1_config.beta2, batch_1_config.batch_size
-)
+
+halflife_baseline = calculate_token_halflife(gpt3_baseline.beta2, gpt3_baseline.batch_size)
+halflife_batch1 = calculate_token_halflife(batch_1_config.beta2, batch_1_config.batch_size)
 
 print(f"Token half-life (baseline): {halflife_baseline:,.0f} tokens")
 print(f"Token half-life (batch=1):  {halflife_batch1:,.0f} tokens")
@@ -918,9 +908,11 @@ for bs in [1, 4, 16, 64, 256, 512, 1024, 4096]:
     config = scale_optimizer_config(gpt3_baseline, bs)
     halflife = calculate_token_halflife(config.beta2, config.batch_size)
 
-    print(f"BS={bs:4d}: β₂={config.beta2:.6f}, "
-          f"LR={config.learning_rate:.6f}, "
-          f"t₁/₂={halflife:>10,.0f} tokens")
+    print(
+        f"BS={bs:4d}: β₂={config.beta2:.6f}, "
+        f"LR={config.learning_rate:.6f}, "
+        f"t₁/₂={halflife:>10,.0f} tokens"
+    )
 ```
 
 Output:
@@ -1093,6 +1085,7 @@ from dataclasses import dataclass
 @dataclass
 class TrainingMetrics:
     """Track training metrics."""
+
     steps: List[int]
     losses: List[float]
     optimizer_name: str
@@ -1157,7 +1150,7 @@ class Adam(SimpleOptimizer):
         learning_rate: float = 0.001,
         beta1: float = 0.9,
         beta2: float = 0.999,
-        epsilon: float = 1e-8
+        epsilon: float = 1e-8,
     ):
         self.lr = learning_rate
         self.beta1 = beta1
@@ -1191,11 +1184,11 @@ class Adam(SimpleOptimizer):
         self.m = self.beta1 * self.m + (1 - self.beta1) * grads
 
         # Update biased second moment estimate
-        self.v = self.beta2 * self.v + (1 - self.beta2) * (grads ** 2)
+        self.v = self.beta2 * self.v + (1 - self.beta2) * (grads**2)
 
         # Bias correction
-        m_hat = self.m / (1 - self.beta1 ** self.t)
-        v_hat = self.v / (1 - self.beta2 ** self.t)
+        m_hat = self.m / (1 - self.beta1**self.t)
+        v_hat = self.v / (1 - self.beta2**self.t)
 
         # Parameter update
         return params - self.lr * m_hat / (np.sqrt(v_hat) + self.epsilon)
@@ -1203,6 +1196,7 @@ class Adam(SimpleOptimizer):
     def state_size_per_param(self) -> int:
         """Adam stores two floats (m and v) per parameter."""
         return 2
+
 
 def ill_conditioned_loss(params: np.ndarray) -> float:
     """
@@ -1214,7 +1208,8 @@ def ill_conditioned_loss(params: np.ndarray) -> float:
     # Different "eigenvalues" for different dimensions
     # Some dimensions have steep curvature, some have flat
     eigenvalues = np.array([1000, 100, 10, 1, 0.1, 0.01, 0.001, 0.0001, 0.00001, 0.000001])
-    return 0.5 * np.sum(eigenvalues * params ** 2)
+    return 0.5 * np.sum(eigenvalues * params**2)
+
 
 def ill_conditioned_gradient(params: np.ndarray, batch_size: int) -> np.ndarray:
     """Gradient with different curvatures per dimension + noise."""
@@ -1228,6 +1223,7 @@ def ill_conditioned_gradient(params: np.ndarray, batch_size: int) -> np.ndarray:
     noise = np.random.normal(0, noise_scale * 10, size=params.shape)  # Increased noise
 
     return true_grad + noise
+
 
 # Run comparison with better toy problem
 # ======================================

--- a/assets/blogs/0018-generative-lm.md
+++ b/assets/blogs/0018-generative-lm.md
@@ -168,6 +168,7 @@ Here's how you might implement a simple RLM-style processor:
 ```python
 from typing import Callable, Any
 
+
 class SimpleRLM:
     """A simplified RLM that processes long documents recursively."""
 
@@ -203,7 +204,7 @@ class SimpleRLM:
             # Recursive sub-query on each chunk
             sub_prompt = f"""Extract information relevant to: {prompt}
 
-This is chunk {i+1} of {len(chunks)}. Only extract relevant info."""
+This is chunk {i + 1} of {len(chunks)}. Only extract relevant info."""
 
             sub_answer = self.llm_call(f"{sub_prompt}\n\n{chunk}")
             sub_answers.append(sub_answer)
@@ -213,7 +214,7 @@ This is chunk {i+1} of {len(chunks)}. Only extract relevant info."""
 
 I've processed {len(chunks)} chunks. Here are the findings:
 
-{chr(10).join(f"Chunk {i+1}: {ans}" for i, ans in enumerate(sub_answers))}
+{chr(10).join(f"Chunk {i + 1}: {ans}" for i, ans in enumerate(sub_answers))}
 
 Synthesize these to answer the original question."""
 
@@ -221,7 +222,7 @@ Synthesize these to answer the original question."""
 
     def _smart_chunk(self, text: str, max_size: int) -> list[str]:
         """Split text at paragraph boundaries when possible."""
-        paragraphs = text.split('\n\n')
+        paragraphs = text.split("\n\n")
         chunks = []
         current_chunk = []
         current_size = 0
@@ -229,7 +230,7 @@ Synthesize these to answer the original question."""
         for para in paragraphs:
             para_size = len(para)
             if current_size + para_size > max_size and current_chunk:
-                chunks.append('\n\n'.join(current_chunk))
+                chunks.append("\n\n".join(current_chunk))
                 current_chunk = [para]
                 current_size = para_size
             else:
@@ -237,7 +238,7 @@ Synthesize these to answer the original question."""
                 current_size += para_size
 
         if current_chunk:
-            chunks.append('\n\n'.join(current_chunk))
+            chunks.append("\n\n".join(current_chunk))
 
         return chunks
 
@@ -247,10 +248,11 @@ def mock_llm(prompt: str) -> str:
     """Placeholder for actual LLM API call."""
     return "Extracted relevant info..."
 
+
 rlm = SimpleRLM(llm_call=mock_llm, chunk_size=5000)
 answer = rlm.process(
     prompt="What are the key findings about protein folding?",
-    context=ten_million_character_biology_paper  # Can handle this!
+    context=ten_million_character_biology_paper,  # Can handle this!
 )
 ```
 
@@ -427,13 +429,13 @@ festival_keywords = ["festival", "La Union", "celebration", "event"]
 results = {}
 
 # Only examine chunks containing keywords
-for i, chunk in enumerate(context.split('\n')):
+for i, chunk in enumerate(context.split("\n")):
     if any(keyword.lower() in chunk.lower() for keyword in festival_keywords):
         results[i] = chunk
         print(f"Found relevant line {i}: {chunk[:100]}...")
 
 # Step 2: Only send filtered content to sub-LLM
-relevant_context = '\n'.join(results.values())
+relevant_context = "\n".join(results.values())
 answer = llm_query(f"About the festival: {relevant_context}")
 ```
 
@@ -681,6 +683,7 @@ import anthropic
 
 client = anthropic.Anthropic(api_key="your-key")
 
+
 def rlm_process(question: str, long_document: str) -> str:
     """Simple RLM-style processing."""
 
@@ -701,22 +704,22 @@ Think step-by-step and use code to explore the document before answering."""
         model="claude-sonnet-4-20250514",
         max_tokens=4000,
         system=system_prompt,
-        messages=[{
-            "role": "user",
-            "content": f"""Question: {question}
+        messages=[
+            {
+                "role": "user",
+                "content": f"""Question: {question}
 
 The document is available as the 'context' variable.
-Use code to explore it and build your answer."""
-        }]
+Use code to explore it and build your answer.""",
+            }
+        ],
     )
 
     return response.content
 
+
 # Example:
-answer = rlm_process(
-    "What are the main findings?",
-    your_10mb_document
-)
+answer = rlm_process("What are the main findings?", your_10mb_document)
 ```
 
 ---

--- a/assets/blogs/0019-engram-deepseek.md
+++ b/assets/blogs/0019-engram-deepseek.md
@@ -183,24 +183,25 @@ The Problem: Current LLMs use only computation for both!
 import numpy as np
 from typing import List, Tuple, Dict
 
+
 class NgramMemoryLookup:
     """
     Simplified implementation of Engram's core N-gram memory lookup.
     Demonstrates how static patterns can be retrieved via O(1) hashing
     rather than expensive multi-layer reconstruction.
     """
-    
+
     def __init__(
-        self, 
-        vocab_size: int = 128000, 
+        self,
+        vocab_size: int = 128000,
         ngram_orders: List[int] = [2, 3],
         num_heads: int = 8,
         embedding_dim: int = 256,
-        table_size: int = 1000003  # Prime number for better hashing
+        table_size: int = 1000003,  # Prime number for better hashing
     ):
         """
         Initialize the N-gram memory module.
-        
+
         Args:
             vocab_size: Size of vocabulary
             ngram_orders: N-gram orders to use (e.g., [2, 3] for bigrams and trigrams)
@@ -213,28 +214,27 @@ class NgramMemoryLookup:
         self.num_heads = num_heads
         self.embedding_dim_per_head = embedding_dim // num_heads
         self.table_size = table_size
-        
+
         # Initialize embedding tables for each (n-gram order, hash head) pair
         self.embeddings = {}
         for n in ngram_orders:
             for k in range(num_heads):
                 # Each table stores embeddings for this n-gram order and head
-                self.embeddings[(n, k)] = np.random.randn(
-                    table_size, 
-                    self.embedding_dim_per_head
-                ) * 0.01
-        
+                self.embeddings[(n, k)] = (
+                    np.random.randn(table_size, self.embedding_dim_per_head) * 0.01
+                )
+
         # Hash seeds for each head to ensure different collision patterns
         self.hash_seeds = [i * 1000003 for i in range(num_heads)]
-    
+
     def _hash_ngram(self, ngram: Tuple[int, ...], head: int) -> int:
         """
         Hash an n-gram to a table index using multiplicative hashing.
-        
+
         Args:
             ngram: Tuple of token IDs
             head: Hash head index
-            
+
         Returns:
             Index in the hash table
         """
@@ -243,83 +243,75 @@ class NgramMemoryLookup:
         for token_id in ngram:
             hash_val = (hash_val * 31 + token_id) ^ (token_id << 5)
         return hash_val % self.table_size
-    
+
     def lookup_ngrams(self, token_sequence: List[int], position: int) -> np.ndarray:
         """
         Retrieve memory vectors for all n-grams ending at position.
-        
+
         This is the O(1) lookup that replaces multi-layer reconstruction!
-        
+
         Args:
             token_sequence: List of token IDs
             position: Current position in sequence
-            
+
         Returns:
             Concatenated embeddings from all n-grams and heads
         """
         retrieved_embeddings = []
-        
+
         # For each n-gram order (e.g., 2-gram, 3-gram)
         for n in self.ngram_orders:
             # Extract the suffix n-gram ending at this position
             if position >= n - 1:
                 ngram = tuple(token_sequence[position - n + 1 : position + 1])
-                
+
                 # Retrieve from each hash head
                 for k in range(self.num_heads):
                     idx = self._hash_ngram(ngram, k)
                     embedding = self.embeddings[(n, k)][idx]
                     retrieved_embeddings.append(embedding)
-        
+
         # Concatenate all retrieved embeddings
         return np.concatenate(retrieved_embeddings)
-    
+
     def compare_with_traditional(self, entity_tokens: List[int]) -> Dict:
         """
         Compare Engram lookup with traditional multi-layer processing.
-        
+
         Returns:
             Statistics showing the efficiency gain
         """
         # Engram: Single O(1) lookup
         engram_time = 1  # Constant time
         engram_layers = 0  # No layers consumed
-        
+
         # Traditional: Must process through multiple layers
         traditional_layers = len(entity_tokens)  # Roughly 1 layer per token
         traditional_time = traditional_layers * 100  # Arbitrary units
-        
+
         return {
             "entity_length": len(entity_tokens),
             "engram": {
                 "operations": engram_time,
                 "layers_consumed": engram_layers,
-                "depth_freed": traditional_layers
+                "depth_freed": traditional_layers,
             },
             "traditional": {
                 "operations": traditional_time,
                 "layers_consumed": traditional_layers,
-                "depth_freed": 0
+                "depth_freed": 0,
             },
             "speedup": traditional_time / engram_time,
-            "depth_gained": traditional_layers
+            "depth_gained": traditional_layers,
         }
 
+
 # Example: Process "Alexander the Great"
-vocab = {
-    "Alexander": 1001,
-    "the": 42,
-    "Great": 2003,
-    "could": 156,
-    "tame": 5678
-}
+vocab = {"Alexander": 1001, "the": 42, "Great": 2003, "could": 156, "tame": 5678}
 
 # Initialize Engram memory
 engram = NgramMemoryLookup(
-    vocab_size=len(vocab),
-    ngram_orders=[2, 3],
-    num_heads=4,
-    embedding_dim=256
+    vocab_size=len(vocab), ngram_orders=[2, 3], num_heads=4, embedding_dim=256
 )
 
 # Simulate processing the entity
@@ -557,11 +549,12 @@ import numpy as np
 from typing import List, Tuple, Dict
 import hashlib
 
+
 class MultiHeadHashedNgram:
     """
     Multi-head hashing strategy for N-gram embeddings with collision mitigation.
     """
-    
+
     def __init__(
         self,
         vocab_size: int = 128000,
@@ -569,11 +562,11 @@ class MultiHeadHashedNgram:
         ngram_orders: List[int] = [2, 3],
         num_heads: int = 8,
         table_sizes: Dict[int, int] = {2: 1000003, 3: 1500007},  # Prime sizes
-        embedding_dim_per_head: int = 32
+        embedding_dim_per_head: int = 32,
     ):
         """
         Initialize multi-head hashed N-gram embedding system.
-        
+
         Args:
             vocab_size: Original vocabulary size
             compressed_vocab_size: Size after tokenizer compression
@@ -588,34 +581,30 @@ class MultiHeadHashedNgram:
         self.num_heads = num_heads
         self.table_sizes = table_sizes
         self.embedding_dim_per_head = embedding_dim_per_head
-        
+
         # Create tokenizer compression map (simplified)
         self.compression_map = self._create_compression_map()
-        
+
         # Initialize embedding tables: E[n,k][idx] for each (order, head)
         self.embedding_tables = {}
         for n in ngram_orders:
             for k in range(num_heads):
                 table_size = table_sizes[n]
-                self.embedding_tables[(n, k)] = np.random.randn(
-                    table_size,
-                    embedding_dim_per_head
-                ) * 0.01
-        
+                self.embedding_tables[(n, k)] = (
+                    np.random.randn(table_size, embedding_dim_per_head) * 0.01
+                )
+
         # Prime numbers for multiplicative hashing (one per head)
-        self.hash_primes = [
-            1000003, 1500007, 2000003, 2500009,
-            3000017, 3500017, 4000037, 4500007
-        ]
-    
+        self.hash_primes = [1000003, 1500007, 2000003, 2500009, 3000017, 3500017, 4000037, 4500007]
+
     def _create_compression_map(self) -> np.ndarray:
         """
         Create vocabulary compression map.
-        
+
         Simulates mapping variants like "Apple", "apple", " apple" to same ID.
         """
         compression = np.arange(self.vocab_size)
-        
+
         # Simplified: map every group of 3 consecutive tokens to first token
         # (Real implementation uses NFKC normalization + case folding)
         for i in range(0, self.vocab_size, 3):
@@ -623,138 +612,134 @@ class MultiHeadHashedNgram:
                 compression[i + 1] = compression[i]
             if i + 2 < self.vocab_size:
                 compression[i + 2] = compression[i]
-        
+
         return compression
-    
+
     def compress_tokens(self, token_ids: List[int]) -> List[int]:
         """
         Apply tokenizer compression to normalize semantically equivalent tokens.
-        
+
         Args:
             token_ids: Original token IDs
-            
+
         Returns:
             Compressed token IDs
         """
-        return [int(self.compression_map[tid % self.vocab_size]) 
-                for tid in token_ids]
-    
+        return [int(self.compression_map[tid % self.vocab_size]) for tid in token_ids]
+
     def _hash_ngram(self, ngram: Tuple[int, ...], head: int, n: int) -> int:
         """
         Hash an n-gram using multiplicative hashing with XOR mixing.
-        
+
         Args:
             ngram: Tuple of compressed token IDs
             head: Hash head index
             n: N-gram order
-            
+
         Returns:
             Index in hash table for this (n, head) combination
         """
         # Multiplicative hashing: h(x) = ((a·x) mod p) mod m
         hash_val = self.hash_primes[head]
-        
+
         for token_id in ngram:
             # Mix with multiplicative and XOR operations
             hash_val = (hash_val * 31 + token_id) & 0x7FFFFFFF
-            hash_val ^= (token_id << (head + 1))
-        
+            hash_val ^= token_id << (head + 1)
+
         return hash_val % self.table_sizes[n]
-    
+
     def retrieve_embeddings(
-        self, 
-        token_sequence: List[int], 
-        position: int
+        self, token_sequence: List[int], position: int
     ) -> Tuple[np.ndarray, Dict]:
         """
         Retrieve all embeddings for n-grams ending at position.
-        
+
         Args:
             token_sequence: List of token IDs
             position: Current position
-            
+
         Returns:
             concatenated_embeddings: All retrieved embeddings
             debug_info: Information about retrieval for analysis
         """
         # First, apply tokenizer compression
         compressed_tokens = self.compress_tokens(token_sequence)
-        
+
         retrieved_embeddings = []
         debug_info = {"ngrams": [], "hash_indices": []}
-        
+
         # For each n-gram order
         for n in self.ngram_orders:
             if position >= n - 1:
                 # Extract suffix n-gram
                 ngram = tuple(compressed_tokens[position - n + 1 : position + 1])
                 debug_info["ngrams"].append((n, ngram))
-                
+
                 # Retrieve from each hash head
                 head_embeddings = []
                 head_indices = []
                 for k in range(self.num_heads):
                     idx = self._hash_ngram(ngram, k, n)
                     head_indices.append(idx)
-                    
+
                     # Lookup in embedding table
                     embedding = self.embedding_tables[(n, k)][idx]
                     head_embeddings.append(embedding)
-                
+
                 debug_info["hash_indices"].append((n, head_indices))
                 retrieved_embeddings.extend(head_embeddings)
-        
+
         # Concatenate all embeddings
         final_embedding = np.concatenate(retrieved_embeddings)
-        
+
         return final_embedding, debug_info
-    
-    def analyze_collision_probability(
-        self, 
-        sample_ngrams: List[Tuple[int, ...]]
-    ) -> Dict:
+
+    def analyze_collision_probability(self, sample_ngrams: List[Tuple[int, ...]]) -> Dict:
         """
         Analyze collision probability for sample n-grams.
-        
+
         Returns:
             Statistics about hash collisions
         """
         collisions_per_head = {k: 0 for k in range(self.num_heads)}
         total_pairs = len(sample_ngrams) * (len(sample_ngrams) - 1) // 2
-        
+
         n = len(sample_ngrams[0])  # Assume all same order
-        
+
         # Check all pairs
         for i in range(len(sample_ngrams)):
             for j in range(i + 1, len(sample_ngrams)):
                 ngram1 = sample_ngrams[i]
                 ngram2 = sample_ngrams[j]
-                
+
                 # Check each head
                 for k in range(self.num_heads):
                     idx1 = self._hash_ngram(ngram1, k, n)
                     idx2 = self._hash_ngram(ngram2, k, n)
                     if idx1 == idx2:
                         collisions_per_head[k] += 1
-        
+
         # Calculate probability of all heads colliding
         all_heads_collide = sum(
-            1 for i in range(len(sample_ngrams))
+            1
+            for i in range(len(sample_ngrams))
             for j in range(i + 1, len(sample_ngrams))
             if all(
-                self._hash_ngram(sample_ngrams[i], k, n) ==
-                self._hash_ngram(sample_ngrams[j], k, n)
+                self._hash_ngram(sample_ngrams[i], k, n) == self._hash_ngram(sample_ngrams[j], k, n)
                 for k in range(self.num_heads)
             )
         )
-        
+
         return {
             "total_pairs": total_pairs,
             "collisions_per_head": collisions_per_head,
-            "single_head_collision_rate": sum(collisions_per_head.values()) / (total_pairs * self.num_heads),
+            "single_head_collision_rate": sum(collisions_per_head.values())
+            / (total_pairs * self.num_heads),
             "all_heads_collision_count": all_heads_collide,
-            "all_heads_collision_prob": all_heads_collide / total_pairs if total_pairs > 0 else 0
+            "all_heads_collision_prob": all_heads_collide / total_pairs if total_pairs > 0 else 0,
         }
+
 
 # Example usage
 hasher = MultiHeadHashedNgram(
@@ -762,7 +747,7 @@ hasher = MultiHeadHashedNgram(
     compressed_vocab_size=98304,
     ngram_orders=[2, 3],
     num_heads=8,
-    embedding_dim_per_head=32
+    embedding_dim_per_head=32,
 )
 
 # Process sentence: "Only Alexander the Great could"
@@ -772,7 +757,7 @@ sentence_tokens = [45, 1001, 42, 2003, 156]
 print("Original tokens:", sentence_tokens)
 compressed = hasher.compress_tokens(sentence_tokens)
 print("After compression:", compressed)
-print(f"Compression achieved: {(1 - len(set(compressed))/len(set(sentence_tokens)))*100:.1f}%")
+print(f"Compression achieved: {(1 - len(set(compressed)) / len(set(sentence_tokens))) * 100:.1f}%")
 
 # Retrieve at position 3 (after "Alexander the Great")
 embedding, info = hasher.retrieve_embeddings(sentence_tokens, position=3)
@@ -783,9 +768,9 @@ print(f"Hash indices for 3-gram: {info['hash_indices'][1]}")
 # Analyze collision probability
 sample_ngrams = [
     (1001, 42, 2003),  # "Alexander the Great"
-    (5678, 91, 234),   # "Princess of Wales" (hypothetical)
-    (111, 222, 333),   # Random pattern
-    (444, 555, 666),   # Random pattern
+    (5678, 91, 234),  # "Princess of Wales" (hypothetical)
+    (111, 222, 333),  # Random pattern
+    (444, 555, 666),  # Random pattern
 ]
 collision_stats = hasher.analyze_collision_probability(sample_ngrams)
 print(f"\nCollision Analysis:")
@@ -903,23 +888,24 @@ Input:
 import numpy as np
 from typing import Tuple
 
+
 class ContextAwareGating:
     """
     Implements the context-aware gating mechanism that dynamically
     modulates retrieved memory based on semantic alignment with
     current hidden state.
     """
-    
+
     def __init__(
         self,
         hidden_dim: int = 2560,
         memory_dim: int = 256,
         conv_kernel_size: int = 4,
-        conv_dilation: int = 3  # max n-gram order
+        conv_dilation: int = 3,  # max n-gram order
     ):
         """
         Initialize gating module.
-        
+
         Args:
             hidden_dim: Dimension of hidden states from attention
             memory_dim: Dimension of retrieved memory vectors
@@ -930,154 +916,149 @@ class ContextAwareGating:
         self.memory_dim = memory_dim
         self.conv_kernel_size = conv_kernel_size
         self.conv_dilation = conv_dilation
-        
+
         # Key and Value projection matrices
         self.W_K = np.random.randn(memory_dim, hidden_dim) * 0.01
         self.W_V = np.random.randn(memory_dim, hidden_dim) * 0.01
-        
+
         # Convolution kernel (simplified, 1D depthwise)
         self.conv_kernel = np.random.randn(conv_kernel_size, hidden_dim) * 0.01
-    
+
     def rms_norm(self, x: np.ndarray, eps: float = 1e-6) -> np.ndarray:
         """
         Root Mean Square Layer Normalization.
-        
+
         More stable than LayerNorm for large models.
         """
-        rms = np.sqrt(np.mean(x ** 2, axis=-1, keepdims=True) + eps)
+        rms = np.sqrt(np.mean(x**2, axis=-1, keepdims=True) + eps)
         return x / rms
-    
+
     def sigmoid(self, x: np.ndarray) -> np.ndarray:
         """Sigmoid activation for gate."""
         return 1 / (1 + np.exp(-np.clip(x, -10, 10)))
-    
+
     def silu(self, x: np.ndarray) -> np.ndarray:
         """
         SiLU (Swish) activation: x * sigmoid(x).
-        
+
         Smooth, non-monotonic activation that works well for deep networks.
         """
         return x * self.sigmoid(x)
-    
+
     def compute_gate(
-        self, 
+        self,
         hidden_state: np.ndarray,  # h_t, shape: (hidden_dim,)
-        memory: np.ndarray          # e_t, shape: (memory_dim,)
+        memory: np.ndarray,  # e_t, shape: (memory_dim,)
     ) -> float:
         """
         Compute attention-style gate to modulate memory retrieval.
-        
+
         Gate α_t measures semantic alignment between current context
         and retrieved memory. High alignment → use memory strongly.
         Low alignment → suppress (likely collision or wrong context).
-        
+
         Args:
             hidden_state: Current hidden state from attention layer
             memory: Retrieved memory vector from n-gram lookup
-            
+
         Returns:
             Gate value in (0, 1)
         """
         # Normalize both inputs for stability
         h_norm = self.rms_norm(hidden_state)
-        
+
         # Project memory to key space
         key = memory @ self.W_K  # shape: (hidden_dim,)
         k_norm = self.rms_norm(key)
-        
+
         # Scaled dot-product (like attention)
         scale = np.sqrt(self.hidden_dim)
         score = np.dot(h_norm, k_norm) / scale
-        
+
         # Sigmoid to get gate in (0, 1)
         gate = self.sigmoid(score)
-        
+
         return gate
-    
+
     def apply_gating(
-        self,
-        hidden_state: np.ndarray,
-        memory: np.ndarray
+        self, hidden_state: np.ndarray, memory: np.ndarray
     ) -> Tuple[np.ndarray, float]:
         """
         Apply context-aware gating to memory retrieval.
-        
+
         Args:
             hidden_state: Current hidden state
             memory: Retrieved memory vector
-            
+
         Returns:
             gated_value: Memory modulated by gate
             gate: The gate value (for analysis)
         """
         # Compute gate
         gate = self.compute_gate(hidden_state, memory)
-        
+
         # Project memory to value space
         value = memory @ self.W_V
-        
+
         # Modulate by gate
         gated_value = gate * value
-        
+
         return gated_value, gate
-    
+
     def depthwise_conv(
         self,
         sequence: np.ndarray,  # Shape: (seq_len, hidden_dim)
-        position: int
+        position: int,
     ) -> np.ndarray:
         """
         Apply causal depthwise convolution to expand receptive field.
-        
+
         "Depthwise" means each channel is convolved independently.
         "Causal" means only look at past positions, not future.
-        
+
         Args:
             sequence: Full sequence of gated values
             position: Current position
-            
+
         Returns:
             Convolved output at this position
         """
         # Extract causal window (only past positions)
         start = max(0, position - (self.conv_kernel_size - 1) * self.conv_dilation)
         window_positions = [
-            start + i * self.conv_dilation 
+            start + i * self.conv_dilation
             for i in range(self.conv_kernel_size)
             if start + i * self.conv_dilation <= position
         ]
-        
+
         # Get values at these positions
         window = sequence[window_positions]
-        
+
         # Depthwise convolution (simplified)
         if len(window) < self.conv_kernel_size:
             # Pad with zeros if at sequence start
             pad_size = self.conv_kernel_size - len(window)
-            window = np.vstack([
-                np.zeros((pad_size, self.hidden_dim)),
-                window
-            ])
-        
+            window = np.vstack([np.zeros((pad_size, self.hidden_dim)), window])
+
         # Element-wise multiplication and sum (simplified depthwise)
-        conv_out = np.sum(window * self.conv_kernel[:len(window)], axis=0)
-        
+        conv_out = np.sum(window * self.conv_kernel[: len(window)], axis=0)
+
         return conv_out
-    
+
     def forward(
         self,
-        hidden_sequence: np.ndarray,   # (seq_len, hidden_dim)
-        memory_sequence: np.ndarray,   # (seq_len, memory_dim)
-        position: int
+        hidden_sequence: np.ndarray,  # (seq_len, hidden_dim)
+        memory_sequence: np.ndarray,  # (seq_len, memory_dim)
+        position: int,
     ) -> Tuple[np.ndarray, Dict]:
         """
         Full forward pass of context-aware gating.
-        
+
         Args:
             hidden_sequence: Hidden states from attention
             memory_sequence: Retrieved memory vectors
             position: Current position
-            
+
         Returns:
             output: Gated and refined output
             debug_info: Information about gating decisions
@@ -1085,67 +1066,64 @@ class ContextAwareGating:
         # Step 1: Apply gating
         h_t = hidden_sequence[position]
         e_t = memory_sequence[position]
-        
+
         gated_value, gate = self.apply_gating(h_t, e_t)
-        
+
         # Step 2: Apply RMS normalization
         gated_value_norm = self.rms_norm(gated_value)
-        
+
         # Step 3: Depthwise convolution
         # (Need to build sequence of gated values first - simplified here)
         conv_input = gated_value_norm.reshape(1, -1)
         conv_out = self.depthwise_conv(conv_input, 0)
-        
+
         # Step 4: SiLU activation and residual
         output = self.silu(conv_out) + gated_value_norm
-        
+
         debug_info = {
             "gate_value": gate,
             "memory_magnitude": np.linalg.norm(e_t),
             "hidden_magnitude": np.linalg.norm(h_t),
-            "output_magnitude": np.linalg.norm(output)
+            "output_magnitude": np.linalg.norm(output),
         }
-        
+
         return output, debug_info
-    
+
     def visualize_gating_pattern(
-        self,
-        sentence_tokens: list,
-        hidden_states: np.ndarray,
-        memory_vectors: np.ndarray
+        self, sentence_tokens: list, hidden_states: np.ndarray, memory_vectors: np.ndarray
     ) -> Dict:
         """
         Visualize how gating responds to different contexts.
-        
+
         Returns:
             Gating pattern for each token
         """
         pattern = []
-        
+
         for pos in range(len(sentence_tokens)):
             h_t = hidden_states[pos]
             e_t = memory_vectors[pos]
             gate = self.compute_gate(h_t, e_t)
-            
-            pattern.append({
-                "position": pos,
-                "token": sentence_tokens[pos],
-                "gate": gate,
-                "decision": "USE" if gate > 0.5 else "SUPPRESS"
-            })
-        
+
+            pattern.append(
+                {
+                    "position": pos,
+                    "token": sentence_tokens[pos],
+                    "gate": gate,
+                    "decision": "USE" if gate > 0.5 else "SUPPRESS",
+                }
+            )
+
         return {
             "tokens": sentence_tokens,
             "pattern": pattern,
             "mean_gate": np.mean([p["gate"] for p in pattern]),
-            "high_confidence_count": sum(1 for p in pattern if p["gate"] > 0.7)
+            "high_confidence_count": sum(1 for p in pattern if p["gate"] > 0.7),
         }
 
+
 # Example usage
-gating = ContextAwareGating(
-    hidden_dim=2560,
-    memory_dim=256
-)
+gating = ContextAwareGating(hidden_dim=2560, memory_dim=256)
 
 # Simulate scenario 1: Correct retrieval
 # Hidden state encodes "Alexander" + royal context
@@ -1329,21 +1307,22 @@ import numpy as np
 from typing import Dict, List, Tuple
 import matplotlib.pyplot as plt
 
+
 class SparsityAllocationAnalyzer:
     """
     Simulate the sparsity allocation trade-off between MoE and Engram
     to find optimal parameter distribution.
     """
-    
+
     def __init__(
         self,
-        total_params: float = 10e9,      # 10B total
-        active_params: float = 1e9,      # 1B active (determines FLOPs)
-        base_loss: float = 1.80          # Starting loss
+        total_params: float = 10e9,  # 10B total
+        active_params: float = 1e9,  # 1B active (determines FLOPs)
+        base_loss: float = 1.80,  # Starting loss
     ):
         """
         Initialize analyzer with parameter budget.
-        
+
         Args:
             total_params: Total parameter count
             active_params: Activated parameters per token
@@ -1353,35 +1332,31 @@ class SparsityAllocationAnalyzer:
         self.active_params = active_params
         self.sparse_params = total_params - active_params
         self.base_loss = base_loss
-    
-    def compute_loss_at_allocation(
-        self, 
-        rho: float,
-        compute_budget: float = 6e20
-    ) -> float:
+
+    def compute_loss_at_allocation(self, rho: float, compute_budget: float = 6e20) -> float:
         """
         Simulate validation loss for a given allocation ratio.
-        
+
         This is a simplified model that captures the U-shaped relationship.
         Real experiments use actual training!
-        
+
         Args:
             rho: Allocation ratio (0-1), fraction to MoE
             compute_budget: Training FLOPs
-            
+
         Returns:
             Predicted validation loss
         """
         # MoE capacity (number of experts increases with rho)
         moe_params = rho * self.sparse_params
         num_experts = max(1, int(moe_params / 1e8))  # ~100M per expert
-        
+
         # Engram capacity (embedding slots increase with 1-rho)
         memory_params = (1 - rho) * self.sparse_params
         memory_slots = max(1000, int(memory_params / 1000))  # ~1K per slot
-        
+
         # Loss components (simplified model)
-        
+
         # 1. MoE benefit: log(num_experts) / log(max_experts)
         #    More experts → better specialization
         max_experts = int(self.sparse_params / 1e8)
@@ -1389,7 +1364,7 @@ class SparsityAllocationAnalyzer:
             moe_benefit = np.log(num_experts) / np.log(max_experts)
         else:
             moe_benefit = 0
-        
+
         # 2. Memory benefit: log(memory_slots) / log(max_slots)
         #    More memory → better pattern coverage
         max_slots = int(self.sparse_params / 1000)
@@ -1397,55 +1372,51 @@ class SparsityAllocationAnalyzer:
             memory_benefit = np.log(memory_slots) / np.log(max_slots)
         else:
             memory_benefit = 0
-        
+
         # 3. Synergy term: MoE and memory complement each other
         #    Peak synergy at ~75-80% MoE allocation
         optimal_rho = 0.77
-        synergy = np.exp(-10 * (rho - optimal_rho)**2)
-        
+        synergy = np.exp(-10 * (rho - optimal_rho) ** 2)
+
         # Combine effects (U-shaped due to synergy term)
         total_benefit = (
-            0.4 * moe_benefit +      # Conditional computation
-            0.4 * memory_benefit +   # Conditional memory
-            0.2 * synergy            # Synergy between both
+            0.4 * moe_benefit  # Conditional computation
+            + 0.4 * memory_benefit  # Conditional memory
+            + 0.2 * synergy  # Synergy between both
         )
-        
+
         # Final loss
         loss = self.base_loss * (1 - 0.08 * total_benefit)
-        
+
         return loss
-    
-    def sweep_allocation_ratios(
-        self,
-        compute_budget: float = 6e20,
-        num_points: int = 20
-    ) -> Dict:
+
+    def sweep_allocation_ratios(self, compute_budget: float = 6e20, num_points: int = 20) -> Dict:
         """
         Sweep allocation ratios to find optimal distribution.
-        
+
         Args:
             compute_budget: Training FLOPs
             num_points: Number of points to sample
-            
+
         Returns:
             Results dictionary with losses and optimal point
         """
         ratios = np.linspace(0.1, 1.0, num_points)
         losses = []
-        
+
         for rho in ratios:
             loss = self.compute_loss_at_allocation(rho, compute_budget)
             losses.append(loss)
-        
+
         # Find optimal
         optimal_idx = np.argmin(losses)
         optimal_rho = ratios[optimal_idx]
         optimal_loss = losses[optimal_idx]
-        
+
         # Pure baselines
         pure_moe_loss = self.compute_loss_at_allocation(1.0, compute_budget)
         pure_memory_loss = self.compute_loss_at_allocation(0.0, compute_budget)
-        
+
         return {
             "ratios": ratios,
             "losses": losses,
@@ -1454,105 +1425,112 @@ class SparsityAllocationAnalyzer:
             "pure_moe_loss": pure_moe_loss,
             "pure_memory_loss": pure_memory_loss,
             "improvement_over_moe": pure_moe_loss - optimal_loss,
-            "improvement_over_memory": pure_memory_loss - optimal_loss
+            "improvement_over_memory": pure_memory_loss - optimal_loss,
         }
-    
-    def analyze_infinite_memory_regime(
-        self,
-        memory_slots_range: List[int]
-    ) -> Dict:
+
+    def analyze_infinite_memory_regime(self, memory_slots_range: List[int]) -> Dict:
         """
         Analyze scaling behavior when memory budget is unconstrained.
-        
+
         Args:
             memory_slots_range: Range of memory slots to test
-            
+
         Returns:
             Scaling results showing log-linear relationship
         """
         losses = []
-        
+
         for slots in memory_slots_range:
             # Fixed MoE backbone, varying memory only
             fixed_moe_params = 3e9  # 3B parameters in MoE
             memory_params = slots * 1000  # ~1K per slot
-            
+
             total = fixed_moe_params + memory_params
-            
+
             # Loss decreases log-linearly with memory slots
             memory_benefit = np.log(slots) / np.log(memory_slots_range[-1])
             loss = self.base_loss * (1 - 0.05 * memory_benefit)
-            
+
             losses.append(loss)
-        
+
         # Compute scaling coefficient (slope in log space)
         log_slots = np.log10(memory_slots_range)
         slope = (losses[0] - losses[-1]) / (log_slots[-1] - log_slots[0])
-        
+
         return {
             "memory_slots": memory_slots_range,
             "losses": losses,
             "scaling_coefficient": slope,
-            "log_linear": True  # Memory exhibits log-linear scaling
+            "log_linear": True,  # Memory exhibits log-linear scaling
         }
-    
+
     def visualize_allocation_law(self, results: Dict):
         """
         Visualize the U-shaped allocation law.
         """
         plt.figure(figsize=(10, 6))
-        
-        plt.plot(results["ratios"] * 100, results["losses"], 
-                'b-', linewidth=2, label='Hybrid Models')
-        
+
+        plt.plot(
+            results["ratios"] * 100, results["losses"], "b-", linewidth=2, label="Hybrid Models"
+        )
+
         # Mark optimal point
-        plt.plot(results["optimal_rho"] * 100, results["optimal_loss"],
-                'ro', markersize=10, label=f'Optimal (ρ={results["optimal_rho"]:.2f})')
-        
+        plt.plot(
+            results["optimal_rho"] * 100,
+            results["optimal_loss"],
+            "ro",
+            markersize=10,
+            label=f"Optimal (ρ={results['optimal_rho']:.2f})",
+        )
+
         # Mark pure baselines
-        plt.axhline(y=results["pure_moe_loss"], color='g', linestyle='--',
-                   label='Pure MoE (ρ=1.0)')
-        plt.axhline(y=results["pure_memory_loss"], color='orange', linestyle='--',
-                   label='Pure Memory (ρ=0.0)')
-        
-        plt.xlabel('MoE Allocation Ratio ρ (%)', fontsize=12)
-        plt.ylabel('Validation Loss', fontsize=12)
-        plt.title('U-Shaped Scaling Law: Optimal Sparsity Allocation', fontsize=14)
+        plt.axhline(y=results["pure_moe_loss"], color="g", linestyle="--", label="Pure MoE (ρ=1.0)")
+        plt.axhline(
+            y=results["pure_memory_loss"],
+            color="orange",
+            linestyle="--",
+            label="Pure Memory (ρ=0.0)",
+        )
+
+        plt.xlabel("MoE Allocation Ratio ρ (%)", fontsize=12)
+        plt.ylabel("Validation Loss", fontsize=12)
+        plt.title("U-Shaped Scaling Law: Optimal Sparsity Allocation", fontsize=14)
         plt.legend(fontsize=10)
         plt.grid(True, alpha=0.3)
-        
+
         # Add annotation
         plt.annotate(
-            f'Δ = {results["improvement_over_moe"]:.4f}\nvs Pure MoE',
+            f"Δ = {results['improvement_over_moe']:.4f}\nvs Pure MoE",
             xy=(results["optimal_rho"] * 100, results["optimal_loss"]),
             xytext=(results["optimal_rho"] * 100 - 15, results["optimal_loss"] + 0.01),
-            arrowprops=dict(arrowstyle='->', color='red', lw=1.5),
-            fontsize=10
+            arrowprops=dict(arrowstyle="->", color="red", lw=1.5),
+            fontsize=10,
         )
-        
+
         plt.tight_layout()
-        plt.savefig('/home/claude/allocation_law.png', dpi=150)
+        plt.savefig("/home/claude/allocation_law.png", dpi=150)
         print("✓ Saved visualization to allocation_law.png")
 
+
 # Run analysis
-analyzer = SparsityAllocationAnalyzer(
-    total_params=10e9,
-    active_params=1e9,
-    base_loss=1.73
-)
+analyzer = SparsityAllocationAnalyzer(total_params=10e9, active_params=1e9, base_loss=1.73)
 
 # Sweep allocation ratios
 results = analyzer.sweep_allocation_ratios(compute_budget=6e20, num_points=30)
 
 print("=== Sparsity Allocation Analysis ===\n")
 print(f"Optimal Allocation Ratio (ρ): {results['optimal_rho']:.3f}")
-print(f"  → {results['optimal_rho']*100:.1f}% to MoE")
-print(f"  → {(1-results['optimal_rho'])*100:.1f}% to Engram")
+print(f"  → {results['optimal_rho'] * 100:.1f}% to MoE")
+print(f"  → {(1 - results['optimal_rho']) * 100:.1f}% to Engram")
 print(f"\nOptimal Loss: {results['optimal_loss']:.4f}")
 print(f"Pure MoE Loss: {results['pure_moe_loss']:.4f}")
 print(f"Pure Memory Loss: {results['pure_memory_loss']:.4f}")
-print(f"\nImprovement over Pure MoE: {results['improvement_over_moe']:.4f} ({(results['improvement_over_moe']/results['pure_moe_loss']*100):.2f}%)")
-print(f"Improvement over Pure Memory: {results['improvement_over_memory']:.4f} ({(results['improvement_over_memory']/results['pure_memory_loss']*100):.2f}%)")
+print(
+    f"\nImprovement over Pure MoE: {results['improvement_over_moe']:.4f} ({(results['improvement_over_moe'] / results['pure_moe_loss'] * 100):.2f}%)"
+)
+print(
+    f"Improvement over Pure Memory: {results['improvement_over_memory']:.4f} ({(results['improvement_over_memory'] / results['pure_memory_loss'] * 100):.2f}%)"
+)
 
 # Analyze infinite memory regime
 memory_slots = [int(10**x) for x in np.linspace(5, 8, 10)]  # 100K to 100M

--- a/assets/blogs/0020-fm-purturb.md
+++ b/assets/blogs/0020-fm-purturb.md
@@ -243,11 +243,12 @@ Remarkably, on the K562 cell line, the best single embedding closes 77% of the g
 import numpy as np
 from typing import Dict, List, Tuple
 
+
 def knn_perturbation_prediction(
-    train_embeddings: np.ndarray,   # (N_train, d) - embeddings of training perturbations
-    train_lfc: np.ndarray,          # (N_train, G) - observed LFC for training perturbations
-    test_embeddings: np.ndarray,    # (N_test, d)  - embeddings of test perturbations
-    k: int = 20
+    train_embeddings: np.ndarray,  # (N_train, d) - embeddings of training perturbations
+    train_lfc: np.ndarray,  # (N_train, G) - observed LFC for training perturbations
+    test_embeddings: np.ndarray,  # (N_test, d)  - embeddings of test perturbations
+    k: int = 20,
 ) -> np.ndarray:
     """
     Predict perturbation response using kNN in embedding space.
@@ -279,6 +280,7 @@ def knn_perturbation_prediction(
         predictions.append(predicted_lfc)
 
     return np.array(predictions)
+
 
 # Example: evaluate with L2 error
 def evaluate_l2(true_lfc: np.ndarray, pred_lfc: np.ndarray) -> float:
@@ -354,11 +356,12 @@ The takeaway is sobering: current perturbation datasets may be too small to reli
 import numpy as np
 from typing import Optional
 
+
 def in_silico_ko_prediction(
     control_expression: np.ndarray,  # (G,) mean expression of control cells
-    target_gene_idx: int,            # index of knocked-out gene
-    encoder_fn,                      # FM encoder: (G,) → (G, d)
-    prediction_head_fn               # head: (d,) → (G,)
+    target_gene_idx: int,  # index of knocked-out gene
+    encoder_fn,  # FM encoder: (G,) → (G, d)
+    prediction_head_fn,  # head: (d,) → (G,)
 ) -> np.ndarray:
     """
     In-Silico Knockout: mask the target gene, encode with FM,
@@ -635,17 +638,23 @@ However, fusion did not help for chemical perturbations, likely because individu
 import numpy as np
 from typing import List, Dict, Optional
 
+
 class EmbeddingFusionModel:
     """
     Simplified attention-based fusion of multiple FM embeddings.
-    
-    Each perturbation is represented by J embeddings from different 
-    FMs. A transformer learns to attend across these sources and 
+
+    Each perturbation is represented by J embeddings from different
+    FMs. A transformer learns to attend across these sources and
     produce a unified prediction.
     """
-    
-    def __init__(self, embedding_dims: List[int], common_dim: int = 100,
-                 n_heads: int = 5, n_genes: int = 1000):
+
+    def __init__(
+        self,
+        embedding_dims: List[int],
+        common_dim: int = 100,
+        n_heads: int = 5,
+        n_genes: int = 1000,
+    ):
         """
         Args:
             embedding_dims: Dimension of each source embedding
@@ -655,52 +664,42 @@ class EmbeddingFusionModel:
         """
         self.common_dim = common_dim
         self.n_sources = len(embedding_dims)
-        
+
         # Per-source projection matrices: map each to common_dim
-        self.projections = [
-            np.random.randn(d, common_dim) * 0.1
-            for d in embedding_dims
-        ]
-        
+        self.projections = [np.random.randn(d, common_dim) * 0.1 for d in embedding_dims]
+
         # Learnable cell line embeddings
         self.cell_line_embeddings: Dict[str, np.ndarray] = {}
-        
+
         # Prediction head weights (simplified)
         self.pred_weights = np.random.randn(common_dim, n_genes) * 0.01
-    
-    def project_embeddings(
-        self, 
-        embeddings: List[Optional[np.ndarray]]
-    ) -> np.ndarray:
+
+    def project_embeddings(self, embeddings: List[Optional[np.ndarray]]) -> np.ndarray:
         """
         Project each source embedding to the common space.
         Handles missing embeddings (not all sources cover all genes).
-        
+
         Returns:
             tokens: (n_valid + 1, common_dim) including CLS token
         """
         tokens = []
-        
+
         # CLS token for aggregation
         cls_token = np.zeros(self.common_dim)
         tokens.append(cls_token)
-        
+
         # Project each available embedding
         for i, emb in enumerate(embeddings):
             if emb is not None:
                 projected = emb @ self.projections[i]
                 tokens.append(projected)
-        
+
         return np.array(tokens)  # (n_tokens, common_dim)
-    
-    def predict(
-        self, 
-        embeddings: List[Optional[np.ndarray]],
-        cell_line: str
-    ) -> np.ndarray:
+
+    def predict(self, embeddings: List[Optional[np.ndarray]], cell_line: str) -> np.ndarray:
         """
         Predict LFC by fusing all available embeddings.
-        
+
         Returns:
             predicted_lfc: (n_genes,) vector
         """
@@ -708,14 +707,14 @@ class EmbeddingFusionModel:
         tokens = self.project_embeddings(embeddings)
         if cell_line in self.cell_line_embeddings:
             tokens += self.cell_line_embeddings[cell_line]
-        
+
         # Step 2: Self-attention (simplified as mean for illustration)
         # In practice: multi-head self-attention transformer layers
         cls_output = tokens.mean(axis=0)  # (common_dim,)
-        
+
         # Step 3: Predict LFC from CLS output
         predicted_lfc = cls_output @ self.pred_weights  # (n_genes,)
-        
+
         return predicted_lfc
 ```
 
@@ -785,12 +784,13 @@ The primary evaluation metric is the L2 error between predicted and observed LFC
 import numpy as np
 from typing import Dict, List
 
+
 def compute_batch_aware_ate(
-    expression_matrix: np.ndarray,       # (N, G) normalized expression
-    cell_labels: np.ndarray,             # (N,) perturbation ID or 'ctrl'
-    batch_labels: np.ndarray,            # (N,) batch assignment
+    expression_matrix: np.ndarray,  # (N, G) normalized expression
+    cell_labels: np.ndarray,  # (N,) perturbation ID or 'ctrl'
+    batch_labels: np.ndarray,  # (N,) batch assignment
     perturbation_id: str,
-    use_global_control: bool = False     # True for small-batch datasets
+    use_global_control: bool = False,  # True for small-batch datasets
 ) -> np.ndarray:
     """
     Compute Batch-Aware Average Treatment Effect (BA-ATE).
@@ -808,18 +808,21 @@ def compute_batch_aware_ate(
     Returns:
         lfc: (G,) vector of per-gene treatment effects
     """
-    ctrl_mask = cell_labels == 'ctrl'
+    ctrl_mask = cell_labels == "ctrl"
     pert_mask = cell_labels == perturbation_id
     G = expression_matrix.shape[1]
 
     if use_global_control:
         # Small-batch mode: compute global control mean
         batches = np.unique(batch_labels)
-        global_ctrl = np.mean([
-            expression_matrix[ctrl_mask & (batch_labels == b)].mean(axis=0)
-            for b in batches
-            if np.any(ctrl_mask & (batch_labels == b))
-        ], axis=0)
+        global_ctrl = np.mean(
+            [
+                expression_matrix[ctrl_mask & (batch_labels == b)].mean(axis=0)
+                for b in batches
+                if np.any(ctrl_mask & (batch_labels == b))
+            ],
+            axis=0,
+        )
 
     # Find batches containing both control and perturbed cells
     valid_batches = []

--- a/assets/blogs/0021-portello.md
+++ b/assets/blogs/0021-portello.md
@@ -414,8 +414,8 @@ class CountsBP(TypedDict):
 
 
 def basecall_error_reduction(
-    pbmm2: CountsBP,    # FN/FP from conventional read mapping
-    portello: CountsBP, # FN/FP from assembly-based remapping
+    pbmm2: CountsBP,  # FN/FP from conventional read mapping
+    portello: CountsBP,  # FN/FP from assembly-based remapping
 ) -> dict[str, float]:
     """Fraction of small-variant basecall errors removed by switching mapper.
 
@@ -429,7 +429,7 @@ def basecall_error_reduction(
     precision-driven.
     """
     # Step 1: total errors per arm
-    err_pbmm2    = pbmm2["fn"]    + pbmm2["fp"]
+    err_pbmm2 = pbmm2["fn"] + pbmm2["fp"]
     err_portello = portello["fn"] + portello["fp"]
 
     # Step 2: relative reduction (positive = portello better)
@@ -444,7 +444,7 @@ def basecall_error_reduction(
 
 # HG002 numbers from Table S1, BASEPAIR row
 hg002 = basecall_error_reduction(
-    pbmm2   ={"fn": 326_253, "fp": 49_381},
+    pbmm2={"fn": 326_253, "fp": 49_381},
     portello={"fn": 156_775, "fp": 42_593},
 )
 # {'total_reduction': 0.469..., 'fn_reduction': 0.519..., 'fp_reduction': 0.137...}
@@ -637,8 +637,8 @@ import numpy as np
 
 
 def transfer_read_alignment(
-    read_to_contig: np.ndarray,   # (L, 2) — (read_pos, contig_pos) per matched base
-    contig_to_ref: np.ndarray,    # (M, 2) — (contig_pos, ref_pos) per matched base
+    read_to_contig: np.ndarray,  # (L, 2) — (read_pos, contig_pos) per matched base
+    contig_to_ref: np.ndarray,  # (M, 2) — (contig_pos, ref_pos) per matched base
 ) -> np.ndarray:
     """Compose read->contig and contig->reference into read->reference.
 

--- a/assets/blogs/0022-spike-sparse-sink-anatomy-massive.md
+++ b/assets/blogs/0022-spike-sparse-sink-anatomy-massive.md
@@ -418,6 +418,7 @@ A minimal sketch of the directional quadratic amplifier — the part of SwiGLU t
 import torch
 import torch.nn as nn
 
+
 class DirectionalQuadraticAmplifier(nn.Module):
     """SwiGLU FFN, simplified to the regime that produces massive activations.
 
@@ -431,14 +432,14 @@ class DirectionalQuadraticAmplifier(nn.Module):
     def __init__(self, d_model: int, d_ffn: int):
         super().__init__()
         self.W_gate = nn.Linear(d_model, d_ffn, bias=False)
-        self.W_up   = nn.Linear(d_model, d_ffn, bias=False)
+        self.W_up = nn.Linear(d_model, d_ffn, bias=False)
         self.W_down = nn.Linear(d_ffn, d_model, bias=False)
 
     def forward(self, h: torch.Tensor) -> torch.Tensor:
         # h shape: (batch, seq, d_model). Each output channel k will end up
         # behaving like a quadratic form h^T S_k h.
         gate = self.W_gate(h)
-        up   = self.W_up(h)
+        up = self.W_up(h)
 
         # SwiGLU normally applies SiLU here; for spike tokens it is
         # near-identity, so the multiplicative gate is the dominant nonlinearity.

--- a/assets/blogs/0023-training-free-grpo.md
+++ b/assets/blogs/0023-training-free-grpo.md
@@ -364,6 +364,7 @@ A minimal sketch of the inner loop. This is a faithful translation of the paper'
 ```python
 from dataclasses import dataclass, field
 
+
 @dataclass
 class TrainingFreeGRPO:
     """One epoch of Training-Free GRPO over a small training set.
@@ -375,9 +376,10 @@ class TrainingFreeGRPO:
     The buffer E starts empty and grows into a few-dozen-line block
     of natural-language lessons that the next epoch's rollouts read.
     """
-    llm: "LLM"                              # frontier API client
-    reward_fn: callable                     # scores one trajectory
-    group_size: int = 5                     # paper used G=5 (math), G=3 (web)
+
+    llm: "LLM"  # frontier API client
+    reward_fn: callable  # scores one trajectory
+    group_size: int = 5  # paper used G=5 (math), G=3 (web)
     experience: list[str] = field(default_factory=list)
 
     def step(self, query: str, ground_truth: str) -> None:
@@ -414,17 +416,21 @@ class TrainingFreeGRPO:
     def _render_buffer(self) -> str:
         if not self.experience:
             return ""
-        lines = "\n".join(f"[{i+1}] {e}" for i, e in enumerate(self.experience))
+        lines = "\n".join(f"[{i + 1}] {e}" for i, e in enumerate(self.experience))
         return f"Useful experiences from prior problems:\n{lines}"
 
     def _apply(self, ops: list[dict]) -> None:
         # ops example: [{"type": "add", "text": "Verify rectangle..."}, ...]
         for op in ops:
             match op["type"]:
-                case "add":    self.experience.append(op["text"])
-                case "delete": self.experience.pop(op["index"])
-                case "modify": self.experience[op["index"]] = op["text"]
-                case "keep":   pass
+                case "add":
+                    self.experience.append(op["text"])
+                case "delete":
+                    self.experience.pop(op["index"])
+                case "modify":
+                    self.experience[op["index"]] = op["text"]
+                case "keep":
+                    pass
 ```
 
 ### Key Takeaways

--- a/assets/blogs/0024-dino-vits.md
+++ b/assets/blogs/0024-dino-vits.md
@@ -337,9 +337,7 @@ class DinoSpeakerLoss(nn.Module):
         loss = -(teacher_probs * student_log_probs).sum(dim=-1).mean()
         # Update center as EMA over the batch mean of (un-centered) teacher outputs.
         batch_center = teacher_out.detach().mean(dim=0, keepdim=True)
-        self.center.mul_(self.center_momentum).add_(
-            batch_center, alpha=1.0 - self.center_momentum
-        )
+        self.center.mul_(self.center_momentum).add_(batch_center, alpha=1.0 - self.center_momentum)
         return loss
 ```
 

--- a/docs/superpowers/plans/2026-04-30-blog-html-pipeline.md
+++ b/docs/superpowers/plans/2026-04-30-blog-html-pipeline.md
@@ -55,6 +55,7 @@
 `tests/test_blog_lint.py`:
 ```python
 """Tests for src.services.blog_lint."""
+
 import pytest
 
 from src.services.blog_lint import LintError, LintFix, lint_body
@@ -205,24 +206,48 @@ import re
 # entities (amp/lt/gt/apos/quot) are intentionally absent — they're valid in
 # both XML and HTML and do not need substitution.
 ENTITY_MAP: dict[str, str] = {
-    "mdash": "—", "ndash": "–",
-    "middot": "·", "bull": "•",
-    "times": "×", "divide": "÷",
-    "plusmn": "±", "minus": "−",
-    "rarr": "→", "larr": "←",
-    "uarr": "↑", "darr": "↓", "harr": "↔",
+    "mdash": "—",
+    "ndash": "–",
+    "middot": "·",
+    "bull": "•",
+    "times": "×",
+    "divide": "÷",
+    "plusmn": "±",
+    "minus": "−",
+    "rarr": "→",
+    "larr": "←",
+    "uarr": "↑",
+    "darr": "↓",
+    "harr": "↔",
     "hellip": "…",
-    "asymp": "≈", "ne": "≠",
-    "ge": "≥", "le": "≤",
+    "asymp": "≈",
+    "ne": "≠",
+    "ge": "≥",
+    "le": "≤",
     "deg": "°",
-    "radic": "√", "infin": "∞",
-    "alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ",
-    "epsilon": "ε", "theta": "θ", "lambda": "λ", "mu": "μ",
-    "pi": "π", "sigma": "σ", "phi": "φ", "omega": "ω",
-    "Sigma": "Σ", "Delta": "Δ", "Omega": "Ω",
-    "sum": "∑", "prod": "∏",
+    "radic": "√",
+    "infin": "∞",
+    "alpha": "α",
+    "beta": "β",
+    "gamma": "γ",
+    "delta": "δ",
+    "epsilon": "ε",
+    "theta": "θ",
+    "lambda": "λ",
+    "mu": "μ",
+    "pi": "π",
+    "sigma": "σ",
+    "phi": "φ",
+    "omega": "ω",
+    "Sigma": "Σ",
+    "Delta": "Δ",
+    "Omega": "Ω",
+    "sum": "∑",
+    "prod": "∏",
     "nbsp": " ",
-    "copy": "©", "reg": "®", "trade": "™",
+    "copy": "©",
+    "reg": "®",
+    "trade": "™",
 }
 
 _XML_SAFE_ENTITIES = frozenset({"amp", "lt", "gt", "apos", "quot"})
@@ -261,11 +286,13 @@ def lint_body(body: str) -> tuple[str, list[LintFix]]:
     fixes: list[LintFix] = []
     body, n = _replace_named_entities(body)
     if n:
-        fixes.append(LintFix(
-            kind="named-entity",
-            count=n,
-            detail=f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals",
-        ))
+        fixes.append(
+            LintFix(
+                kind="named-entity",
+                count=n,
+                detail=f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals",
+            )
+        )
     return body, fixes
 ```
 
@@ -298,8 +325,8 @@ def test_lint_collapses_multi_line_svg_open():
         '<svg viewBox="0 0 100 100"\n'
         '     xmlns="http://www.w3.org/2000/svg"\n'
         '     role="img">\n'
-        '  <title>x</title>\n'
-        '</svg>'
+        "  <title>x</title>\n"
+        "</svg>"
     )
     fixed, fixes = lint_body(src)
     first_line = fixed.split("\n", 1)[0]
@@ -320,11 +347,11 @@ def test_lint_collapses_only_svg_tag_not_other_multi_line_tags():
         '<svg viewBox="0 0 100 100" xmlns="..." role="img">\n'
         '  <text x="10" y="20"\n'
         '        font-size="13">hello</text>\n'
-        '</svg>'
+        "</svg>"
     )
     fixed, _ = lint_body(src)
     # The multi-line <text> should be unchanged; the <svg> open is already on one line.
-    assert "<text x=\"10\" y=\"20\"\n        font-size=\"13\">" in fixed
+    assert '<text x="10" y="20"\n        font-size="13">' in fixed
 ```
 
 - [ ] **Step 3.2: Run tests to verify they fail**
@@ -368,10 +395,22 @@ def lint_body(body: str) -> tuple[str, list[LintFix]]:
     fixes: list[LintFix] = []
     body, n = _replace_named_entities(body)
     if n:
-        fixes.append(LintFix("named-entity", n, f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals"))
+        fixes.append(
+            LintFix(
+                "named-entity",
+                n,
+                f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals",
+            )
+        )
     body, n = _collapse_svg_open_tags(body)
     if n:
-        fixes.append(LintFix("multi-line-svg-open", n, f"collapsed {n} multi-line <svg ...> opening tag(s) to single line"))
+        fixes.append(
+            LintFix(
+                "multi-line-svg-open",
+                n,
+                f"collapsed {n} multi-line <svg ...> opening tag(s) to single line",
+            )
+        )
     return body, fixes
 ```
 
@@ -400,17 +439,9 @@ git commit -m "feat(blog-lint): collapse multi-line <svg> opening tags to single
 Append to `tests/test_blog_lint.py`:
 ```python
 def test_lint_strips_blank_lines_inside_svg():
-    src = (
-        '<svg>\n'
-        '  <title>t</title>\n'
-        '\n'
-        '  <text>line a</text>\n'
-        '\n'
-        '  <text>line b</text>\n'
-        '</svg>'
-    )
+    src = "<svg>\n  <title>t</title>\n\n  <text>line a</text>\n\n  <text>line b</text>\n</svg>"
     fixed, fixes = lint_body(src)
-    inside = fixed[fixed.index("<svg>"):fixed.index("</svg>")]
+    inside = fixed[fixed.index("<svg>") : fixed.index("</svg>")]
     assert "\n\n" not in inside
     assert "<text>line a</text>" in fixed and "<text>line b</text>" in fixed
     assert any(f.kind == "blank-line-in-svg" for f in fixes)
@@ -422,11 +453,11 @@ def test_lint_preserves_blank_lines_outside_svg():
         "\n"
         "Paragraph two.\n"
         "\n"
-        '<svg>\n'
-        '  <title>t</title>\n'
-        '\n'
-        '  <text>x</text>\n'
-        '</svg>\n'
+        "<svg>\n"
+        "  <title>t</title>\n"
+        "\n"
+        "  <text>x</text>\n"
+        "</svg>\n"
         "\n"
         "Paragraph three.\n"
     )
@@ -436,13 +467,7 @@ def test_lint_preserves_blank_lines_outside_svg():
 
 
 def test_lint_preserves_indentation_in_svg():
-    src = (
-        '<svg>\n'
-        '  <title>t</title>\n'
-        '\n'
-        '  <text>indented body</text>\n'
-        '</svg>'
-    )
+    src = "<svg>\n  <title>t</title>\n\n  <text>indented body</text>\n</svg>"
     fixed, _ = lint_body(src)
     assert "  <text>indented body</text>" in fixed
 ```
@@ -492,13 +517,29 @@ def lint_body(body: str) -> tuple[str, list[LintFix]]:
     fixes: list[LintFix] = []
     body, n = _replace_named_entities(body)
     if n:
-        fixes.append(LintFix("named-entity", n, f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals"))
+        fixes.append(
+            LintFix(
+                "named-entity",
+                n,
+                f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals",
+            )
+        )
     body, n = _collapse_svg_open_tags(body)
     if n:
-        fixes.append(LintFix("multi-line-svg-open", n, f"collapsed {n} multi-line <svg ...> opening tag(s) to single line"))
+        fixes.append(
+            LintFix(
+                "multi-line-svg-open",
+                n,
+                f"collapsed {n} multi-line <svg ...> opening tag(s) to single line",
+            )
+        )
     body, n = _strip_blank_lines_in_svg(body)
     if n:
-        fixes.append(LintFix("blank-line-in-svg", n, f"stripped {n} blank line(s) inside <svg>...</svg> blocks"))
+        fixes.append(
+            LintFix(
+                "blank-line-in-svg", n, f"stripped {n} blank line(s) inside <svg>...</svg> blocks"
+            )
+        )
     return body, fixes
 ```
 
@@ -544,7 +585,7 @@ def test_lint_does_not_mangle_fenced_code_blocks():
         "And here's a real one:\n"
         "\n"
         '<svg viewBox="0 0 200 200" xmlns="..." role="img">\n'
-        '  <title>real</title>\n'
+        "  <title>real</title>\n"
         "\n"
         "  <text>real text</text>\n"
         "</svg>\n"
@@ -552,7 +593,7 @@ def test_lint_does_not_mangle_fenced_code_blocks():
     fixed, fixes = lint_body(src)
     # The CODE BLOCK content must be preserved verbatim — multi-line open and blanks stay.
     assert (
-        '```svg\n'
+        "```svg\n"
         '<svg viewBox="0 0 100 100"\n'
         '     xmlns="..."\n'
         '     role="img">\n'
@@ -612,13 +653,29 @@ def lint_body(body: str) -> tuple[str, list[LintFix]]:
     fixes: list[LintFix] = []
     body, n = _replace_named_entities(body)
     if n:
-        fixes.append(LintFix("named-entity", n, f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals"))
+        fixes.append(
+            LintFix(
+                "named-entity",
+                n,
+                f"replaced {n} HTML named entit{'y' if n == 1 else 'ies'} with Unicode literals",
+            )
+        )
     body, n = _collapse_svg_open_tags(body)
     if n:
-        fixes.append(LintFix("multi-line-svg-open", n, f"collapsed {n} multi-line <svg ...> opening tag(s) to single line"))
+        fixes.append(
+            LintFix(
+                "multi-line-svg-open",
+                n,
+                f"collapsed {n} multi-line <svg ...> opening tag(s) to single line",
+            )
+        )
     body, n = _strip_blank_lines_in_svg(body)
     if n:
-        fixes.append(LintFix("blank-line-in-svg", n, f"stripped {n} blank line(s) inside <svg>...</svg> blocks"))
+        fixes.append(
+            LintFix(
+                "blank-line-in-svg", n, f"stripped {n} blank line(s) inside <svg>...</svg> blocks"
+            )
+        )
     body = _restore_fenced_code(body, stash)
     return body, fixes
 ```
@@ -652,10 +709,10 @@ def test_lint_is_idempotent():
         '<svg viewBox="0 0 100 100"\n'
         '     xmlns="..."\n'
         '     role="img">\n'
-        '  <title>t &mdash; subtitle</title>\n'
-        '\n'
-        '  <text>x &times; y</text>\n'
-        '</svg>'
+        "  <title>t &mdash; subtitle</title>\n"
+        "\n"
+        "  <text>x &times; y</text>\n"
+        "</svg>"
     )
     once, _ = lint_body(src)
     twice, fixes_second = lint_body(once)
@@ -676,10 +733,10 @@ def test_lint_does_not_mangle_indented_widget_svg():
     src = (
         '<div class="ptb-state" id="s1">\n'
         '    <svg viewBox="0 0 100 100" xmlns="..." role="img">\n'
-        '      <title>indented</title>\n'
-        '      <text>x</text>\n'
-        '    </svg>\n'
-        '</div>'
+        "      <title>indented</title>\n"
+        "      <text>x</text>\n"
+        "    </svg>\n"
+        "</div>"
     )
     fixed, fixes = lint_body(src)
     # No changes expected — this SVG is already lint-clean.
@@ -695,10 +752,12 @@ def test_lint_canary_against_real_post_0022():
     assert that after lint, the body has no <svg> block with a blank line in it.
     """
     from pathlib import Path
+
     src = Path("assets/blogs/0022-spike-sparse-sink-anatomy-massive.md").read_text(encoding="utf-8")
     fixed, _ = lint_body(src)
     # Find every <svg>...</svg> and check no blank line inside.
     import re
+
     for m in re.finditer(r"<svg\b[^>]*>.*?</svg>", fixed, re.DOTALL):
         block = m.group(0)
         for line in block.split("\n"):
@@ -730,6 +789,7 @@ git commit -m "test(blog-lint): idempotency, indented widget skip, real-post can
 `tests/test_blog_render.py`:
 ```python
 """Tests for src.services.blog_render."""
+
 import pytest
 from src.services.blog_render import RenderError, render_to_html
 
@@ -752,9 +812,9 @@ def test_render_returns_plain_string_not_notstr():
 def test_render_preserves_inline_svg_when_clean():
     md = (
         '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img">\n'
-        '  <title>t</title>\n'
-        '  <text>x</text>\n'
-        '</svg>'
+        "  <title>t</title>\n"
+        "  <text>x</text>\n"
+        "</svg>"
     )
     html = render_to_html(md)
     assert "<svg" in html
@@ -845,7 +905,7 @@ def test_validate_returns_empty_for_clean_html():
 
 
 def test_validate_catches_p_wrapping_svg():
-    bad = '<p><svg></svg></p>'
+    bad = "<p><svg></svg></p>"
     issues = validate_html(bad)
     assert any(i.kind == "p-wraps-svg" for i in issues)
 
@@ -875,14 +935,14 @@ def test_validate_catches_svg_missing_role_img():
 
 
 def test_validate_returns_multiple_issues_at_once():
-    bad = '<p><svg></svg></p><p><text>x</text></p>'  # two <p> wraps + tag mismatch + missing title
+    bad = "<p><svg></svg></p><p><text>x</text></p>"  # two <p> wraps + tag mismatch + missing title
     issues = validate_html(bad)
     kinds = [i.kind for i in issues]
     assert kinds.count("p-wraps-svg") >= 2
 
 
 def test_validate_issue_includes_snippet():
-    bad = '<p><svg></svg></p>'
+    bad = "<p><svg></svg></p>"
     issues = validate_html(bad)
     p_issues = [i for i in issues if i.kind == "p-wraps-svg"]
     assert len(p_issues) >= 1
@@ -910,8 +970,15 @@ class ValidationIssue:
 
 # Tags whose presence inside a <p> wrap is the diagnostic of the class-3 bug.
 _SVG_INTERNAL_TAGS = (
-    "svg", "text", "rect", "line", "circle", "path",
-    "g", "defs", "marker",
+    "svg",
+    "text",
+    "rect",
+    "line",
+    "circle",
+    "path",
+    "g",
+    "defs",
+    "marker",
 )
 _P_WRAPS_SVG = re.compile(
     r"<p\b[^>]*>\s*<(?:" + "|".join(_SVG_INTERNAL_TAGS) + r"|!--)\b",
@@ -934,21 +1001,25 @@ def validate_html(html: str) -> list[ValidationIssue]:
 
     # Rule 1: <p>-wraps-SVG-internal-tag
     for match in _P_WRAPS_SVG.finditer(html):
-        issues.append(ValidationIssue(
-            kind="p-wraps-svg",
-            line=_line_of(html, match.start()),
-            snippet=html[match.start(): match.start() + 120],
-        ))
+        issues.append(
+            ValidationIssue(
+                kind="p-wraps-svg",
+                line=_line_of(html, match.start()),
+                snippet=html[match.start() : match.start() + 120],
+            )
+        )
 
     # Rule 2: <svg> open count == </svg> close count
     n_open = len(_SVG_OPEN.findall(html))
     n_close = len(_SVG_CLOSE.findall(html))
     if n_open != n_close:
-        issues.append(ValidationIssue(
-            kind="svg-tag-mismatch",
-            line=None,
-            snippet=f"<svg> opens={n_open}, </svg> closes={n_close}",
-        ))
+        issues.append(
+            ValidationIssue(
+                kind="svg-tag-mismatch",
+                line=None,
+                snippet=f"<svg> opens={n_open}, </svg> closes={n_close}",
+            )
+        )
 
     # Rules 3+4 operate per top-level SVG block.
     # We don't try to detect nesting here — top-level SVGs are the only ones
@@ -957,19 +1028,23 @@ def validate_html(html: str) -> list[ValidationIssue]:
         block = match.group(0)
         line = _line_of(html, match.start())
         if not _HAS_TITLE_CHILD.search(block):
-            issues.append(ValidationIssue(
-                kind="svg-missing-title",
-                line=line,
-                snippet=block[:120],
-            ))
+            issues.append(
+                ValidationIssue(
+                    kind="svg-missing-title",
+                    line=line,
+                    snippet=block[:120],
+                )
+            )
         # Inspect the opening tag specifically (first match within the block).
         open_match = _SVG_OPEN.match(block)
         if open_match and not _HAS_ROLE_IMG.search(open_match.group(0)):
-            issues.append(ValidationIssue(
-                kind="svg-missing-role",
-                line=line,
-                snippet=open_match.group(0),
-            ))
+            issues.append(
+                ValidationIssue(
+                    kind="svg-missing-role",
+                    line=line,
+                    snippet=open_match.group(0),
+                )
+            )
 
     return issues
 ```
@@ -1004,6 +1079,7 @@ def test_blog_row_validates_minimal_payload():
     """BlogRow accepts a complete payload (markdown + html) with no errors."""
     from datetime import datetime, timezone
     from src.services.blog_frontmatter import BlogRow
+
     row = BlogRow(
         id="00000000-0000-0000-0000-000000000000",
         title="Test",
@@ -1025,6 +1101,7 @@ def test_blog_row_rejects_empty_body_html():
     from datetime import datetime, timezone
     from pydantic import ValidationError
     from src.services.blog_frontmatter import BlogRow
+
     with pytest.raises(ValidationError, match="body_html"):
         BlogRow(
             id="x",
@@ -1046,14 +1123,21 @@ def test_blog_row_extra_fields_forbidden():
     from datetime import datetime, timezone
     from pydantic import ValidationError
     from src.services.blog_frontmatter import BlogRow
+
     with pytest.raises(ValidationError):
         BlogRow(
-            id="x", title="t",
+            id="x",
+            title="t",
             date=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            tags=[], description="d",
+            tags=[],
+            description="d",
             image="https://e.com/i.svg",
-            type="note", disabled=False, views=0, likes=0,
-            body="md", body_html="<h1/>",
+            type="note",
+            disabled=False,
+            views=0,
+            likes=0,
+            body="md",
+            body_html="<h1/>",
             unexpected="boom",
         )
 ```
@@ -1128,16 +1212,17 @@ def test_payload_from_blog_includes_body_html(tmp_path):
     """_payload_from_blog returns a dict with both `body` (markdown) and
     `body_html` (rendered)."""
     from src.cli.blog import _payload_from_blog
+
     md = tmp_path / "post.md"
     md.write_text(
-        "@{title = \"T\"\n"
-        "  date = \"2026-01-01T00:00:00Z\"\n"
-        "  tags = [\"x\"]\n"
+        '@{title = "T"\n'
+        '  date = "2026-01-01T00:00:00Z"\n'
+        '  tags = ["x"]\n'
         "  views = 0\n"
         "  likes = 0\n"
-        "  image = \"https://e.com/i.svg\"\n"
-        "  description = \"d\"\n"
-        "  type = \"note\"\n"
+        '  image = "https://e.com/i.svg"\n'
+        '  description = "d"\n'
+        '  type = "note"\n'
         "  disabled = false\n"
         "}\n"
         "# Body\n",
@@ -1152,16 +1237,17 @@ def test_payload_from_blog_includes_body_html(tmp_path):
 def test_payload_from_blog_persists_lint_fixes_to_disk(tmp_path, capsys):
     """If lint changes the body, the .md file is overwritten with the linted text."""
     from src.cli.blog import _payload_from_blog
+
     md = tmp_path / "post.md"
     raw = (
-        "@{title = \"T\"\n"
-        "  date = \"2026-01-01T00:00:00Z\"\n"
-        "  tags = [\"x\"]\n"
+        '@{title = "T"\n'
+        '  date = "2026-01-01T00:00:00Z"\n'
+        '  tags = ["x"]\n'
         "  views = 0\n"
         "  likes = 0\n"
-        "  image = \"https://e.com/i.svg\"\n"
-        "  description = \"d\"\n"
-        "  type = \"note\"\n"
+        '  image = "https://e.com/i.svg"\n'
+        '  description = "d"\n'
+        '  type = "note"\n'
         "  disabled = false\n"
         "}\n"
         "# Body\n"
@@ -1182,21 +1268,22 @@ def test_payload_from_blog_persists_lint_fixes_to_disk(tmp_path, capsys):
 def test_payload_from_blog_raises_on_validation_failure(tmp_path):
     """If validate_html finds an issue, _payload_from_blog raises."""
     from src.cli.blog import _payload_from_blog
+
     md = tmp_path / "post.md"
     # Body contains an SVG with no <title> and no role="img" — both will fail validation.
     md.write_text(
-        "@{title = \"T\"\n"
-        "  date = \"2026-01-01T00:00:00Z\"\n"
-        "  tags = [\"x\"]\n"
+        '@{title = "T"\n'
+        '  date = "2026-01-01T00:00:00Z"\n'
+        '  tags = ["x"]\n'
         "  views = 0\n"
         "  likes = 0\n"
-        "  image = \"https://e.com/i.svg\"\n"
-        "  description = \"d\"\n"
-        "  type = \"note\"\n"
+        '  image = "https://e.com/i.svg"\n'
+        '  description = "d"\n'
+        '  type = "note"\n'
         "  disabled = false\n"
         "}\n"
         "# Body\n"
-        "<svg viewBox=\"0 0 100 100\"><text>x</text></svg>\n",
+        '<svg viewBox="0 0 100 100"><text>x</text></svg>\n',
         encoding="utf-8",
     )
     with pytest.raises(ValueError, match="validate_html"):
@@ -1257,9 +1344,7 @@ def _payload_from_blog(path: Path) -> dict[str, Any]:
                 f"[error] {i.kind} (line {i.line}): {i.snippet[:120]}",
                 file=sys.stderr,
             )
-        raise ValueError(
-            f"validate_html found {len(issues)} issue(s); fix the source and re-run"
-        )
+        raise ValueError(f"validate_html found {len(issues)} issue(s); fix the source and re-run")
 
     row = BlogRow(**{**blog.model_dump(), "body_html": html})
     return row.model_dump(mode="json")
@@ -1309,20 +1394,21 @@ Append to `tests/test_cli_blog.py`:
 def test_validate_reports_lint_issues_without_writing(tmp_path, capsys):
     """`blog validate` reports lint issues but does NOT write the file."""
     from src.cli.__main__ import main
+
     md = tmp_path / "post.md"
     raw = (
-        "@{id = \"00000000-0000-0000-0000-000000000000\"\n"
-        "  title = \"T\"\n"
-        "  date = \"2026-01-01T00:00:00Z\"\n"
-        "  tags = [\"x\"]\n"
+        '@{id = "00000000-0000-0000-0000-000000000000"\n'
+        '  title = "T"\n'
+        '  date = "2026-01-01T00:00:00Z"\n'
+        '  tags = ["x"]\n'
         "  views = 0\n"
         "  likes = 0\n"
-        "  image = \"https://e.com/i.svg\"\n"
-        "  description = \"d\"\n"
-        "  type = \"note\"\n"
+        '  image = "https://e.com/i.svg"\n'
+        '  description = "d"\n'
+        '  type = "note"\n'
         "  disabled = false\n"
         "}\n"
-        "# B\n<svg viewBox=\"0 0 1 1\" xmlns=\"...\" role=\"img\"><title>x &mdash; y</title></svg>\n"
+        '# B\n<svg viewBox="0 0 1 1" xmlns="..." role="img"><title>x &mdash; y</title></svg>\n'
     )
     md.write_text(raw, encoding="utf-8")
     rc = main(["blog", "validate", str(md)])
@@ -1338,20 +1424,21 @@ def test_validate_reports_lint_issues_without_writing(tmp_path, capsys):
 def test_validate_exits_nonzero_on_validation_issue(tmp_path):
     """`blog validate` exits nonzero when validate_html finds an issue."""
     from src.cli.__main__ import main
+
     md = tmp_path / "post.md"
     md.write_text(
-        "@{id = \"00000000-0000-0000-0000-000000000000\"\n"
-        "  title = \"T\"\n"
-        "  date = \"2026-01-01T00:00:00Z\"\n"
-        "  tags = [\"x\"]\n"
+        '@{id = "00000000-0000-0000-0000-000000000000"\n'
+        '  title = "T"\n'
+        '  date = "2026-01-01T00:00:00Z"\n'
+        '  tags = ["x"]\n'
         "  views = 0\n"
         "  likes = 0\n"
-        "  image = \"https://e.com/i.svg\"\n"
-        "  description = \"d\"\n"
-        "  type = \"note\"\n"
+        '  image = "https://e.com/i.svg"\n'
+        '  description = "d"\n'
+        '  type = "note"\n'
         "  disabled = false\n"
         "}\n"
-        "# B\n<svg viewBox=\"0 0 1 1\"><text>missing title and role</text></svg>\n",
+        '# B\n<svg viewBox="0 0 1 1"><text>missing title and role</text></svg>\n',
         encoding="utf-8",
     )
     rc = main(["blog", "validate", str(md)])
@@ -1437,6 +1524,7 @@ git commit -m "feat(cli-blog): upgrade validate command to read-only lint+render
 Uses real files in assets/blogs/ as fixtures. These tests run BEFORE BigQuery
 is touched — they exercise pure-Python pipeline only.
 """
+
 from pathlib import Path
 
 from src.services.blog_lint import lint_body
@@ -1556,6 +1644,7 @@ git commit -m "chore(bq): add body_html column to gn-blog table"
 `tests/test_backfill_blog_html.py`:
 ```python
 """Tests for scripts.backfill_blog_html."""
+
 from pathlib import Path
 
 import pytest
@@ -1563,6 +1652,7 @@ import pytest
 
 def test_iter_blog_paths_returns_sorted_md_files(tmp_path):
     from scripts.backfill_blog_html import iter_blog_paths
+
     (tmp_path / "0003-c.md").write_text("@{}\n", encoding="utf-8")
     (tmp_path / "0001-a.md").write_text("@{}\n", encoding="utf-8")
     (tmp_path / "0002-b.md").write_text("@{}\n", encoding="utf-8")
@@ -1586,6 +1676,7 @@ def test_dry_run_does_not_call_submit(tmp_path, monkeypatch, capsys):
     # Stub out _payload_from_blog so we don't need real Pydantic frontmatter.
     def fake_payload(path):
         return {"id": "x", "body": path.read_text(), "body_html": "<p>html</p>"}
+
     monkeypatch.setattr(blog_module, "_payload_from_blog", fake_payload)
 
     blogs = tmp_path / "blogs"
@@ -1605,7 +1696,9 @@ def test_classify_streaming_buffer_error_recognizes_known_message():
     class MockExc(Exception):
         pass
 
-    err = MockExc("UPDATE or DELETE statement over table ... would affect rows in the streaming buffer, which is not supported")
+    err = MockExc(
+        "UPDATE or DELETE statement over table ... would affect rows in the streaming buffer, which is not supported"
+    )
     assert is_streaming_buffer_error(err)
     assert not is_streaming_buffer_error(MockExc("permission denied"))
 ```
@@ -1686,7 +1779,9 @@ def run_backfill(blogs_dir: Path, dry_run: bool) -> int:
             continue
 
         if dry_run:
-            print(f"[dry-run] would update id={payload.get('id', '?')} (body_html: {len(payload.get('body_html', ''))} chars)")
+            print(
+                f"[dry-run] would update id={payload.get('id', '?')} (body_html: {len(payload.get('body_html', ''))} chars)"
+            )
             successes.append(path)
             continue
 
@@ -1706,7 +1801,9 @@ def run_backfill(blogs_dir: Path, dry_run: bool) -> int:
             successes.append(path)
 
     if streaming_failures and not dry_run:
-        print(f"\n=== Sleeping 35 minutes before retrying {len(streaming_failures)} streaming-buffer post(s) ===")
+        print(
+            f"\n=== Sleeping 35 minutes before retrying {len(streaming_failures)} streaming-buffer post(s) ==="
+        )
         time.sleep(35 * 60)
         for path in streaming_failures:
             print(f"\n--- retry: {path.name} ---")
@@ -1731,8 +1828,14 @@ def run_backfill(blogs_dir: Path, dry_run: bool) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--dry-run", action="store_true", help="Preview only; do not push to BigQuery.")
-    parser.add_argument("--blogs-dir", default=str(DEFAULT_BLOGS_DIR), help="Directory containing the blog .md files.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Preview only; do not push to BigQuery."
+    )
+    parser.add_argument(
+        "--blogs-dir",
+        default=str(DEFAULT_BLOGS_DIR),
+        help="Directory containing the blog .md files.",
+    )
     args = parser.parse_args(argv)
     return run_backfill(Path(args.blogs_dir), dry_run=args.dry_run)
 
@@ -1821,6 +1924,7 @@ Expected: `n_total == n_with_html` and equal to the number of posts.
 `tests/test_project_model.py` (or extend existing):
 ```python
 """Tests for src.models.project."""
+
 from src.models.project import Project
 
 
@@ -1872,8 +1976,8 @@ class Project:
     views: int = 0
     likes: int = 0
     date: str = ""
-    body: str = ""           # legacy markdown source; dropped after the body column is dropped
-    body_html: str = ""      # rendered HTML; the new source for the renderer
+    body: str = ""  # legacy markdown source; dropped after the body column is dropped
+    body_html: str = ""  # rendered HTML; the new source for the renderer
     slug: str = ""
 
     @classmethod
@@ -1920,9 +2024,9 @@ git commit -m "feat(models): Project gains body_html field for rendered HTML"
 In `src/features/projects/projects_page.py`, line 54:
 ```python
 # before
-render_md(project.body),
+(render_md(project.body),)
 # after
-NotStr(project.body_html) if project.body_html else render_md(project.body),
+(NotStr(project.body_html) if project.body_html else render_md(project.body),)
 ```
 
 Why the conditional: it's a defensive fallback so a row missing `body_html` (e.g. if someone manually inserts a row in the BQ console without going through the CLI) doesn't render as a blank page. Once we DROP the `body` column at task 20, the fallback is removed.
@@ -1932,6 +2036,7 @@ Why the conditional: it's a defensive fallback so a row missing `body_html` (e.g
 In `tests/test_blog_detail_view.py` (new file):
 ```python
 """Tests that the blog detail page reads body_html in preference to body."""
+
 from src.models.project import Project
 
 
@@ -1940,8 +2045,13 @@ def test_blog_detail_uses_body_html_when_present(monkeypatch):
     from src.features.projects import projects_page
 
     project = Project(
-        id="x", blog_id="x", title="T", description="d", image="i",
-        body="# markdown", body_html="<h1>html-rendered</h1>",
+        id="x",
+        blog_id="x",
+        title="T",
+        description="d",
+        image="i",
+        body="# markdown",
+        body_html="<h1>html-rendered</h1>",
     )
     out = projects_page._render_blog_detail(project)
     rendered = str(out)
@@ -1954,8 +2064,13 @@ def test_blog_detail_falls_back_to_body_when_html_missing():
     from src.features.projects import projects_page
 
     project = Project(
-        id="x", blog_id="x", title="T", description="d", image="i",
-        body="# markdown", body_html="",
+        id="x",
+        blog_id="x",
+        title="T",
+        description="d",
+        image="i",
+        body="# markdown",
+        body_html="",
     )
     out = projects_page._render_blog_detail(project)
     rendered = str(out)
@@ -2109,6 +2224,7 @@ class BlogRow(BaseModel):
     The legacy `body` column was dropped on YYYY-MM-DD; only `body_html`
     is stored.
     """
+
     model_config = ConfigDict(extra="forbid")
     id: str
     title: str
@@ -2151,7 +2267,7 @@ class Project:
 
 In `src/features/projects/projects_page.py`:
 ```python
-NotStr(project.body_html),
+(NotStr(project.body_html),)
 ```
 (remove the conditional fallback).
 

--- a/docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-30-blog-html-pipeline-design.md
@@ -82,8 +82,9 @@ Pure-Python, no I/O coupling. Exposes:
 @dataclass
 class LintFix:
     kind: Literal["named-entity", "multi-line-svg-open", "blank-line-in-svg"]
-    count: int        # how many sites the rule fixed
-    detail: str       # short human-readable summary
+    count: int  # how many sites the rule fixed
+    detail: str  # short human-readable summary
+
 
 def lint_body(body: str) -> tuple[str, list[LintFix]]: ...
 ```
@@ -112,6 +113,7 @@ class ValidationIssue:
     line: int | None
     snippet: str
 
+
 def render_to_html(body: str) -> str: ...
 def validate_html(html: str) -> list[ValidationIssue]: ...
 ```
@@ -133,6 +135,7 @@ class BlogRow(BaseModel):
     step 10 drops the `body` column, the field is removed from this
     model and its callers.
     """
+
     model_config = ConfigDict(extra="forbid")
     id: str
     title: str
@@ -144,8 +147,8 @@ class BlogRow(BaseModel):
     disabled: bool
     views: int
     likes: int
-    body: str          # legacy markdown source; dropped at step 10
-    body_html: str     # rendered HTML; the new source of truth for the renderer
+    body: str  # legacy markdown source; dropped at step 10
+    body_html: str  # rendered HTML; the new source of truth for the renderer
 
     @field_validator("body_html")
     @classmethod
@@ -163,10 +166,10 @@ class BlogRow(BaseModel):
 
 ```python
 def _payload_from_blog(path: Path) -> dict[str, Any]:
-    blog = parse_blog(path)                     # BlogFrontmatter
+    blog = parse_blog(path)  # BlogFrontmatter
     fixed, fixes = lint_body(blog.body)
     if fixes:
-        _persist_lint_fixes(path, fixed)        # write back to .md
+        _persist_lint_fixes(path, fixed)  # write back to .md
         for f in fixes:
             print(f"[lint] {f.kind}: {f.detail} (×{f.count})")
     html = render_to_html(fixed)
@@ -194,9 +197,9 @@ Note that `blog.body` (the linted markdown) and `html` (rendered) are both writt
 Single line change:
 ```python
 # before
-render_md(project.body),
+(render_md(project.body),)
 # after
-NotStr(project.body_html),
+(NotStr(project.body_html),)
 ```
 
 ### New script: `scripts/backfill_blog_html.py`

--- a/src/cli/__main__.py
+++ b/src/cli/__main__.py
@@ -7,7 +7,7 @@ today; future subcommands (e.g. project import/export) plug in here.
 from __future__ import annotations
 
 import argparse
-from typing import Sequence
+from collections.abc import Sequence
 
 from .blog import register_blog_parser, run_blog
 

--- a/src/components/__init__.py
+++ b/src/components/__init__.py
@@ -1,5 +1,5 @@
-from .layout.page import StandardPage
 from .layout.navigation import navigation
+from .layout.page import StandardPage
 from .modals.contact import ContactModal
 
-__all__ = ["StandardPage", "navigation", "ContactModal"]
+__all__ = ["ContactModal", "StandardPage", "navigation"]

--- a/src/components/base/card.py
+++ b/src/components/base/card.py
@@ -2,7 +2,6 @@
 
 from fasthtml.common import A, Div
 
-
 _PADDING_CLASSES = {
     "sm": "factory-card-padding-sm",
     "md": "factory-card-padding-md",

--- a/src/components/base/chips.py
+++ b/src/components/base/chips.py
@@ -1,5 +1,5 @@
-from typing import List, Tuple
-from fasthtml.common import Div, Button, Style, Script
+from fasthtml.common import Button, Div, Script, Style
+
 from src.styles import CHIPS_CSS
 
 
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
     )
 
 
-def filter_chips(chips: List[Tuple[str, str, str, bool]]) -> Div:
+def filter_chips(chips: list[tuple[str, str, str, bool]]) -> Div:
     chip_list = [
         Button(
             name,

--- a/src/components/base/icons.py
+++ b/src/components/base/icons.py
@@ -1,5 +1,5 @@
-from fasthtml.svg import Svg, Path, Rect, Circle
 from fasthtml.common import A, Style
+from fasthtml.svg import Circle, Path, Rect, Svg
 
 SOCIAL_BTN_CSS = """
 .social-btn {

--- a/src/components/decorative/backgrounds.py
+++ b/src/components/decorative/backgrounds.py
@@ -1,4 +1,5 @@
-from fasthtml.common import Div, Style, Script
+from fasthtml.common import Div, Script, Style
+
 from src.styles import BALL_BACKGROUND_CSS, TRANSITION_CSS
 
 # ==============================================================================

--- a/src/components/decorative/parallax.py
+++ b/src/components/decorative/parallax.py
@@ -1,4 +1,5 @@
-from fasthtml.common import Div, Style, Script
+from fasthtml.common import Div, Script, Style
+
 from src.styles import DOT_PARALLAX_CSS, SUNSET_PARALLAX_CSS
 
 # ==============================================================================

--- a/src/components/layout/footer.py
+++ b/src/components/layout/footer.py
@@ -1,6 +1,6 @@
 """Site footer rendered on every page below the main container."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from fasthtml.common import A, Div, P
 
@@ -14,7 +14,7 @@ def Footer():
     so the navigation, social buttons, and footer share a single source of
     truth. Outputs Factory-style monochrome markup that mirrors the navbar.
     """
-    year = datetime.now().year
+    year = datetime.now(tz=UTC).year
     return Div(
         Div(
             Div(

--- a/src/components/layout/page.py
+++ b/src/components/layout/page.py
@@ -1,9 +1,11 @@
 from fasthtml.common import *
 from monsterui.all import *
-from .footer import Footer
-from .navigation import navigation
+
 from src.services.javascript.bfcache_scroll import BFCACHE_SCROLL_RESET_JS
 from src.styles import FACTORY_CSS, THEME_CSS
+
+from .footer import Footer
+from .navigation import navigation
 
 
 def StandardPage(

--- a/src/components/modals/contact.py
+++ b/src/components/modals/contact.py
@@ -1,9 +1,10 @@
-from fasthtml.common import Style, Script, Div, H2, Span, Button
+from fasthtml.common import H2, Button, Div, Script, Span, Style
+
 from src.components.base.icons import (
     COPY_ICON,
-    linkedin_icon,
-    github_icon,
     bluesky_icon,
+    github_icon,
+    linkedin_icon,
 )
 from src.styles import CONTACT_MODAL_CSS
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -7,6 +7,7 @@ UI constants, color schemes, and content for the hero page.
 
 import logging
 import os
+from typing import ClassVar
 
 logger = logging.getLogger(__name__)
 
@@ -34,13 +35,13 @@ class Settings:
     # ============================================================================
     # Navigation & Social Links
     # ============================================================================
-    NAV_LINKS = [
+    NAV_LINKS: ClassVar[list[dict[str, str]]] = [
         {"label": "Projects", "href": "/projects"},
         {"label": "Blogs", "href": "/blogs"},
         {"label": "CV", "href": "/cv"},
     ]
 
-    SOCIAL_LINKS = [
+    SOCIAL_LINKS: ClassVar[list[dict[str, str]]] = [
         {"label": "LinkedIn", "href": "https://www.linkedin.com/in/gcnavarro/"},
         {"label": "GitHub", "href": "https://github.com/gabenavarro"},
         {"label": "Email", "href": "mailto:gchinonavarro@gmail.com"},
@@ -49,7 +50,7 @@ class Settings:
     # ============================================================================
     # Category Mapping
     # ============================================================================
-    CATEGORY_MAP = {
+    CATEGORY_MAP: ClassVar[dict[str, str]] = {
         "bioinformatics": "omics",
         "genomics": "omics",
         "transcriptomics": "omics",
@@ -73,14 +74,14 @@ class Settings:
     # ============================================================================
     # Hero Skills & Descriptions
     # ============================================================================
-    HERO_SKILLS = [
+    HERO_SKILLS: ClassVar[list[str]] = [
         "Computational Scientist",
         "Machine Learning Researcher",
         "Bioinformatician",
         "Synthetic Chemist",
     ]
 
-    HERO_SKILLS_DESCRIPTION = {
+    HERO_SKILLS_DESCRIPTION: ClassVar[dict[str, str]] = {
         "Bioinformatician": "I decode complex biological datasets to uncover hidden insights and accelerate scientific breakthroughs. Let's transform data into discoveries together!",
         "Data Engineer": "I build robust, scalable pipelines that efficiently handle petabyte-scale datasets. Let's turn massive data into actionable insights together!",
         "Computational Scientist": "I employ cutting-edge computational methods to solve challenging scientific problems. Let's push the boundaries of research together!",
@@ -107,7 +108,7 @@ class Settings:
     # ============================================================================
     # Hero Page Content
     # ============================================================================
-    HERO_CONTENT = {
+    HERO_CONTENT: ClassVar[dict[str, str]] = {
         "greeting": "Hi, I'm Gabriel Navarro, PhD ",
         "portrait_url": "https://storage.googleapis.com/gn-portfolio/images/portriat.png",
         "default_skill": "Computational Scientist",

--- a/src/core/routes.py
+++ b/src/core/routes.py
@@ -1,6 +1,8 @@
 from fasthtml.common import *
 from starlette.responses import Response
 
+from src.features.cv import CV_PAGE
+from src.features.feed.rss import build_rss_feed
 from src.features.hero import HERO_PAGE
 from src.features.projects import (
     PROJECTS_PAGE,
@@ -8,8 +10,6 @@ from src.features.projects import (
     create_blog_page_by_slug,
     create_masonry_page,
 )
-from src.features.cv import CV_PAGE
-from src.features.feed.rss import build_rss_feed
 from src.services.projects import ProjectService
 
 
@@ -23,11 +23,11 @@ def register_routes(app, rt):
         return HERO_PAGE
 
     @rt("/projects")
-    def projects(tag: str = None):
+    def projects(tag: str | None = None):
         return PROJECTS_PAGE
 
     @rt("/blogs")
-    def blogs(tag: str = None):
+    def blogs(tag: str | None = None):
         return create_masonry_page(tag)
 
     @rt("/blogs/slug/{slug}")

--- a/src/features/cv/components.py
+++ b/src/features/cv/components.py
@@ -1,6 +1,8 @@
 from fasthtml.common import *
 from monsterui.all import *
+
 from src.components.base import Card
+
 from .diagrams import diagram_for
 
 

--- a/src/features/cv/cv_page.py
+++ b/src/features/cv/cv_page.py
@@ -1,12 +1,14 @@
 from fasthtml.common import *
 from monsterui.all import *
+
 from src.components.layout.page import StandardPage
+
 from .components import (
-    cv_experience,
     cv_education,
-    cv_skills,
+    cv_experience,
     cv_patents,
     cv_publications,
+    cv_skills,
 )
 
 CV_PAGE = StandardPage(

--- a/src/features/feed/rss.py
+++ b/src/features/feed/rss.py
@@ -4,9 +4,8 @@ Pure stdlib XML construction (no feedgen, no lxml). Caps at 50 items per
 the RSS spec convention; CDATA-wraps title/description to avoid escaping.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from email.utils import format_datetime
-from typing import List
 
 from src.models.project import Project
 
@@ -26,13 +25,14 @@ def _format_pub_date(date_str: str) -> str:
     """Convert an ISO 8601 string (BigQuery format) to RFC 822 for RSS."""
     if not date_str:
         return ""
-    # BigQuery serializes timestamps with trailing Z; normalize for fromisoformat
+    # BigQuery serializes timestamps with a trailing Z; Python 3.11+
+    # fromisoformat parses that natively, so no normalization is needed.
     try:
-        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(date_str)
     except ValueError:
         return ""
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=UTC)
     return format_datetime(dt)
 
 
@@ -49,9 +49,9 @@ def _item_xml(project: Project) -> str:
     </item>"""
 
 
-def build_rss_feed(projects: List[Project], site_url: str = SITE_URL) -> str:
+def build_rss_feed(projects: list[Project], site_url: str = SITE_URL) -> str:
     """Render an RSS 2.0 feed for the given projects (cap 50 items)."""
-    last_build = format_datetime(datetime.now(timezone.utc))
+    last_build = format_datetime(datetime.now(UTC))
     items = "\n".join(_item_xml(p) for p in projects[:50])
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">

--- a/src/features/hero/components.py
+++ b/src/features/hero/components.py
@@ -1,5 +1,6 @@
 from fasthtml.common import *
 from monsterui.all import *
+
 from src.components.base import Card, button_ghost
 from src.config import settings
 

--- a/src/features/hero/hero_page.py
+++ b/src/features/hero/hero_page.py
@@ -1,4 +1,5 @@
 from src.components.layout.page import StandardPage
+
 from .components import hero_section
 
 

--- a/src/features/projects/components.py
+++ b/src/features/projects/components.py
@@ -1,5 +1,6 @@
 from fasthtml.common import *
 from monsterui.all import *
+
 from src.components.base import Card
 
 

--- a/src/features/projects/projects_page.py
+++ b/src/features/projects/projects_page.py
@@ -1,8 +1,10 @@
 from fasthtml.common import *
 from monsterui.all import *
+
 from src.components.base import button_ghost, button_primary
 from src.components.layout.page import StandardPage
 from src.services.projects import ProjectService
+
 from .components import render_project_card
 
 

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import List
 
 from slugify import slugify
 
@@ -16,7 +15,7 @@ class Project:
     title: str
     description: str
     image: str
-    tags: List[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
     disabled: bool = False
     views: int = 0
     likes: int = 0

--- a/src/services/blog_frontmatter.py
+++ b/src/services/blog_frontmatter.py
@@ -82,8 +82,7 @@ def _split_frontmatter(text: str) -> tuple[str, str, str]:
         head = lines[first_idx][len("@{") :]
         if head.strip():
             inner_lines.append(head)
-        for ln in lines[first_idx + 1 : end_idx]:
-            inner_lines.append(ln)
+        inner_lines.extend(lines[first_idx + 1 : end_idx])
         return "legacy", "".join(inner_lines), "".join(lines[end_idx + 1 :])
 
     if first.startswith("---"):
@@ -127,7 +126,9 @@ def _parse_yaml(frontmatter: str) -> dict[str, Any]:
     if data is None:
         return {}
     if not isinstance(data, dict):
-        raise ValueError("YAML frontmatter must be a mapping at the top level")
+        # ValueError (not TypeError) keeps this consistent with every other
+        # malformed-frontmatter failure in this module, so callers catch one type.
+        raise ValueError("YAML frontmatter must be a mapping at the top level")  # noqa: TRY004
     return data
 
 

--- a/src/services/blog_render.py
+++ b/src/services/blog_render.py
@@ -29,7 +29,7 @@ def render_to_html(body: str) -> str:
     """
     try:
         rendered = render_md(body)
-    except Exception as exc:  # noqa: BLE001 - we want to wrap any failure
+    except Exception as exc:
         raise RenderError(f"render_md failed: {exc}") from exc
 
     # monsterui returns a NotStr (subclass of str). __str__ is the HTML.

--- a/src/services/gcp/bigquery.py
+++ b/src/services/gcp/bigquery.py
@@ -18,6 +18,7 @@ A minimal BigQuery client using google-api-core and avoiding the full SDK.
 """
 
 import time
+
 from google.auth import default
 from google.auth.transport.requests import AuthorizedSession
 

--- a/src/services/javascript/__init__.py
+++ b/src/services/javascript/__init__.py
@@ -1,6 +1,6 @@
 from .bfcache_scroll import BFCACHE_SCROLL_RESET_JS
-from .scroll_animations import SCROLL_JS
 from .masonry import MasonryJS
+from .scroll_animations import SCROLL_JS
 
 # NOTE: `marked.py` does NOT export a `MarkedJS` symbol — the previous
 # `from .marked import MarkedJS` here raised ImportError on first access

--- a/src/services/javascript/marked.py
+++ b/src/services/javascript/marked.py
@@ -5,7 +5,6 @@ https://marked.js.org/
 
 from fasthtml.common import Link
 
-
 highlight_css = "https://cdn.jsdelivr.net/gh/PrismJS/prism@1.30.0/themes/prism-tomorrow.min.css"
 highlight_link = Link(rel="stylesheet", href=highlight_css)
 

--- a/src/services/projects.py
+++ b/src/services/projects.py
@@ -1,14 +1,13 @@
-from typing import List, Optional
-from src.services.gcp.bigquery import BigQueryClient
-from src.models.project import Project
 from src.config.settings import settings
+from src.models.project import Project
+from src.services.gcp.bigquery import BigQueryClient
 
 
 class ProjectService:
     def __init__(self):
         self.client = BigQueryClient(project_id=settings.GOOGLE_PROJECT_ID)
 
-    def get_all_projects(self, limit: int = 1000, include_disabled: bool = False) -> List[Project]:
+    def get_all_projects(self, limit: int = 1000, include_disabled: bool = False) -> list[Project]:
         """Fetches all projects from BigQuery.
 
         By default, rows where `disabled = true` are filtered out at the SQL
@@ -31,7 +30,7 @@ class ProjectService:
 
         return [Project.from_dict(r) for r in results]
 
-    def get_project_by_id(self, project_id: str) -> Optional[Project]:
+    def get_project_by_id(self, project_id: str) -> Project | None:
         """Fetches a single project by its ID."""
         # Using parameterized query for security
         query = f"SELECT * FROM `{settings.BIGQUERY_TABLE}` WHERE id = @project_id"
@@ -45,7 +44,7 @@ class ProjectService:
 
         return None
 
-    def get_project_by_slug(self, slug: str) -> Optional[Project]:
+    def get_project_by_slug(self, slug: str) -> Project | None:
         """Look up a project by its slug. Client-side scan over all projects.
 
         BigQuery's gn-blog table does not yet have a slug column. Until the one-time
@@ -58,7 +57,7 @@ class ProjectService:
                 return project
         return None
 
-    def get_projects_by_tag(self, tag: str, include_disabled: bool = False) -> List[Project]:
+    def get_projects_by_tag(self, tag: str, include_disabled: bool = False) -> list[Project]:
         """Fetches projects filtered by tag.
 
         By default, rows where `disabled = true` are filtered out at the SQL

--- a/src/styles/__init__.py
+++ b/src/styles/__init__.py
@@ -10,19 +10,19 @@ compatibility with existing per-component `Style(...)` injections.
 """
 
 from ._base import BASE_CSS
-from ._layout import LAYOUT_CSS
 from ._components import COMPONENTS_CSS
+from ._layout import LAYOUT_CSS
 from ._pages import PAGES_CSS
+from .custom_css import *
 from .theme import THEME_CSS
-from .custom_css import *  # noqa: F401,F403  re-export individual *_CSS constants
 
-FACTORY_CSS = "\n".join([BASE_CSS, LAYOUT_CSS, COMPONENTS_CSS, PAGES_CSS])
+FACTORY_CSS = f"{BASE_CSS}\n{LAYOUT_CSS}\n{COMPONENTS_CSS}\n{PAGES_CSS}"
 
 __all__ = [
-    "FACTORY_CSS",
-    "THEME_CSS",
     "BASE_CSS",
-    "LAYOUT_CSS",
     "COMPONENTS_CSS",
+    "FACTORY_CSS",
+    "LAYOUT_CSS",
     "PAGES_CSS",
+    "THEME_CSS",
 ]

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -4,8 +4,9 @@ import re
 from unittest.mock import patch
 
 from fasthtml.common import to_xml
-from src.features.hero import HERO_PAGE
+
 from src.features.cv import CV_PAGE
+from src.features.hero import HERO_PAGE
 
 
 def _img_tags_without_alt(html: str) -> list[str]:

--- a/tests/test_blog_frontmatter.py
+++ b/tests/test_blog_frontmatter.py
@@ -1,6 +1,6 @@
 """Tests for src.services.blog_frontmatter."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 import yaml
@@ -20,7 +20,7 @@ def test_parses_legacy_at_brace_format():
     assert result.disabled is False
     assert result.views == 0
     assert result.likes == 0
-    assert result.date == datetime(2025, 4, 26, 0, 0, 0, tzinfo=timezone.utc)
+    assert result.date == datetime(2025, 4, 26, 0, 0, 0, tzinfo=UTC)
     assert str(result.image).startswith("https://")
     assert result.body.strip().startswith("# Speeding Up FASTQ Preprocessing with FastP")
 
@@ -113,13 +113,14 @@ def test_empty_body_raises(tmp_path):
 
 def test_blog_row_validates_minimal_payload():
     """BlogRow accepts a complete payload (markdown + html) with no errors."""
-    from datetime import datetime, timezone
+    from datetime import datetime
+
     from src.services.blog_frontmatter import BlogRow
 
     row = BlogRow(
         id="00000000-0000-0000-0000-000000000000",
         title="Test",
-        date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        date=datetime(2026, 1, 1, tzinfo=UTC),
         tags=["test"],
         description="d",
         image="https://example.com/img.svg",
@@ -134,15 +135,17 @@ def test_blog_row_validates_minimal_payload():
 
 
 def test_blog_row_rejects_empty_body_html():
-    from datetime import datetime, timezone
+    from datetime import datetime
+
     from pydantic import ValidationError
+
     from src.services.blog_frontmatter import BlogRow
 
     with pytest.raises(ValidationError, match="body_html"):
         BlogRow(
             id="x",
             title="t",
-            date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            date=datetime(2026, 1, 1, tzinfo=UTC),
             tags=[],
             description="d",
             image="https://e.com/i.svg",
@@ -156,15 +159,17 @@ def test_blog_row_rejects_empty_body_html():
 
 
 def test_blog_row_extra_fields_forbidden():
-    from datetime import datetime, timezone
+    from datetime import datetime
+
     from pydantic import ValidationError
+
     from src.services.blog_frontmatter import BlogRow
 
     with pytest.raises(ValidationError):
         BlogRow(
             id="x",
             title="t",
-            date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            date=datetime(2026, 1, 1, tzinfo=UTC),
             tags=[],
             description="d",
             image="https://e.com/i.svg",

--- a/tests/test_blog_lint.py
+++ b/tests/test_blog_lint.py
@@ -142,7 +142,7 @@ def test_lint_does_not_mangle_fenced_code_blocks():
         "  <text>real text</text>\n"
         "</svg>\n"
     )
-    fixed, fixes = lint_body(src)
+    fixed, _fixes = lint_body(src)
     # The CODE BLOCK content must be preserved verbatim — multi-line open and blanks stay.
     assert (
         "```svg\n"

--- a/tests/test_blog_pipeline_e2e.py
+++ b/tests/test_blog_pipeline_e2e.py
@@ -38,7 +38,7 @@ def test_e2e_post_0022_renders_clean():
 
 def test_e2e_post_0001_renders_clean():
     """Old prose-only post (no SVG) should still pass through cleanly."""
-    html, issues = _full_pipeline(Path("assets/blogs/0001-fastp.md"))
+    _html, issues = _full_pipeline(Path("assets/blogs/0001-fastp.md"))
     assert issues == [], f"Issues found: {[i.kind for i in issues]}"
 
 

--- a/tests/test_blog_render.py
+++ b/tests/test_blog_render.py
@@ -1,7 +1,6 @@
 """Tests for src.services.blog_render."""
 
-from src.services.blog_render import render_to_html
-from src.services.blog_render import ValidationIssue, validate_html
+from src.services.blog_render import ValidationIssue, render_to_html, validate_html
 
 
 def test_render_passes_simple_markdown_to_html():

--- a/tests/test_footer.py
+++ b/tests/test_footer.py
@@ -1,6 +1,6 @@
 """Tests for src.components.layout.footer."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from fasthtml.common import to_xml
 
@@ -26,7 +26,7 @@ def test_footer_contains_nav_links_in_bottom_row():
 def test_footer_contains_current_year_copyright():
     """Footer shows the current year in the copyright line."""
     html = to_xml(Footer())
-    assert f"© {datetime.now().year}" in html
+    assert f"© {datetime.now(tz=UTC).year}" in html
 
 
 def test_social_links_container_does_not_combine_col_and_row_classes():

--- a/tests/test_masonry.py
+++ b/tests/test_masonry.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from fasthtml.common import to_xml
+
 from src.features.projects.projects_page import create_masonry_page
 from src.models.project import Project
 

--- a/tests/test_meta_tags.py
+++ b/tests/test_meta_tags.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from fasthtml.common import to_xml
+
 from src.features.projects.projects_page import create_blog_page
 from src.models.project import Project
 


### PR DESCRIPTION
## Why CI is red

`pyproject.toml` declares `"ruff"` **unpinned** with no `select =` key, so the project silently rides ruff's *default rule set*. Ruff 0.16.0 broadened those defaults to add `I` (isort), `UP` (pyupgrade), `RUF`, `PERF`, and `DTZ`.

The result: **`main` goes red with no code change.** Its last green run was 2026-05-07 against an older ruff. Reproduced by running ruff 0.16.0 against unmodified `main` — same 68 errors.

## What this does

Adopts the new defaults rather than pinning around them.

**Auto-fixed (63)** — `ruff check --fix` + `ruff format`: import sorting, PEP 585/604 generics, `__all__` ordering.

**Hand-fixed (16):**

| Rule | Change |
|---|---|
| `DTZ005` | Footer copyright year uses `datetime.now(tz=UTC)` |
| `RUF012` | `settings.py` constants annotated `ClassVar` — matches the convention its own docstring documents |
| `RUF013` | `/projects` and `/blogs` `tag` is now `str \| None` |
| `FURB162` | Drop manual `"Z"` → `"+00:00"` rewrite; Python 3.11+ `fromisoformat` handles it |
| `PERF402`, `FLY002`, `RUF059` | Mechanical |
| `TRY004` | **Kept `ValueError`** behind a `noqa` — every other malformed-frontmatter failure in that module raises `ValueError`; splitting the taxonomy would force callers to catch two types |

## Verification

- `ruff check .` clean, `ruff format --check .` clean (114 files)
- **103 tests pass**
- `FACTORY_CSS` byte-identical to `main` (sha256 `6ce97e71`, 22309 chars) and `__all__` unchanged
- RSS date output identical across every BigQuery shape — trailing `Z`, explicit offset, naive, and malformed
- FastHTML query-param parsing verified unchanged for `?tag=` absent / valued / empty / repeated

## Note

This leaves ruff unpinned, so a future release that broadens defaults again can repeat this. Adding an explicit `select = [...]` would make lint deterministic across versions — happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)