### PR TITLE
feat(cli): add `blog enable` as the atomic inverse of `blog disable`

### DIFF
--- a/src/cli/blog.py
+++ b/src/cli/blog.py
@@ -1,7 +1,7 @@
 """Blog subcommands for the ``src.cli`` CLI.
 
-Provides ``validate``, ``submit``, ``update``, ``disable``, and ``list``
-operations against the BigQuery-backed blog table. Parsing and validation
+Provides ``validate``, ``submit``, ``update``, ``disable``, ``enable``, and
+``list`` operations against the BigQuery-backed blog table. Parsing and validation
 use :mod:`src.services.blog_frontmatter`; BigQuery writes use the official
 ``google.cloud.bigquery`` SDK (the project's lightweight REST client only
 supports queries, not row inserts).
@@ -47,6 +47,10 @@ def register_blog_parser(p: argparse.ArgumentParser) -> None:
     d.add_argument("id", help="The blog post id (UUID)")
     d.add_argument("--table", default=None, help="Override settings.BIGQUERY_TABLE")
 
+    e = sub.add_parser("enable", help="Mark a blog post as enabled (inverse of disable)")
+    e.add_argument("id", help="The blog post id (UUID)")
+    e.add_argument("--table", default=None, help="Override settings.BIGQUERY_TABLE")
+
     lst = sub.add_parser(
         "list",
         help="List blog posts (id, title, disabled flag). --table is currently ignored.",
@@ -69,6 +73,8 @@ def run_blog(args: argparse.Namespace) -> int:
         return _cmd_update(args)
     if args.blog_cmd == "disable":
         return _cmd_disable(args)
+    if args.blog_cmd == "enable":
+        return _cmd_enable(args)
     if args.blog_cmd == "list":
         return _cmd_list(args)
     return 1
@@ -248,17 +254,42 @@ def _cmd_update(args: argparse.Namespace) -> int:
 
 
 def _cmd_disable(args: argparse.Namespace) -> int:
+    return _set_disabled(args, disabled=True)
+
+
+def _cmd_enable(args: argparse.Namespace) -> int:
+    return _set_disabled(args, disabled=False)
+
+
+def _set_disabled(args: argparse.Namespace, *, disabled: bool) -> int:
+    """Flip the ``disabled`` flag on one post via a single atomic UPDATE.
+
+    Backs both ``disable`` and ``enable`` so the two can never drift apart.
+    Deliberately not implemented on top of ``update``: that path is a DELETE
+    followed by an INSERT, which is not atomic and loses the row if the insert
+    fails.
+
+    Args:
+        args: Parsed namespace carrying ``id`` and optionally ``table``.
+        disabled: Value to write.
+
+    Returns:
+        Process exit code; 0 on success.
+    """
     table = args.table or settings.BIGQUERY_TABLE
 
     from google.cloud import bigquery
 
     client = _bq_client()
-    sql = f"UPDATE `{table}` SET disabled = true WHERE id = @id"
+    sql = f"UPDATE `{table}` SET disabled = @disabled WHERE id = @id"
     job_config = bigquery.QueryJobConfig(
-        query_parameters=[bigquery.ScalarQueryParameter("id", "STRING", args.id)]
+        query_parameters=[
+            bigquery.ScalarQueryParameter("id", "STRING", args.id),
+            bigquery.ScalarQueryParameter("disabled", "BOOL", disabled),
+        ]
     )
     client.query(sql, job_config=job_config).result()
-    print(f"disabled {args.id}")
+    print(f"{'disabled' if disabled else 'enabled'} {args.id}")
     return 0
 
 

--- a/tests/test_cli_blog.py
+++ b/tests/test_cli_blog.py
@@ -173,3 +173,83 @@ def test_validate_exits_nonzero_on_validation_issue(tmp_path):
     )
     rc = main(["blog", "validate", str(md)])
     assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# disable / enable
+# ---------------------------------------------------------------------------
+#
+# These two do reach BigQuery, but the client is stubbed at the _bq_client
+# boundary, so no credentials are needed. What matters is the emitted SQL:
+# `enable` must be the exact inverse of `disable` and must be a single atomic
+# UPDATE, never a delete-then-insert.
+
+
+class _FakeQueryJob:
+    def result(self):
+        return None
+
+
+class _FakeClient:
+    def __init__(self):
+        self.calls: list[tuple[str, object]] = []
+
+    def query(self, sql, job_config=None):
+        self.calls.append((sql, job_config))
+        return _FakeQueryJob()
+
+
+def _params(job_config) -> dict[str, object]:
+    return {p.name: p.value for p in job_config.query_parameters}
+
+
+@pytest.fixture
+def fake_bq(monkeypatch):
+    """Stub src.cli.blog._bq_client and hand back the fake client."""
+    from src.cli import blog
+
+    client = _FakeClient()
+    monkeypatch.setattr(blog, "_bq_client", lambda: client)
+    return client
+
+
+@pytest.mark.parametrize(
+    ("subcommand", "expected"),
+    [("disable", True), ("enable", False)],
+)
+def test_disable_and_enable_issue_one_atomic_update(fake_bq, capsys, subcommand, expected):
+    rc = main(["blog", subcommand, "abc-123"])
+    assert rc == 0
+
+    assert len(fake_bq.calls) == 1, "must be a single statement, not delete-then-insert"
+    sql, job_config = fake_bq.calls[0]
+
+    assert sql.startswith("UPDATE ")
+    assert "SET disabled = @disabled" in sql
+    assert "WHERE id = @id" in sql
+    assert "DELETE" not in sql.upper()
+
+    assert _params(job_config) == {"id": "abc-123", "disabled": expected}
+
+    captured = capsys.readouterr()
+    assert f"{subcommand}d abc-123" in captured.out
+
+
+def test_enable_is_the_exact_inverse_of_disable(fake_bq):
+    """The two subcommands must differ only in the boolean they bind."""
+    main(["blog", "disable", "x"])
+    main(["blog", "enable", "x"])
+
+    disable_sql, disable_cfg = fake_bq.calls[0]
+    enable_sql, enable_cfg = fake_bq.calls[1]
+
+    assert disable_sql == enable_sql
+    assert _params(disable_cfg)["disabled"] is True
+    assert _params(enable_cfg)["disabled"] is False
+
+
+def test_enable_honours_table_override(fake_bq):
+    rc = main(["blog", "enable", "abc-123", "--table", "proj.ds.other"])
+    assert rc == 0
+    sql, _ = fake_bq.calls[0]
+    assert "`proj.ds.other`" in sql


### PR DESCRIPTION
## Problem

`blog disable` has no inverse. Nothing in the codebase sets `disabled = false`, so the only way to bring a hidden post back is `blog update` — which is `DELETE ... WHERE id` followed by `insert_rows_json`.

That is not atomic. The existing code even acknowledges the window:

```python
errors = client.insert_rows_json(table, [payload])
if errors:
    print(f"insert failed after delete: {errors}", file=sys.stderr)
```

If the insert fails after the delete succeeds, the post is gone. It also re-renders `body_html` and rewrites the row, which is a lot of moving parts for what should be flipping one boolean.

## Change

Adds `blog enable <uuid>` — one parameterised `UPDATE`, no delete, no re-render, `views`/`likes` untouched.

`disable` and `enable` now share `_set_disabled(args, *, disabled=...)` so they cannot drift apart, and the flag moves out of string interpolation into a bound `BOOL` query parameter.

```bash
python -m src.cli blog enable 3f8a1c2e-...
# enabled 3f8a1c2e-...
```

## Why this matters beyond symmetry

`get_project_by_id` does **not** filter `disabled`, while `get_all_projects`, `get_project_by_slug` and RSS all do:

| Route | Filters `disabled`? | A `disabled = true` post |
|---|---|---|
| `/blogs` listing | yes | hidden |
| `/blogs/slug/{slug}` | yes | hidden |
| RSS | yes | absent |
| **`/blogs/{uuid}`** | **no** | **served** |

So a post submitted with `disabled = true` is invisible everywhere public *and* previewable at its UUID — effectively an unlisted preview link, out of machinery that already exists.

That makes staged publishing possible: **submit hidden → review at `/blogs/<uuid>` → enable.** It only works if enabling is a safe single statement, which is what this PR adds.

## Tests

Stub `_bq_client`, so no GCP credentials are needed — consistent with the note at the top of `tests/test_cli_blog.py` about `disable`/`submit` being omitted for that reason. They assert:

- the emitted SQL is a single `UPDATE` containing no `DELETE`
- the two subcommands differ **only** in the bound boolean
- `--table` is honoured

## Verification

- `ruff check` and `ruff format --check` pass on both changed files.
- **`pytest` was not run locally** — this host has Python 3.12 and the project requires `>=3.13`. Left to CI.

## Notes

- No schema change. `disabled` already exists and is already written by `submit`/`update`.
- Nothing else in the repo is touched.
- Docstring updated to list `enable` alongside the other subcommands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)